### PR TITLE
A free camera, a transform gizmo, and the engine work that makes them sound

### DIFF
--- a/.claude/skills/drive-the-app/SKILL.md
+++ b/.claude/skills/drive-the-app/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: drive-the-app
+description: Launch, drive and screenshot the running BrokkrSculpt window on this KDE Wayland session. Use when asked to run or start the app, to verify an interaction end to end, to reproduce a reported bug, or to check that a gizmo handle, camera gesture or panel control is actually live — anything the test suite cannot see because 3D and widget hit-testing both need a compositor.
+---
+
+# Driving BrokkrSculpt
+
+Two `#[ignore]`-free facts to start from: **this project has shipped a
+green-but-dead interaction twice**, and no test in the suite can catch a third,
+because both 3D handle picking and widget picking need a compositor. That is
+what this skill is for. It is not a substitute for `cargo test`; it is the only
+way to answer "does the handle actually grab".
+
+## The three tools
+
+| | |
+|---|---|
+| `scripts/drive.py` | virtual pointer and keyboard over `/dev/uinput` |
+| `scripts/shot.sh` | screenshot the window, refusing anything it cannot prove is ours |
+| `scripts/drive.py --geometry` | where the window is right now |
+
+## Always, in this order
+
+**1. Build, then check the binary is the one you built.** A GUI fix means
+nothing until the process is the one you just compiled, and the mistake is
+silent — a stale process looks exactly like a failed fix. This has wasted a
+session here before.
+
+```bash
+cargo build --release -p brokkr-app
+ls -l --time-style=+%H:%M:%S target/release/brokkrsculpt; date +%H:%M:%S
+pgrep -x brokkrsculpt || ./target/release/brokkrsculpt &
+```
+
+**2. Drive it.** Coordinates are WINDOW-LOCAL; `drive.py` reads the window
+position from KWin every run, so nothing is hard-coded to where the window
+happened to be.
+
+```bash
+cat > /tmp/t.txt <<'EOF'
+move 420 418        # viewport centre of a 1024x768 window
+key w               # arm the gizmo
+sleep 700
+EOF
+scripts/drive.py /tmp/t.txt
+```
+
+**3. Screenshot, and LOOK at it.** A blank frame is a failure to launch, and a
+screenshot you did not read is not evidence.
+
+```bash
+./scripts/shot.sh /tmp/out.png
+```
+
+## Converting a capture position into a drive coordinate
+
+`shot.sh` captures at the output's scale factor, **1.5** on this desktop: a
+1024x768 window comes back 1536x1152. So a feature you can see at image
+`(ix, iy)` is driven at `(ix / 1.5, iy / 1.5)`.
+
+Verified: the brush ring drawn at the pointer lands at exactly
+`window_local * 1.5` in the capture, with no offset on either axis. Do not
+assume that survives a change of scale or a second monitor — re-check it by
+moving to a point over the model and confirming the ring is where you aimed.
+
+## Controls worth knowing before you script anything
+
+- **Left** press picks a gizmo handle, or sculpts.
+- **Middle or right drag** orbits; **shift** with them pans. Right *click*
+  opens the brush menu, so use middle for orbiting.
+- **Wheel** zooms about the surface under the cursor.
+- `w` arms the transform gizmo, `1`-`7` pick a brush, `x`/`y`/`z` toggle a
+  mirror plane, `m` masks, `esc` cancels a live drag, `ctrl+z` undoes.
+- A **release with no motion is deliberately a no-op** — it will not re-bake.
+  If you are testing a drag, move at least a few pixels.
+
+## The traps, all of which have produced confident wrong conclusions here
+
+**Focus.** Everything typed goes to whatever the compositor thinks is focused.
+`drive.py` activates the window and **refuses to run** if it did not come
+forward, because the alternative is typing into the user's terminal — that is
+how a capture once showed a brush changed and a mirror plane on that no code
+had touched. If it refuses, something took focus back; do not work around it.
+
+**Absolute, never relative.** libinput accelerates relative motion, so a delta
+of 500 does not travel 500 pixels. The device is absolute over the logical
+desktop union, read from `kscreen-doctor`.
+
+**A drag is many small steps.** An application tells a drag from a click by
+travel; one jump reads as neither. `drag` emits 24 steps by default.
+
+**`shot.sh` may refuse, and that is it working.** It checks focus before *and*
+after the grab and compares the image's aspect ratio to the window's, then
+deletes anything it cannot prove is ours — because it once captured a media
+player and a private browsing session straight into an agent's context. Never
+work around it with `spectacle -f`.
+
+**Do not kill the app to rebuild without asking.** The title bar shows `*` for
+unsaved work. The autosave in `$XDG_STATE_HOME/brokkrsculpt/autosave.brokkr` is
+only written every two minutes, and File > Recover is the way back.
+
+## Reading the status line is most of the value
+
+The status line names what actually happened, and it is usually a better oracle
+than the picture. Real examples, each of which confirmed a whole code path:
+
+- `moved 16.75 mm — exact, 14 ms, not one voxel recomputed` — the lossless
+  `Bake::Exact` route.
+- `resized to 100/45/100% — resampled in 122 ms` — a per-axis scale on the Y
+  axis alone, and it names the cost.
+- `cancelled the drag` — a gesture abandoned rather than committed.
+
+If a gesture produced no status change at all, the press probably missed the
+handle. Screenshot before assuming the feature is broken.
+
+## What has been driven this way, and worked
+
+Arming the gizmo; dragging an axis arrow; dragging a per-axis scale box;
+abandoning a live drag with a second button; scrolling while holding a handle;
+orbiting; adding a primitive from the BODIES panel; and `ctrl+z`. Six of those
+are behaviours no test in the suite can reach.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 
 # Internal session-handoff doc — kept locally, never shipped
 handoff.md
+
+# Working plan — kept locally, never shipped. It names an unprotected public
+# write endpoint, which a public repository is the wrong place for.
+plan.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,9 +417,11 @@ dependencies = [
  "evdev",
  "glam 0.33.3",
  "iced",
+ "image",
  "log",
  "pollster",
  "rfd",
+ "roxmltree",
  "serde_json",
  "ureq",
  "wgpu",
@@ -470,6 +478,12 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -719,6 +733,15 @@ dependencies = [
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1011,10 +1034,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float_next_after"
@@ -1464,6 +1506,7 @@ dependencies = [
  "iced_runtime",
  "iced_widget",
  "iced_winit",
+ "image",
  "thiserror 2.0.20",
 ]
 
@@ -1552,6 +1595,8 @@ dependencies = [
  "half",
  "iced_core",
  "iced_futures",
+ "image",
+ "kamadak-exif",
  "log",
  "lyon_path",
  "raw-window-handle",
@@ -1665,6 +1710,21 @@ dependencies = [
  "web-sys",
  "window_clipboard",
  "winit",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1802,6 +1862,15 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kamadak-exif"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
+dependencies = [
+ "mutate_once",
 ]
 
 [[package]]
@@ -2020,6 +2089,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2107,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -2054,6 +2143,12 @@ dependencies = [
  "windows 0.62.2",
  "zbus",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "naga"
@@ -2670,6 +2765,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,6 +2841,12 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-xml"
@@ -3146,6 +3260,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -4669,6 +4789,21 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/crates/brokkr-app/Cargo.toml
+++ b/crates/brokkr-app/Cargo.toml
@@ -28,7 +28,8 @@ glam.workspace = true
 # fill_quad is axis-aligned rectangles only, which a 24px stroke icon with
 # circles and diagonals cannot be made of. A whole icon set is what earns the
 # six. See `icon.rs`.
-iced = { workspace = true, features = ["advanced", "wgpu", "debug", "canvas"] }
+iced = { workspace = true, features = ["advanced", "wgpu", "debug", "canvas", "image-without-codecs"] }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 log.workspace = true
 rfd.workspace = true
 serde_json = "1.0.151"

--- a/crates/brokkr-app/Cargo.toml
+++ b/crates/brokkr-app/Cargo.toml
@@ -46,6 +46,9 @@ serde_json = "1.0.151"
 # risk than a fortnight-old release of the code that terminates our TLS.
 # Lift the bound to "3" once 3.4.x has aged.
 ureq = { version = "~3.3", default-features = false, features = ["rustls"] }
+# +0 crates: already compiled for brokkr-core's 3MF importer. See articles.rs
+# for why the welcome screen reads RSS rather than the JSON API.
+roxmltree.workspace = true
 wgpu.workspace = true
 
 # Stylus pressure is read straight from the kernel's evdev interface. That sits

--- a/crates/brokkr-app/Cargo.toml
+++ b/crates/brokkr-app/Cargo.toml
@@ -29,6 +29,12 @@ glam.workspace = true
 # circles and diagonals cannot be made of. A whole icon set is what earns the
 # six. See `icon.rs`.
 iced = { workspace = true, features = ["advanced", "wgpu", "debug", "canvas", "image-without-codecs"] }
+# The welcome screen's article thumbnails. `default-features = false` is the
+# whole point: iced's own `image` feature is `image-without-codecs` PLUS
+# `image/default`, and it is the second half that brings AVIF, EXR, AV1 grain
+# synthesis and fax decoding -- measured against this lockfile, +72 crates.
+# The widget alone is +6 and these two decoders are +9. Both are needed: the
+# feed carries JPEG and PNG, and the render endpoint keeps a PNG a PNG.
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 log.workspace = true
 rfd.workspace = true

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -7881,7 +7881,7 @@ impl Brokkr {
                     Err(why) => crate::articles::Feed::Failed(why),
                 };
             }
-            Message::ArticleOpened(link) => {
+            Message::LinkOpened(link) => {
                 // The screen stays up: reading an article is not choosing what
                 // to do with the application, and coming back to a dismissed
                 // welcome screen would be a surprise.
@@ -9769,7 +9769,7 @@ mod tests {
         assert!(!dismisses_the_welcome(&Message::WelcomeOnStartupSet(false)));
         assert!(!dismisses_the_welcome(&Message::WelcomeOnStartupSet(true)));
         assert!(
-            !dismisses_the_welcome(&Message::ArticleOpened("https://tinkeratlas.com/x".into())),
+            !dismisses_the_welcome(&Message::LinkOpened("https://tinkeratlas.com/x".into())),
             "reading an article closed the screen it was read from"
         );
         assert!(!dismisses_the_welcome(&Message::ArticlesRetried));

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -2280,13 +2280,22 @@ impl Brokkr {
         self.doc.replace_volume(body, baked);
         self.gizmo_base = Some(base);
 
-        // The one-body version of the unit `apply_merge` documents: the slots
-        // the old field held are in nobody's dirty set now, so `forget_body`
-        // releases them, and the whole-document remesh is the other half --
-        // freeing pool space without re-offering everything takes the
-        // pool-full warning down and leaves the geometry that was refused
-        // missing.
-        self.shared.forget_body(body);
+        // The slots the old field held are in nobody's dirty set now -- the
+        // bricks are at new coordinates -- so they have to be let go, and the
+        // whole-document remesh is the other half: freeing pool space without
+        // re-offering everything takes the pool-full warning down and leaves
+        // the geometry that was refused missing.
+        //
+        // **`release_body` and NOT `forget_body`, and that distinction is the
+        // whole of a bug that shipped.** A forget means the body has left the
+        // document, so `SharedFrame::apply` drops every queued upload and the
+        // pending thumbnail naming it. Here the body is still very much in the
+        // document and its new meshes are queued in the same frame, so a forget
+        // threw them away: the cube disappeared from the viewport, its
+        // thumbnail went black, and the status line said "moved 50.63 mm --
+        // exact". The field was never touched, which is why nothing in the
+        // document looked wrong.
+        self.shared.release_body(body);
         self.doc.mark_everything_dirty();
         self.refresh_model_radius();
         self.remesh_dirty();
@@ -2412,7 +2421,7 @@ impl Brokkr {
         }
         restored.mark_everything_dirty();
         self.doc.replace_volume(body, *restored);
-        self.shared.forget_body(body);
+        self.shared.release_body(body);
         self.doc.mark_everything_dirty();
         self.refresh_model_radius();
         self.remesh_dirty();
@@ -7816,7 +7825,33 @@ impl Brokkr {
                 // stays open after a press that was refused reads as a press
                 // that never landed.
                 self.adding = false;
+                let before = self.doc.body_count();
                 self.add_primitive(kind);
+
+                // **A primitive arrives with its gizmo already on it**, which
+                // is ZBrush's behaviour and the reason Thomas asked for it: you
+                // add a cube in order to put it somewhere and give it a shape,
+                // so making that the default saves reaching for the tool every
+                // single time. It also puts the thing you just made under an
+                // obvious handle, which is the clearest possible answer to
+                // "where did it go" -- a primitive is placed clear of the
+                // model, so it can arrive outside the view.
+                //
+                // Only when a body was actually added: `add_primitive` refuses
+                // on the body ceiling and on the mesh pool, and arming a gizmo
+                // over a refusal would light a mode for a body that does not
+                // exist. And only from Sculpt, so adding a primitive mid-mask
+                // or with a cut armed does not silently change what the next
+                // drag does.
+                if self.doc.body_count() > before && self.tool == Tool::Sculpt {
+                    if let Err(why) = self.arm_gizmo() {
+                        // Not a failure of the add, so the add's own status
+                        // line survives and this is only logged.
+                        log::info!("the new primitive kept the sculpt tool: {why}");
+                    } else {
+                        self.swap_strength(|app| app.tool = Tool::Transform);
+                    }
+                }
             }
             Message::BodyDeleted => self.delete_active_body(),
             Message::BodyDuplicated => self.duplicate_active_body(),
@@ -18955,6 +18990,45 @@ mod gizmo_tests {
         // has to know how big the widget is before the first one.
         app.viewport_size = Vec2::new(SIZE.x, SIZE.y);
         app
+    }
+
+    /// **A transform must not tell the renderer the body has gone.**
+    ///
+    /// `SharedFrame::apply` drops every queued upload and the pending thumbnail
+    /// naming a FORGOTTEN body, which is right for a delete and catastrophic
+    /// for a move: the new meshes are queued in the same frame, so forgetting
+    /// throws away the very geometry that replaces what was released. That
+    /// shipped. Thomas moved a cube, the status line said "moved 50.63 mm --
+    /// exact", and the cube vanished from the viewport with a black thumbnail
+    /// while its field sat intact in the document.
+    ///
+    /// The old test asserted `world_bounds()` had changed -- that the DATA
+    /// moved -- and passed the whole time, which is this project's oldest
+    /// failure wearing a new hat. This asserts what the RENDERER was told.
+    #[test]
+    fn a_transform_releases_the_body_rather_than_forgetting_it() {
+        let mut app = app();
+        update(&mut app, Message::PrimitiveAdded(brokkr_core::PrimitiveKind::Cube));
+        let body = app.doc.active();
+        let _ = app.shared.take_forgotten_for_tests();
+        let _ = app.shared.take_released_for_tests();
+
+        arm(&mut app);
+        drag_the_x_arrow(&mut app, 120.0);
+
+        let forgotten = app.shared.take_forgotten_for_tests();
+        let released = app.shared.take_released_for_tests();
+        assert!(
+            !forgotten.contains(&body),
+            "the moved body was FORGOTTEN, so its re-meshed bricks and its thumbnail              are dropped by SharedFrame::apply and it disappears from the screen"
+        );
+        assert!(
+            released.contains(&body),
+            "the moved body's stale slots were never released, so it draws at both              its old and its new position: forgotten {forgotten:?} released {released:?}"
+        );
+        // And the field is untouched by any of this, which is what made the bug
+        // invisible from the document's side.
+        assert!(app.doc.active_volume().stats().dense_bricks > 0, "the move emptied the body");
     }
 
     fn arm(app: &mut Brokkr) {

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -19,6 +19,7 @@ use iced::{Subscription, Task};
 
 use crate::camera::OrbitCamera;
 use crate::cursor;
+use crate::gizmo;
 use crate::message::{
     ConfirmChoice, ExportFormat, MaskGenerator, Message, PanelSection, PointerButton, PointerEvent,
     SpaceMouseSetting, TopMenu,
@@ -219,13 +220,6 @@ const MAX_TILT: f32 = std::f32::consts::PI / 3.0;
 /// about a second, which is long enough to be steady and short enough to react.
 const FRAME_HISTORY: usize = 60;
 
-/// How close a flown-to pitch may come to straight up or down.
-///
-/// The camera clamps this itself, but a flight interpolates the field directly,
-/// so it has to respect the same limit or a top view would collapse the view
-/// matrix on arrival.
-const PITCH_SAFE: f32 = std::f32::consts::FRAC_PI_2 - 0.02;
-
 /// How far the pointer may travel during a right press and still count as a
 /// click rather than an orbit.
 ///
@@ -236,6 +230,17 @@ const PITCH_SAFE: f32 = std::f32::consts::FRAC_PI_2 - 0.02;
 /// named.
 const CLICK_SLOP_PX: f32 = 4.0;
 const CLICK_MS: u128 = 250;
+
+/// How much a scaled bake is assumed to overshoot the square law.
+///
+/// Measured rather than chosen: `Volume::warped` of a 10 mm sphere at 0.25 mm
+/// gives 4.66x its resident bytes at scale 2 and 15.25x at scale 4, against the
+/// 4 and 16 a pure square law predicts. The excess at small scales is the
+/// narrow band, which is a fixed thickness in VOXELS and so a bigger share of a
+/// small shell. One number covering both, rounded up.
+///
+/// See [`Brokkr::largest_scale_that_fits`], its only reader.
+const SCALE_GROWTH_MARGIN: f64 = 1.25;
 
 /// What a held pointer button is currently doing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -267,6 +272,16 @@ enum DragKind {
     /// the user had not chosen a target for is exactly the surprise this
     /// ordering exists to remove.
     Selecting,
+    /// The pointer is dragging a gizmo handle, locked at the press.
+    ///
+    /// **The handle is a payload for the same reason [`DragKind::Sculpt`]
+    /// carries its direction and [`DragKind::Masking`] deliberately does not.**
+    /// Which handle is being dragged is decided once, by where the button went
+    /// down, and re-picking it per motion event would hand the gesture to a
+    /// different axis the moment the pointer wandered off the shaft -- which it
+    /// does immediately, because the whole point of an axis drag is to move
+    /// away from where you started.
+    Transforming(gizmo::Handle),
     /// The press had nothing it was allowed to do: the pointer was over
     /// nothing that is drawn, and the body edits would land on is hidden.
     ///
@@ -293,6 +308,14 @@ struct Drag {
     /// than a click. Once true it stays true: a drag that returns to where it
     /// started is still a drag.
     moved: bool,
+    /// The world point a camera drag turns about, latched at the press.
+    ///
+    /// **Latched, and not asked for again per motion event.** The pivot is the
+    /// surface under the cursor when the button went down; re-picking it as the
+    /// pointer moves would hand the orbit a new centre every frame, which is a
+    /// camera that slides away under a steady drag rather than one that turns a
+    /// model in your hand. `None` for a drag that is not a camera drag.
+    pivot: Option<Vec3>,
 }
 
 /// Timings for the debug overlay.
@@ -536,6 +559,20 @@ pub struct Brokkr {
     facts_recorded: bool,
     /// The navigation cube's geometry, swapped to the renderer the same way.
     cube: brokkr_gpu::OverlayBatch,
+    /// The transform gizmo's geometry, in a batch of its own because it is
+    /// drawn in a pass of its own -- the sculpt's matrix, over the sculpt's
+    /// depth. See `SculptRenderer::overlay_pass`.
+    gizmo_batch: brokkr_gpu::OverlayBatch,
+    /// The gizmo, when [`Tool::Transform`] has taken a body.
+    gizmo: Option<gizmo::Gizmo>,
+    /// The active body's field as it was when the gizmo armed.
+    ///
+    /// **Every bake is from this, and that is the whole anti-degradation
+    /// design.** See [`Brokkr::rebake_gizmo`]. Held out of the document while
+    /// armed -- the document holds the baked result -- so peak memory while the
+    /// gizmo is up is twice the body, which is what
+    /// [`Brokkr::arm_gizmo`] checks for before it allocates anything.
+    gizmo_base: Option<Box<brokkr_core::Volume>>,
     /// The cube part under the pointer, lit so a click's effect is visible
     /// before the click.
     cube_hover: Option<navcube::Part>,
@@ -1303,6 +1340,14 @@ pub enum Tool {
     /// The next left drag is a plane cut line. One shot: [`Brokkr::finish_cut`]
     /// puts the tool back to [`Tool::Sculpt`].
     Cut,
+    /// The transform gizmo moves, turns and scales the active body. Key `w`.
+    ///
+    /// **The predicted fourth variant**, and it arrived as the paragraph above
+    /// said it would: a variant here rather than a second concept beside
+    /// [`DragKind`]. The press-lock-commit lifecycle it shares with the plane
+    /// cut is [`DragKind::Transforming`], which locks the handle at the press
+    /// and commits on the release.
+    Transform,
 }
 
 /// Turn a window event the widget tree did not want into a message.
@@ -1423,6 +1468,32 @@ pub(crate) const RENAME_FIELD: &str = "brokkr-body-rename";
 /// background -- arrives as [`Message::PressedNothing`], which is on no list
 /// here and therefore commits. That message exists for exactly this, because
 /// the field has already blurred itself by then.
+/// Whether a message belongs to a gizmo session, or ends it.
+///
+/// The allowlist is deliberately short and deliberately errs toward COMMITTING:
+/// a message wrongly on this list acts on a document whose last change is not
+/// yet on the undo stack, and a message wrongly off it costs the user one extra
+/// press of `w`. Those two mistakes are not the same size.
+///
+/// `KeyPressed` is on it because every keyboard shortcut arrives as one first
+/// and is re-dispatched as the message it means -- which is then judged here on
+/// its own merits. Escape's `MenuClosed` is on it because Escape is how a
+/// session is ABANDONED, and committing on the way past would be the opposite
+/// of what was pressed.
+fn keeps_the_gizmo_armed(message: &Message) -> bool {
+    match message {
+        // The gesture itself, and the camera moves that happen around it.
+        Message::Pointer(_) | Message::Frame => true,
+        Message::KeyPressed { .. } | Message::MenuClosed => true,
+        Message::ToolChanged(_) => true,
+        Message::SizingEnded | Message::MaskPeekEnded => true,
+        // Framing the active body is how a user gets back to what they are
+        // placing; it changes no document state at all.
+        Message::CameraFramedOnActive => true,
+        _ => false,
+    }
+}
+
 fn keeps_the_rename_open(message: &Message) -> bool {
     match message {
         Message::BodyRenameEdited(_) => true,
@@ -1534,6 +1605,9 @@ impl Brokkr {
             bug_report: None,
             facts_recorded: false,
             cube: brokkr_gpu::OverlayBatch::default(),
+            gizmo_batch: brokkr_gpu::OverlayBatch::default(),
+            gizmo: None,
+            gizmo_base: None,
             cube_hover: None,
             flight: None,
             menu: None,
@@ -1592,6 +1666,10 @@ impl Brokkr {
         app.perf.load_ms = app.perf.remesh_ms;
         app.perf.remesh_ms = 0.0;
         app.perf.dirty_bricks = 0;
+        // Before the first publish, so the camera's floor and far plane are in
+        // the document's units from the first frame rather than from the
+        // defaults `framing` leaves behind.
+        app.refresh_camera_lattice();
         app.publish_camera();
         app.refresh_detail_advice();
         app.refresh_overlay();
@@ -1754,10 +1832,189 @@ impl Brokkr {
     }
 
     fn publish_camera(&mut self) {
+        // **The one place a camera becomes legal.** Every gesture, every
+        // flight, every restore passes through here, so containing the target
+        // here rather than in each of them makes "the camera is lost" a state
+        // the application cannot reach rather than one it has to detect. See
+        // [`Brokkr::contain_target`] for why that is worth a check per frame of
+        // a drag.
+        self.contain_target();
         self.shared.set_camera(self.camera);
         // The cube shows the camera's orientation, so it is stale the moment the
         // camera moves. This is the one place that knows that happened.
         self.refresh_cube();
+        // And the gizmo is held at a constant SIZE on screen, so it is stale
+        // for the same reason. See `refresh_gizmo` for why it cannot ride
+        // `refresh_overlay` instead.
+        self.refresh_gizmo();
+    }
+
+    /// The ball the camera is allowed to aim inside: everything the document
+    /// holds, plus nothing.
+    ///
+    /// Over [`Document::world_bounds`] and not the active body, because a user
+    /// panning across a two body document is doing something reasonable and
+    /// must not be fenced into whichever one happens to be selected. The union
+    /// spans the gaps between bodies, which for a camera bound is the safe
+    /// direction to be loose in -- unlike sizing a primitive, where the same
+    /// looseness compounds and is refused.
+    ///
+    /// Falls back to the starting ball when the document is empty, so a new
+    /// file still has somewhere legal to look.
+    fn document_ball(&self) -> (Vec3, f32) {
+        match self.doc.world_bounds() {
+            Some((low, high)) => ((low + high) * 0.5, ((high - low).length() * 0.5).max(1.0e-3)),
+            None => (Vec3::ZERO, MODEL_RADIUS_MM),
+        }
+    }
+
+    /// Pull the camera's target back inside [`Brokkr::document_ball`].
+    ///
+    /// **The fence is what makes the rest of the system's assumptions true.**
+    /// Two subsystems take the eye-to-target distance as the eye-to-MODEL
+    /// distance and would break silently without it: [`OrbitCamera::far`] is
+    /// both the far plane and the length of every pick ray, and
+    /// [`OrbitCamera::near`] is a hundredth of the distance. Let the target
+    /// wander a long way from the model and the model goes behind the far plane
+    /// -- measured, at 2405 mm from the eye against a far plane of 2318: it is
+    /// not drawn and it is not pickable, and nothing says so.
+    ///
+    /// So the fence stays the document's own ball, in millimetres. **Widening
+    /// it in proportion to the distance was tried and is what produced that
+    /// measurement** -- the idea being that a target far from the model is
+    /// harmless when the eye is even further away, which is true of the camera
+    /// alone and false of the two derived quantities above.
+    ///
+    /// It is [`Document::world_bounds`] and not the active body, because a user
+    /// panning across a two body document is doing something reasonable and
+    /// must not be fenced into whichever one happens to be selected.
+    ///
+    /// The clamp is to the surface of the ball rather than to its centre, so
+    /// nothing jumps: a gesture pushing outward simply stops moving the target,
+    /// and every gesture pulling back inward is free.
+    ///
+    /// **What keeps the fence from being felt is that the wheel no longer
+    /// pushes the target at it**; see [`Brokkr::navigation_anchor`].
+    fn contain_target(&mut self) {
+        let (centre, radius) = self.document_ball();
+        if !self.camera.target.is_finite() {
+            self.camera.target = centre;
+            return;
+        }
+        let offset = self.camera.target - centre;
+        if offset.length() > radius {
+            self.camera.target = centre + offset.normalize() * radius;
+        }
+    }
+
+    /// Tell the camera the lattice and extent it should measure itself against.
+    ///
+    /// The zoom floor is a number of voxels and the far plane a multiple of the
+    /// content radius, so both go stale the moment the document is resampled,
+    /// imported into, or grown. Called from the same places
+    /// [`Brokkr::refresh_model_radius`] is.
+    fn refresh_camera_lattice(&mut self) {
+        let radius = self
+            .doc
+            .world_bounds()
+            .map_or(MODEL_RADIUS_MM, |(low, high)| ((high - low).length() * 0.5).max(1.0e-3));
+        self.camera.set_lattice(self.doc.voxel_size(), radius);
+    }
+
+    /// Frame the active body, which is the one keystroke that recovers from any
+    /// camera at all.
+    ///
+    /// **A camera free enough to be useful is a camera that can get lost**, and
+    /// the answer to that tension is not to restrict the freedom but to make
+    /// coming back cost one key. `contain_target` stops the target wandering
+    /// out of the document; this is what puts it back on the thing the user
+    /// meant when it has merely wandered somewhere unhelpful.
+    ///
+    /// The angles are kept, exactly as [`Brokkr::apply_view`] keeps them: a
+    /// user who has turned the model to see the back of its head has not asked
+    /// to be spun round to the front.
+    fn frame_active(&mut self) {
+        let volume = self.doc.active_volume();
+        let (centre, radius) = match (volume.world_bounds(), volume.content_radius()) {
+            (Some((low, high)), Some(radius)) => ((low + high) * 0.5, radius.max(1.0e-3)),
+            _ => (Vec3::ZERO, MODEL_RADIUS_MM),
+        };
+        let framed = OrbitCamera::framing(centre, radius);
+        self.camera.target = framed.target;
+        self.refresh_camera_lattice();
+        // Clamped, because a body smaller than a couple of voxels frames at a
+        // distance under its own floor and the camera would sit inside its own
+        // limit until the next scroll pushed it back out.
+        self.camera.distance =
+            framed.distance.clamp(self.camera.min_distance(), self.camera.max_distance());
+        self.publish_camera();
+        self.status = "framed the active body".to_string();
+    }
+
+    /// The world point a wheel notch should zoom about.
+    ///
+    /// **The surface under the cursor when moving in, the target otherwise**,
+    /// and both halves of that were arrived at by measuring rather than by
+    /// taste.
+    ///
+    /// Anchoring the way IN is the feature Thomas asked for. The eye travels
+    /// toward the target, and after a file is opened the target is the middle
+    /// of the model -- so a target-centred zoom walks the camera INTO the
+    /// geometry, and by the time an eyelid fills the view the eye is inside the
+    /// skull. Lowering the distance floor only chooses how deep in you may get.
+    /// Anchoring on the surface under the cursor is what Nomad and Blender do
+    /// and what makes "closer" mean closer to the detail. It costs nothing:
+    /// `update_hover` already ran a full pick on the last pointer move, and a
+    /// wheel notch does not move the pointer.
+    ///
+    /// Everything else is the target, because an anchor that is NOT on the
+    /// model pushes the target off the model in exact proportion to the
+    /// distance. `(target - anchor) / distance` is invariant across
+    /// [`OrbitCamera::zoom_by_about`] -- that invariance is exactly why the
+    /// anchor stays pinned under the cursor -- so the drift is unbounded in the
+    /// distance, and it breaks three things in rising order of quietness:
+    ///
+    /// - It walks the target into [`Brokkr::contain_target`]'s fence, and that
+    ///   clamp is not invertible. Measured through the real wheel path, cursor
+    ///   over empty background on the default ball: four notches out and four
+    ///   back returned the target to within 0.00 mm, eight and eight left it
+    ///   25.62 mm away on the opposite side, twelve and twelve left it 69.06 mm
+    ///   away -- the whole fence -- with the model no longer under the middle of
+    ///   the viewport. Two flicks of a wheel.
+    /// - Widening the fence to admit the drift is worse, not better. With the
+    ///   target far from the model, [`OrbitCamera::far`] -- the far plane AND
+    ///   the length of every pick ray -- stops reaching the model. Measured at
+    ///   2405 mm from the eye against a far plane of 2318: the model is not
+    ///   drawn and not pickable, and nothing says so.
+    /// - [`OrbitCamera::near`] is a hundredth of the distance, so far enough
+    ///   out the same drift clips the near side too.
+    ///
+    /// Two anchors are off the model, and both are handled by falling back:
+    ///
+    /// - **Zooming out, wherever the cursor is.** Anchoring outward is the same
+    ///   arithmetic run backwards and drifts the target away from the cursor.
+    /// - **Zooming in with the cursor over background.** The fallback this
+    ///   replaced was the ray's crossing of the plane through the target, argued
+    ///   for as being continuous across a silhouette -- but that point is not on
+    ///   the model, so it drifts too: twelve notches out and twelve back in over
+    ///   a corner puts the target 188 mm from a 69 mm document, i.e. hard into
+    ///   the fence. Continuity across the silhouette is not worth losing the
+    ///   sculpt for.
+    ///
+    /// What this gives up is stated plainly: zooming in on a detail and back out
+    /// restores the distance and the angles exactly but leaves the view centred
+    /// on that detail rather than on wherever it started. That is not a camera
+    /// that failed to come back -- the model is whole and on screen, at the
+    /// distance and angle it was -- and it is the price of the target never
+    /// being anywhere the rest of the system does not expect it. **The target
+    /// cannot leave the document ball through the wheel at all now:** the only
+    /// anchor that moves it is a point on the model, the ball is convex, and a
+    /// zoom-in leaves the target on the segment between two points inside it.
+    fn navigation_anchor(&self, factor: f32) -> Vec3 {
+        match self.hover {
+            Some(hover) if factor < 1.0 => hover,
+            _ => self.camera.target,
+        }
     }
 
     /// Rebuild the navigation cube and hand it to the renderer.
@@ -1768,12 +2025,409 @@ impl Brokkr {
         self.cube = batch;
     }
 
+    /// Rebuild the transform gizmo and hand it to the renderer.
+    ///
+    /// **Beside `refresh_cube` and never inside `refresh_overlay`.** That
+    /// function's own header says it is deliberately not camera dependent --
+    /// the ring and the mirror planes are world-space geometry, so a camera
+    /// moving under them needs no rebuild. A gizmo held at a constant size on
+    /// screen falsifies exactly that premise: every one of its dimensions is a
+    /// number of pixels converted through the camera. So it travels the way the
+    /// cube does, through `publish_camera`, and by the same buffer rotation, so
+    /// nothing allocates once warm.
+    fn refresh_gizmo(&mut self) {
+        let mut batch = std::mem::take(&mut self.gizmo_batch);
+        match &self.gizmo {
+            Some(gizmo) => gizmo::build(&mut batch, &self.camera, self.viewport_size, gizmo),
+            // Cleared rather than left: a stale gizmo is one that is still
+            // drawn on a body nothing is armed on.
+            None => batch.clear(),
+        }
+        self.shared.swap_gizmo(&mut batch);
+        self.gizmo_batch = batch;
+    }
+
+    /// Take the active body under the gizmo, or say why not.
+    ///
+    /// # The refusal is at ARM time, before anything is allocated
+    ///
+    /// `merge_plan`'s header states the rule this follows: the user is asked
+    /// before the allocation, and never after it. Arming is the commitment
+    /// point here and not the first release, because arming is what promises to
+    /// hold a second copy of the body for as long as the gizmo is up -- and by
+    /// the first release the memory is already spent and the field already
+    /// baked.
+    ///
+    /// Two ceilings, and they fail differently:
+    ///
+    /// * The reclaim allowance. A field larger than it would be evicted from
+    ///   history the instant it was pushed, so the transform would be
+    ///   **un-undoable** -- and a free-angle transform has no "do it backwards"
+    ///   recovery the way a quarter turn does. That is the one that matters.
+    /// * The document's own volume ceiling, against holding base and baked at
+    ///   once.
+    ///
+    /// Both name the voxel size that would fit, from the same square law
+    /// [`Brokkr::too_fine_for_the_pool`] uses: a surface has a fixed area, so
+    /// halving the voxel quadruples the shell that stores it.
+    fn arm_gizmo(&mut self) -> Result<(), String> {
+        if self.gizmo.is_some() {
+            return Ok(());
+        }
+        let body = self.doc.active();
+        if !self.active_is_drawn() {
+            return Err("that body is hidden — turn its eye on to move it".to_string());
+        }
+        let volume = self.doc.active_volume();
+        let Some((low, high)) = volume.world_bounds() else {
+            return Err("there is nothing in this body to move".to_string());
+        };
+        let stats = volume.stats();
+        let resident = stats.resident_bytes;
+        let entry_bytes = size_of::<brokkr_core::Volume>() + resident;
+
+        let coarser = |headroom: f64| self.doc.voxel_size() / headroom.sqrt() as f32 * 1.03;
+        if entry_bytes as f64 > brokkr_core::DEFAULT_RECLAIM_BUDGET as f64 {
+            let headroom = brokkr_core::DEFAULT_RECLAIM_BUDGET as f64 / entry_bytes.max(1) as f64;
+            return Err(format!(
+                "this body is {:.0} MB and undo can hold {:.0} MB, so the move could not be \
+                 undone — {:.3} mm is the coarsest voxel that would fit",
+                entry_bytes as f64 / (1024.0 * 1024.0),
+                brokkr_core::DEFAULT_RECLAIM_BUDGET as f64 / (1024.0 * 1024.0),
+                coarser(headroom),
+            ));
+        }
+        // Base and baked are both resident for as long as the gizmo is up.
+        let peak = self.doc_stats.resident_bytes as f64 + resident as f64;
+        if peak > MAX_VOLUME_BYTES {
+            let headroom = MAX_VOLUME_BYTES / peak.max(1.0);
+            return Err(format!(
+                "moving this body needs about {:.1} GB while the gizmo is up, against a {:.0} GB \
+                 ceiling — {:.3} mm is the coarsest voxel that would fit",
+                peak / (1024.0 * 1024.0 * 1024.0),
+                MAX_VOLUME_BYTES / (1024.0 * 1024.0 * 1024.0),
+                coarser(headroom),
+            ));
+        }
+
+        let max_scale = self.largest_scale_that_fits(stats);
+        self.gizmo = Some(gizmo::Gizmo::new(body, low, high, max_scale));
+        self.refresh_gizmo();
+        Ok(())
+    }
+
+    /// The largest TOTAL scale a bake of this body could be built at.
+    ///
+    /// # Why this is a clamp on the gesture and not a refusal at the release
+    ///
+    /// `merge_plan`'s rule is that the user is asked before the allocation and
+    /// never after it, and a gizmo has no moment in which to ask: the gesture
+    /// IS the question, so a refusal that arrives once the pointer has been
+    /// released is an answer too late to act on. Folding the ceiling into the
+    /// gesture instead means the preview box stops growing exactly where the
+    /// bake would stop fitting, and everything the user is shown is a placement
+    /// that can actually be built. See the clamp in `gizmo::drag`.
+    ///
+    /// Without it there is no bound anywhere on the path. `Volume::warped`
+    /// builds a dense grid of destination brick coordinates between the moved
+    /// bounds with no cap, `arm_gizmo`'s two refusals are evaluated once
+    /// against the UNSCALED body, and `Similarity::then` composes gestures by
+    /// multiplying their scales.
+    ///
+    /// # The prediction, and where each term comes from
+    ///
+    /// Two terms, because the field and the mask do not grow at the same rate
+    /// and only the field obeys the square law the rest of this file uses.
+    ///
+    /// * A surface has fixed area, so scaling by `s` multiplies the shell that
+    ///   stores it by `s * s`. Measured on a 10 mm sphere at 0.25 mm:
+    ///   4.66x resident at `s = 2` and 15.25x at `s = 4`, against 4 and 16 --
+    ///   which is where [`SCALE_GROWTH_MARGIN`] comes from.
+    /// * `MaskField::warped` has no interior shortcut to collapse a thickened
+    ///   protection region with, so one source mask brick's forward image is
+    ///   `s * s * s` destination bricks. A heavily masked body scaled far up is
+    ///   the case a single square law would miss.
+    ///
+    /// `A s^2 + B s^3 <= headroom` has no closed form worth writing, so the
+    /// answer is bisected. It runs once, at arming.
+    ///
+    /// Never below 1.0: a body can always be placed at the size it already is,
+    /// and a ceiling that said otherwise would make even the identity
+    /// unreachable at the moment the document is fullest.
+    fn largest_scale_that_fits(&self, stats: brokkr_core::VolumeStats) -> f32 {
+        // What the BAKED field may occupy. The base is held aside for as long
+        // as the gizmo is up and `doc_stats` was measured with it still in the
+        // document, so the two cancel: the room left for the baked field is the
+        // room left beside the document as it stands.
+        let headroom = MAX_VOLUME_BYTES - self.doc_stats.resident_bytes as f64;
+        let mask = stats.mask_bytes as f64;
+        let field = (stats.resident_bytes as f64 - mask).max(0.0);
+        let cost =
+            |scale: f64| (field * scale * scale + mask * scale.powi(3)) * SCALE_GROWTH_MARGIN;
+
+        let mut fits = 1.0f64;
+        // Above `gizmo::MAX_SCALE`, so the search never becomes the binding
+        // constraint on a document with room to spare.
+        let mut refused = 64.0f64;
+        for _ in 0..24 {
+            let middle = (fits + refused) * 0.5;
+            if cost(middle) <= headroom {
+                fits = middle;
+            } else {
+                refused = middle;
+            }
+        }
+        fits as f32
+    }
+
+    /// Rebuild the body from the field the gizmo armed on.
+    ///
+    /// # Always from the base, and that is the whole design
+    ///
+    /// The obvious implementation bakes the current field through whatever the
+    /// last drag did, which makes N gestures cost N trilinear passes. Placement
+    /// is fiddly: thirty nudges over a session is an ordinary number, and
+    /// thirty passes is detail the user sculpted, gone, with nothing having
+    /// said so -- discovered at the printer. Baking from the base instead
+    /// bounds the erosion at **one pass per arming**, whatever the user does in
+    /// between, and makes dragging in a circle and back exactly the identity
+    /// rather than approximately it.
+    ///
+    /// The exact routes cost zero passes, not one: a snapped move is a
+    /// value-exact gather and a snapped quarter turn is a permutation, so an
+    /// entire session of snapped gestures leaves the field bit-identical to
+    /// what it was.
+    ///
+    /// The base is taken out of the document on the FIRST bake rather than at
+    /// arming, so that arming alone never touches the field -- pressing `w` and
+    /// pressing it again has to be free.
+    fn rebake_gizmo(&mut self) {
+        let Some(gizmo) = self.gizmo else {
+            return;
+        };
+        let body = gizmo.body;
+        let voxel_size = self.doc.voxel_size();
+        let route = gizmo.placement.route(voxel_size);
+
+        // Nothing is asked for. Two cases, and the second one is the trap.
+        //
+        // Nothing baked yet: leave the document alone entirely, so an armed
+        // gizmo that is only looked at costs nothing at all.
+        //
+        // Something baked and then undone by hand -- a nudge out and a nudge
+        // back, which is an ordinary way to change your mind -- must not go on
+        // to `base.shifted(IVec3::ZERO)`. That route is real work:
+        // `Volume::duplicated`'s own header quotes 1.53 GiB on the dragon, and
+        // it would be spent producing a field identical to the one already
+        // held. Worse, it leaves `gizmo_base` set, so the disarm pushes a
+        // whole-field undo entry for a placement that changed nothing --
+        // charged against the reclaim allowance, where `History::trim` can
+        // evict real strokes to make room for it. Putting the base BACK returns
+        // the session to armed-and-untouched, which is exact, allocates
+        // nothing, and makes the disarm correctly push no entry at all.
+        if route == brokkr_core::Bake::Identity {
+            if self.gizmo_base.is_none() {
+                return;
+            }
+            let started = Instant::now();
+            self.restore_base(body);
+            self.status =
+                Self::bake_summary(&gizmo.placement, route, voxel_size, started.elapsed());
+            return;
+        }
+
+        // Move the field out on the first bake. Two steps rather than one so
+        // the old baked field is dropped BEFORE the new one is built: peak
+        // memory stays at two copies of the body rather than three.
+        let placeholder = brokkr_core::Volume::new(voxel_size);
+        let Some(previous) = self.doc.replace_volume(body, placeholder) else {
+            return;
+        };
+        let stale: Vec<brokkr_core::BrickCoord> = previous.brick_coords().collect();
+        let base = match self.gizmo_base.take() {
+            Some(base) => {
+                drop(previous);
+                base
+            }
+            None => Box::new(previous),
+        };
+
+        let started = Instant::now();
+        let mut baked = match route {
+            // Unreachable: the identity route returns above, having put the
+            // base back rather than deep copying it. Left as the harmless
+            // answer rather than a panic, because the cost of being wrong here
+            // is one wasted copy and the cost of a panic is the sculpt.
+            brokkr_core::Bake::Identity => base.shifted(glam::IVec3::ZERO),
+            // Turn first, then carry it to where the pivot asked for. Both are
+            // exact; see `Similarity::route`, which works out why the shift is
+            // not simply the translation in voxels.
+            brokkr_core::Bake::Exact { turns, voxel_offset } => {
+                let turned = if turns.is_identity() { None } else { Some(base.rotated(turns)) };
+                match turned {
+                    Some(turned) => turned.shifted(voxel_offset),
+                    None => base.shifted(voxel_offset),
+                }
+            }
+            brokkr_core::Bake::Resample => base.warped(gizmo.placement),
+        };
+        // The bricks the outgoing field occupied, marked in the INCOMING one:
+        // without this the renderer keeps drawing triangles nothing will ever
+        // overwrite. The same rule `Document::resample` follows.
+        for coord in stale {
+            baked.mark_dirty(coord);
+        }
+        self.doc.replace_volume(body, baked);
+        self.gizmo_base = Some(base);
+
+        // The one-body version of the unit `apply_merge` documents: the slots
+        // the old field held are in nobody's dirty set now, so `forget_body`
+        // releases them, and the whole-document remesh is the other half --
+        // freeing pool space without re-offering everything takes the
+        // pool-full warning down and leaves the geometry that was refused
+        // missing.
+        self.shared.forget_body(body);
+        self.doc.mark_everything_dirty();
+        self.refresh_model_radius();
+        self.remesh_dirty();
+        self.unsaved = true;
+        self.thumbs.geometry_changed(body);
+        self.status = Self::bake_summary(&gizmo.placement, route, voxel_size, started.elapsed());
+    }
+
+    /// What just happened to the field, in the words that matter.
+    ///
+    /// **The route is named on every bake, not only the lossy ones.** A user
+    /// who is told nothing when a move is exact has no way to learn that some
+    /// of them are not, and the whole point of snapping by default is that the
+    /// ordinary gesture is free. Saying so is what teaches that.
+    fn bake_summary(
+        placement: &brokkr_core::Similarity,
+        route: brokkr_core::Bake,
+        voxel_size: f32,
+        elapsed: std::time::Duration,
+    ) -> String {
+        let (axis, angle) = placement.rotation.to_axis_angle();
+        let degrees = crate::camera::wrap_angle(angle).to_degrees() * axis.length().max(1.0);
+        let mut what = Vec::new();
+        if placement.translation.length() > voxel_size * 0.5 {
+            what.push(format!("moved {:.2} mm", placement.translation.length()));
+        }
+        if degrees.abs() > 0.05 {
+            what.push(format!("turned {:.0}°", degrees.abs()));
+        }
+        if (placement.scale - 1.0).abs() > 1.0e-4 {
+            what.push(format!("scaled to {:.0}%", placement.scale * 100.0));
+        }
+        if what.is_empty() {
+            what.push("put back where it started".to_string());
+        }
+        let ms = elapsed.as_secs_f64() * 1000.0;
+        if route.is_lossy() {
+            format!(
+                "{} — resampled in {ms:.0} ms; turning it back will not restore it exactly, \
+                 and undo will",
+                what.join(", ")
+            )
+        } else {
+            format!("{} — exact, {ms:.0} ms, not one voxel recomputed", what.join(", "))
+        }
+    }
+
+    /// Put the gizmo away.
+    ///
+    /// `commit` decides which of the two answers the user asked for, and the
+    /// split follows the convention every modelling tool already has: Escape
+    /// abandons, anything else commits.
+    ///
+    /// * Committing pushes ONE [`brokkr_core::Change::WholeVolume`] holding the
+    ///   field as it was when the gizmo armed -- one entry per SESSION and not
+    ///   one per drag, because a per-drag entry would be a full field each and
+    ///   thirty of them would evict each other and every stroke behind them.
+    /// * Abandoning puts that field straight back and pushes nothing, so a
+    ///   session the user changed their mind about leaves no trace in the
+    ///   history at all.
+    ///
+    /// Either way the base is given up, which is what makes the erosion bound
+    /// -- one pass per arming -- a statement about the whole session.
+    fn disarm_gizmo(&mut self, commit: bool) {
+        let Some(gizmo) = self.gizmo.take() else {
+            return;
+        };
+        self.refresh_gizmo();
+        if self.gizmo_base.is_none() {
+            // Armed and never baked, or baked and then returned to the identity
+            // by hand -- `rebake_gizmo` puts the base back in that case, which
+            // is what makes this branch cover both. Nothing was moved, so there
+            // is nothing to commit and nothing to put back.
+            return;
+        }
+        let body = gizmo.body;
+
+        if commit {
+            let base = self.gizmo_base.take().expect("checked just above");
+            let before = self.history.stats();
+            self.history.push(brokkr_core::Entry::new(vec![brokkr_core::Change::WholeVolume {
+                body,
+                volume: base,
+            }]));
+            self.record_history(before);
+            return;
+        }
+
+        if self.restore_base(body) {
+            self.status = "put the body back where it was".to_string();
+        }
+    }
+
+    /// Put the field the gizmo armed on back into the document, exactly, and
+    /// give the base up.
+    ///
+    /// Two callers, and they want it for two different reasons: Escape
+    /// abandoning a session, and a gesture that has returned the placement to
+    /// the identity. Both leave the document holding the field the gizmo armed
+    /// on and `gizmo_base` empty, which is the state a disarm has nothing to
+    /// commit from -- so a session the user changed their mind about leaves no
+    /// entry on the stack whether they said so with Escape or with the pointer.
+    ///
+    /// Answers whether there was a base to put back.
+    fn restore_base(&mut self, body: NodeId) -> bool {
+        let Some(base) = self.gizmo_base.take() else {
+            return false;
+        };
+        let voxel_size = self.doc.voxel_size();
+        let placeholder = brokkr_core::Volume::new(voxel_size);
+        let Some(baked) = self.doc.replace_volume(body, placeholder) else {
+            return false;
+        };
+        // The bricks the baked field occupied, marked in the one going back:
+        // without them the renderer keeps drawing triangles nothing will ever
+        // overwrite. The same pairing `rebake_gizmo` makes in the other
+        // direction.
+        let stale: Vec<brokkr_core::BrickCoord> = baked.brick_coords().collect();
+        drop(baked);
+        let mut restored = base;
+        for coord in stale {
+            restored.mark_dirty(coord);
+        }
+        restored.mark_everything_dirty();
+        self.doc.replace_volume(body, *restored);
+        self.shared.forget_body(body);
+        self.doc.mark_everything_dirty();
+        self.refresh_model_radius();
+        self.remesh_dirty();
+        true
+    }
+
     /// Start an animated move to a cube part's orientation.
     fn fly_to(&mut self, part: navcube::Part) {
+        // **Not clamped short of the pole any more, and that is the point.**
+        // A flight interpolates the angle fields directly, so while `look_at`
+        // built the view matrix a top view had to stop 0.02 rad short or arrive
+        // at a collapsed matrix -- which meant clicking "top" on the cube gave
+        // a view that was very nearly but visibly not the top. The composed
+        // basis is orthonormal at the pole, so the cube now lands on it.
         let (yaw, pitch) = navcube::orientation(part.direction, self.camera.yaw);
-        // Clamped the way a drag would be, so a top or bottom face lands just
-        // short of the pole rather than collapsing the view matrix.
-        let pitch = pitch.clamp(-PITCH_SAFE, PITCH_SAFE);
         // The shortest way round, so a click never spins the model several times
         // to reach a heading a few degrees away.
         let yaw = self.camera.yaw + OrbitCamera::shortest_angle_delta(self.camera.yaw, yaw);
@@ -1855,6 +2509,9 @@ impl Brokkr {
         // long a body would be missing from the screen with nothing in the
         // panel saying why.
         self.publish_visibility();
+        // A whole-document swap can change both the lattice and the extent,
+        // which are the two numbers the camera measures itself against.
+        self.refresh_model_radius();
     }
 
     fn remesh_dirty(&mut self) {
@@ -1938,6 +2595,9 @@ impl Brokkr {
     fn refresh_model_radius(&mut self) {
         self.model_radius = self.doc.active_volume().content_radius().unwrap_or(MODEL_RADIUS_MM);
         self.model_radius_body = self.doc.active();
+        // The camera measures its floor in voxels and its far plane in content
+        // radii, so it goes stale for exactly the reasons this does.
+        self.refresh_camera_lattice();
     }
 
     /// Choose the body that edits land on, with everything that has to follow.
@@ -3301,6 +3961,17 @@ impl Brokkr {
         // paint lands on the active body wherever the cursor is. A ring built
         // from another body's field at a point on that other body's surface is
         // a confident ring in mid air over a body that is not being painted.
+        // **The gizmo takes the ring away entirely**, which is not the same
+        // case as the two below. A brush ring says "a press here would carve
+        // this much of that surface", and under the gizmo a press does no such
+        // thing -- it grabs a handle, or it chooses a body. Drawing one would
+        // be the same lie the live-stroke case below exists to stop, told about
+        // a different gesture.
+        if self.tool == Tool::Transform {
+            self.hover = None;
+            self.hover_body = None;
+            return;
+        }
         let owns_the_ring = self.tool == Tool::Mask
             || matches!(self.drag.map(|drag| drag.kind), Some(DragKind::Sculpt(_)));
         if !owns_the_ring {
@@ -3323,7 +3994,7 @@ impl Brokkr {
     /// carved.
     fn pick(&self, pixel: Vec2) -> Option<(NodeId, brokkr_core::Hit)> {
         let (origin, ray) = self.ray_through(pixel);
-        self.doc.pick(origin, ray, self.camera.far, &self.shown)
+        self.doc.pick(origin, ray, self.camera.far(), &self.shown)
     }
 
     /// Whether the body edits land on is one of the ones being drawn.
@@ -3384,6 +4055,60 @@ impl Brokkr {
         MAX_RADIUS_MM.min(MAX_RADIUS_VOXELS * self.doc.voxel_size()).max(MIN_RADIUS_MM)
     }
 
+    /// Carry a live gizmo drag to the pointer.
+    ///
+    /// **Nothing is baked here.** The placement is arithmetic and the preview
+    /// box is twelve lines; the field is rebuilt exactly once, on the release,
+    /// by [`Brokkr::rebake_gizmo`]. That is the difference between a gesture
+    /// costing one trilinear pass and costing one per pointer event.
+    ///
+    /// Shift frees the snap rather than imposing it, which is the opposite of
+    /// every other application's convention and is deliberate: here the snapped
+    /// gesture is the LOSSLESS one, so the default has to be the one that costs
+    /// the surface nothing and the modifier has to be the one that admits a
+    /// price. See `gizmo::ROTATION_SNAP`.
+    fn transform_to(&mut self, handle: gizmo::Handle, position: Vec2) {
+        let (Some(drag), Some(gizmo)) = (self.drag, self.gizmo) else {
+            return;
+        };
+        let gesture = gizmo::drag(
+            &self.camera,
+            self.viewport_size,
+            &gizmo,
+            handle,
+            drag.origin,
+            position,
+            (!self.shift).then(|| self.doc.voxel_size()),
+        );
+        let placement = gizmo.pinned.then(gesture);
+        if let Some(live) = &mut self.gizmo {
+            live.placement = placement;
+        }
+        self.refresh_gizmo();
+        // What the release is ABOUT to cost, before it is spent. The armed
+        // badge the plan asked for, in the one place the interface already
+        // reads from.
+        let route = placement.route(self.doc.voxel_size());
+        // **The clamp says so.** A preview box that stops growing under the
+        // pointer with nothing said reads as the gizmo having lost the drag.
+        // Naming the ceiling is what turns it into an answer.
+        let capped = handle == gizmo::Handle::Uniform
+            && placement.scale >= gizmo.max_scale - 1.0e-3
+            && gizmo.max_scale < gizmo::MAX_SCALE;
+        if capped {
+            self.status = format!(
+                "scale — {:.0}% is as large as this body fits in memory",
+                gizmo.max_scale * 100.0
+            );
+            return;
+        }
+        self.status = format!(
+            "{} — {}",
+            handle.verb(),
+            if route.is_lossy() { "will resample" } else { "exact" }
+        );
+    }
+
     /// The world space ray through a point in widget pixels.
     fn ray_through(&self, pixel: Vec2) -> (Vec3, Vec3) {
         let aspect = self.viewport_size.x / self.viewport_size.y.max(1.0);
@@ -3401,7 +4126,9 @@ impl Brokkr {
     /// the ring in one place and the stroke in another.
     fn surface_under(&self, pixel: Vec2) -> Option<Vec3> {
         let (origin, ray) = self.ray_through(pixel);
-        self.doc.pick_body(self.doc.active(), origin, ray, self.camera.far).map(|hit| hit.position)
+        self.doc
+            .pick_body(self.doc.active(), origin, ray, self.camera.far())
+            .map(|hit| hit.position)
     }
 
     /// Open the undo recorder on the body this stroke is about to write to, if
@@ -3450,7 +4177,7 @@ impl Brokkr {
     fn live_strength_slot(&self) -> usize {
         match self.tool {
             Tool::Mask => MASK_STRENGTH_SLOT,
-            Tool::Sculpt | Tool::Cut => Self::strength_slot(self.brush.kind),
+            Tool::Sculpt | Tool::Cut | Tool::Transform => Self::strength_slot(self.brush.kind),
         }
     }
 
@@ -3458,7 +4185,7 @@ impl Brokkr {
     pub(crate) fn max_strength(&self) -> f32 {
         match self.tool {
             Tool::Mask => MAX_MASK_STRENGTH,
-            Tool::Sculpt | Tool::Cut => MAX_STRENGTH,
+            Tool::Sculpt | Tool::Cut | Tool::Transform => MAX_STRENGTH,
         }
     }
 
@@ -3473,6 +4200,7 @@ impl Brokkr {
             (Tool::Mask, true) => "MASK — BLUR".to_string(),
             (Tool::Mask, false) => "MASK".to_string(),
             (Tool::Cut, _) => "PLANE CUT".to_string(),
+            (Tool::Transform, _) => "MOVE".to_string(),
             (Tool::Sculpt, _) => self.effective_brush().kind.label().to_uppercase(),
         }
     }
@@ -4237,6 +4965,9 @@ impl Brokkr {
         self.history.clear();
         self.history_stats = self.history.stats();
         self.camera = OrbitCamera::framing(Vec3::ZERO, MODEL_RADIUS_MM);
+        // `framing` leaves the default lattice behind, and the floor is a
+        // number of voxels, so it has to be told the real one.
+        self.refresh_camera_lattice();
         self.project_path = None;
         self.unsaved = false;
         self.status = String::new();
@@ -4463,6 +5194,28 @@ impl Brokkr {
             roll: view.camera_roll,
             ..framed
         };
+        // **The admissible range is asked of a camera carrying the document's
+        // own lattice and extent, which is the pair the live camera will be
+        // given the moment this restore lands.**
+        //
+        // `framing` sets neither: it takes a radius and leaves `voxel_size` at
+        // the 0.25 mm default, so `framed.min_distance()` was 0.5 mm for every
+        // document ever opened while the live floor is
+        // `doc.voxel_size() * 2.0`. Measured: resample to 0.05, scroll in, the
+        // camera legitimately reaches 0.1 -- and reopening threw that framing
+        // away and re-framed to 158 mm, with a status line telling the user
+        // their file was wrong. Every lattice but 0.25 was affected, and the
+        // suite could not see it because `VOXEL_SIZE_MM` happens to equal the
+        // camera default.
+        //
+        // The ceiling had the same shape for a second reason: it came from the
+        // ACTIVE body's content radius while the live one comes from the
+        // document ball, so 200 notches of scroll-out parked the camera at
+        // 6906 -- legal, the live clamp put it there -- and the loader called
+        // 5520 the limit and rejected it. This is the same "the loader and the
+        // live camera must not disagree about the same word" the target test
+        // below is built on; it simply was not applied to the distance.
+        camera.set_lattice(self.doc.voxel_size(), self.document_ball().1);
 
         // **A file written before that fix carries the bad numbers, so the
         // restore has to be able to recover one rather than merely stop making
@@ -4478,18 +5231,32 @@ impl Brokkr {
         // And the distance may be outside what `zoom_by` will now admit, which
         // is what a floor computed from the wrong radius leaves behind.
         //
+        // **The target test is [`Brokkr::document_ball`] and not the active
+        // body's own sphere, so that the loader and the live camera cannot
+        // disagree about the same word.** [`Brokkr::contain_target`] holds the
+        // camera inside that ball on every mutation; if the restore accepted a
+        // smaller one, a target the live camera reaches legitimately -- panned
+        // across a two body document, say -- would be refused on the way back
+        // in and the user's framing thrown away for no reason. The union spans
+        // the gaps between bodies, which for a camera bound is the safe
+        // direction to be loose in.
+        //
         // The angles are kept in both cases. They are the part of a saved view
         // that is still meaningful when the rest of it is not, and re-framing
         // without them would spin a model the user had deliberately turned.
-        let lost_target = !camera.target.is_finite() || camera.target.distance(centre) > radius;
+        let (ball_centre, ball_radius) = self.document_ball();
+        let lost_target =
+            !camera.target.is_finite() || camera.target.distance(ball_centre) > ball_radius;
         let lost_distance = !camera.distance.is_finite()
-            || camera.distance < framed.near * 10.0
-            || camera.distance > framed.far;
+            || camera.distance < camera.min_distance()
+            || camera.distance > camera.max_distance();
         if lost_target {
             camera.target = framed.target;
         }
         if lost_distance {
-            camera.distance = framed.distance;
+            // Clamped for the same reason `frame_active` clamps: a body smaller
+            // than a couple of voxels frames at a distance under its own floor.
+            camera.distance = framed.distance.clamp(camera.min_distance(), camera.max_distance());
         }
         if lost_target || lost_distance {
             // Said out loud rather than fixed silently: the view really is not
@@ -4502,6 +5269,7 @@ impl Brokkr {
         }
 
         self.camera = camera;
+        self.refresh_camera_lattice();
         self.brush.radius = view.brush_radius.clamp(MIN_RADIUS_MM, self.max_radius());
         self.brush.strength = view.brush_strength.clamp(MIN_STRENGTH, MAX_STRENGTH);
         self.symmetry = MirrorAxis::ALL
@@ -4612,6 +5380,9 @@ impl Brokkr {
     fn adopt_import(&mut self, imported: crate::message::Imported) {
         self.doc = Document::from_volume(imported.volume);
         self.camera = OrbitCamera::framing(Vec3::ZERO, MODEL_RADIUS_MM);
+        // `framing` leaves the default lattice behind, and the floor is a
+        // number of voxels, so it has to be told the real one.
+        self.refresh_camera_lattice();
         self.history.clear();
         self.history_stats = self.history.stats();
         self.project_path = None;
@@ -5080,6 +5851,9 @@ impl Brokkr {
         self.rebuild_everything();
         let _ = previous_radius;
         self.camera = OrbitCamera::framing(Vec3::ZERO, self.model_radius.max(1.0e-3));
+        // `framing` leaves the default lattice behind, and the floor is a
+        // number of voxels, so it has to be told the real one.
+        self.refresh_camera_lattice();
         self.publish_camera();
         self.refresh_overlay();
         self.refresh_detail_advice();
@@ -5160,37 +5934,58 @@ impl Brokkr {
         log::info!("{}", self.status);
     }
 
+    /// What one puck button press does.
+    ///
+    /// Split out of [`Brokkr::drive_from_spacemouse`] so a test can press a
+    /// button without a `/dev/input` node: the press queue is filled by a
+    /// reader thread, and the two camera arms below are exactly the kind of
+    /// code that goes wrong unobserved because nothing in CI can reach it.
+    fn run_puck_button(&mut self, action: ButtonAction) {
+        match action {
+            ButtonAction::None => {}
+            ButtonAction::Undo => self.undo(),
+            ButtonAction::Redo => self.redo(),
+            // Recentre and refit without losing which way the model is being
+            // looked at, which is what makes this useful mid sculpt.
+            //
+            // **Through `frame_active`, not a fresh `framing`.** Assigning one
+            // resets `voxel_size` to the 0.25 mm default and `content_radius`
+            // to the hardcoded 30 mm starting ball, and both are now
+            // load-bearing: the first is the zoom floor and the second is both
+            // the far plane and the length of every pick ray. Measured on a
+            // document resampled to 0.05, the floor went from 0.1 to 0.5 -- a
+            // puck button silently making the camera five times coarser than
+            // the lattice deserves, which is the precise complaint this work
+            // exists to fix. On a large model the same assignment collapses
+            // `far()` to well inside the geometry, so the far half of it stops
+            // being drawn and stops being pickable at once. `frame_active`
+            // frames the body that is actually there and refreshes the lattice
+            // from the document, which is the whole job.
+            ButtonAction::FrameModel => self.frame_active(),
+            // Everything back to the start, roll included. This is the way out
+            // of a view that has been twisted somewhere confusing.
+            ButtonAction::ResetView => {
+                let start = OrbitCamera::default();
+                self.camera.yaw = start.yaw;
+                self.camera.pitch = start.pitch;
+                self.camera.roll = start.roll;
+                // The angles are the reset; the framing is `frame_active`'s,
+                // for the reason above.
+                self.frame_active();
+                self.status = "reset the view".to_string();
+            }
+            ButtonAction::ToggleSymmetry => {
+                // Through the same gate the strip uses, and not a bare
+                // `toggled`: see `toggle_mirror`.
+                self.toggle_mirror(MirrorAxis::X);
+            }
+        }
+    }
+
     /// Apply one frame of puck motion, and whatever its buttons asked for.
     fn drive_from_spacemouse(&mut self, elapsed_ms: f32) {
         for action in self.spacemouse.take_presses() {
-            match action {
-                ButtonAction::None => {}
-                ButtonAction::Undo => self.undo(),
-                ButtonAction::Redo => self.redo(),
-                // Recentre and refit without losing which way the model is
-                // being looked at, which is what makes this useful mid sculpt.
-                ButtonAction::FrameModel => {
-                    let framed = OrbitCamera::framing(Vec3::ZERO, MODEL_RADIUS_MM);
-                    self.camera = OrbitCamera {
-                        yaw: self.camera.yaw,
-                        pitch: self.camera.pitch,
-                        roll: self.camera.roll,
-                        ..framed
-                    };
-                    self.publish_camera();
-                }
-                // Everything back to the start, roll included. This is the way
-                // out of a view that has been twisted somewhere confusing.
-                ButtonAction::ResetView => {
-                    self.camera = OrbitCamera::framing(Vec3::ZERO, MODEL_RADIUS_MM);
-                    self.publish_camera();
-                }
-                ButtonAction::ToggleSymmetry => {
-                    // Through the same gate the strip uses, and not a bare
-                    // `toggled`: see `toggle_mirror`.
-                    self.toggle_mirror(MirrorAxis::X);
-                }
-            }
+            self.run_puck_button(action);
         }
 
         let motion = self.spacemouse.motion();
@@ -6302,6 +7097,46 @@ impl Brokkr {
                     return;
                 }
 
+                // **Before every other left-press rule, and bounds-checked
+                // before it may claim anything.** ONLY BOUNDS-CHECKED EVENTS
+                // MAY CAPTURE: `gizmo::pick` returns `None` for anything
+                // outside the gizmo's own disc, so a press on the model still
+                // reaches the sculpt below. It sits above the tool match rather
+                // than inside `Tool::Transform`'s arm so that the gizmo is
+                // reachable while the pointer is over another body -- selecting
+                // a different body out from under an armed gizmo is exactly the
+                // surprise the press ordering exists to remove.
+                //
+                // A held resize still outranks it, which is the precedence the
+                // press dispatch below already settled between sizing and the
+                // cut: a resize whose press turned into something else is the
+                // worse of the two surprises, and the pointer belongs to that
+                // gesture whether or not a button is down.
+                if button == PointerButton::Left
+                    && self.sizing.is_none()
+                    && let Some(gizmo) = self.gizmo
+                    && let Some(handle) =
+                        gizmo::pick(&self.camera, self.viewport_size, &gizmo, position)
+                {
+                    if let Some(live) = &mut self.gizmo {
+                        // Latched at the press: `drag` is absolute from this
+                        // pixel and measures about the placement as it stands
+                        // now, so both have to be held for the whole gesture.
+                        live.pinned = live.placement;
+                        live.grabbed = Some(handle);
+                    }
+                    self.drag = Some(Drag {
+                        button,
+                        kind: DragKind::Transforming(handle),
+                        origin: position,
+                        pressed_at: Instant::now(),
+                        moved: false,
+                        pivot: None,
+                    });
+                    self.refresh_gizmo();
+                    return;
+                }
+
                 let kind = match button {
                     // Left sculpts -- unless a hold-and-drag resize is in
                     // progress, in which case the pointer belongs to that
@@ -6327,6 +7162,25 @@ impl Brokkr {
                         // reason and so that the two agree.
                         Tool::Mask => DragKind::Masking,
                         Tool::Sculpt => self.sculpt_press(position),
+                        // The press missed every handle -- the gizmo claims its
+                        // own above. Choosing a body is the useful thing left,
+                        // and it re-arms on the new one, which is what makes
+                        // "move this one now" one press rather than three.
+                        Tool::Transform => {
+                            let chosen = self.pick(position).map(|(body, _)| body);
+                            match chosen {
+                                Some(body) if body != self.doc.active() => {
+                                    self.disarm_gizmo(true);
+                                    self.select_body(body);
+                                    if let Err(why) = self.arm_gizmo() {
+                                        self.status = why;
+                                        self.tool = Tool::Sculpt;
+                                    }
+                                    DragKind::Selecting
+                                }
+                                _ => DragKind::Refused,
+                            }
+                        }
                     },
                     // Right and middle move the camera. Shift slides instead of
                     // turning.
@@ -6344,6 +7198,20 @@ impl Brokkr {
                     origin: position,
                     pressed_at: Instant::now(),
                     moved: false,
+                    // `refresh_hover` ran on the motion event that brought the
+                    // pointer here, so this costs a field read and no march.
+                    //
+                    // **The hover, with no fallback.** Orbiting about a point
+                    // MOVES the target, so an anchor off the model walks the
+                    // target sideways on every drag that started over empty
+                    // background -- measured at 68 mm from one twenty step drag
+                    // on a 30 mm ball, and it compounds. `None` here means
+                    // "turn about the target", which is what orbiting has
+                    // always done. [`Brokkr::navigation_anchor`] refuses an
+                    // off-model anchor for the wheel for the same reason,
+                    // arrived at separately and measured separately. Pinned by
+                    // `an_orbit_drag_that_starts_off_the_model_turns_about_the_target`.
+                    pivot: (kind == DragKind::Orbit).then_some(self.hover).flatten(),
                 });
 
                 if let DragKind::Sculpt(direction) = kind {
@@ -6368,6 +7236,18 @@ impl Brokkr {
                     if matches!(drag.kind, DragKind::Cutting) {
                         // The drag already recorded where the button went down.
                         self.finish_cut(drag.origin);
+                    }
+                    // **The one place the field is rebuilt**, and it is the
+                    // release rather than the motion: a bake per frame would be
+                    // hundreds of trilinear passes for one gesture, and the
+                    // preview box is what stands in for the model in the
+                    // meantime.
+                    if matches!(drag.kind, DragKind::Transforming(_)) {
+                        if let Some(live) = &mut self.gizmo {
+                            live.grabbed = None;
+                        }
+                        self.rebake_gizmo();
+                        self.refresh_gizmo();
                     }
                     // A mask gesture ends the same way a sculpt one does, and
                     // through the same function: both opened the same recorder,
@@ -6412,11 +7292,47 @@ impl Brokkr {
                     return;
                 }
 
+                // The gizmo's hover, whether or not a button is down: it is
+                // what says which handle a press would take, and it is a
+                // handful of projections rather than a raycast.
+                if let Some(gizmo) = self.gizmo {
+                    let hovered = (self.drag.is_none())
+                        .then(|| gizmo::pick(&self.camera, self.viewport_size, &gizmo, position))
+                        .flatten();
+                    if let Some(live) = &mut self.gizmo
+                        && live.hovered != hovered
+                    {
+                        live.hovered = hovered;
+                        self.refresh_gizmo();
+                    }
+                }
+
                 match self.drag.map(|drag| drag.kind) {
+                    Some(DragKind::Transforming(handle)) => {
+                        self.transform_to(handle, position);
+                        // Nothing else on this event: a gizmo drag owns the
+                        // pointer, and the brush ring under it would be a ring
+                        // on a surface that is about to move.
+                        return;
+                    }
                     Some(DragKind::Sculpt(direction)) => self.sculpt_to(position, direction, false),
                     Some(DragKind::Masking) => self.mask_to(position, false),
                     Some(DragKind::Orbit) => {
-                        self.camera.orbit(delta);
+                        // About the surface the press landed on, so turning to
+                        // look at the other side of a detail keeps the detail
+                        // on screen instead of swinging it out of frame.
+                        //
+                        // **The fallback is the TARGET**, which is what
+                        // orbiting has always turned about. An anchor off the
+                        // model would put the pivot wherever the cursor
+                        // happened to be over empty background, and since
+                        // orbiting about it moves the target, every drag that
+                        // started off the model would walk the target sideways
+                        // for no benefit at all.
+                        match self.drag.and_then(|drag| drag.pivot) {
+                            Some(pivot) => self.camera.orbit_about(delta, pivot),
+                            None => self.camera.orbit(delta),
+                        }
                         self.publish_camera();
                     }
                     Some(DragKind::Pan) => {
@@ -6454,9 +7370,21 @@ impl Brokkr {
                 self.refresh_hover(position);
                 self.refresh_overlay();
             }
-            PointerEvent::Scrolled { amount } => {
-                self.camera.zoom(amount);
+            PointerEvent::Scrolled { amount, position, size } => {
+                self.viewport_size = Vec2::new(size.x, size.y);
+                let position = Vec2::new(position.x, position.y);
+                // The anchor rule lives in `navigation_anchor`, and it is the
+                // whole of the fix for "I cannot zoom in to work on a detail"
+                // and for the drift that fixing it originally introduced.
+                let factor = OrbitCamera::zoom_factor(amount);
+                let anchor = self.navigation_anchor(factor);
+                self.camera.zoom_by_about(factor, anchor);
                 self.publish_camera();
+                // The ring is pushed onto the surface it sits over and the
+                // pick that placed it was taken at the old camera, so a zoom
+                // leaves it stale. Cheap, and only on a real wheel notch.
+                self.refresh_hover(position);
+                self.refresh_overlay();
             }
         }
     }
@@ -6487,7 +7415,34 @@ impl Brokkr {
         if self.renaming.is_some() && !keeps_the_rename_open(&message) {
             self.commit_rename();
         }
+        // **The same pattern as the rename above, and it is here for a
+        // stronger reason than tidiness.** While the gizmo is armed the
+        // DOCUMENT already holds the baked field and the HISTORY does not yet
+        // hold the entry that undoes it -- the entry is pushed once per
+        // session, at disarm, because one per drag would be a whole field each
+        // and thirty of them would evict every stroke behind them. So any
+        // message that is not part of the gesture has to close the session
+        // first, or it acts on a document whose last change is not on the
+        // stack. Undo is the sharpest case and by no means the only one: save,
+        // export, delete, resample and every future operation belong to the
+        // same set, and that set is not a list anyone can keep correct.
+        // Asking the question once, before the message is acted on, cannot go
+        // out of date.
+        if self.gizmo.is_some() && !keeps_the_gizmo_armed(&message) {
+            self.disarm_gizmo(true);
+        }
         let task = self.dispatch(message);
+        // And the gizmo follows the active body. The guard above committed
+        // whatever was in flight; this re-arms on whatever is active NOW, so
+        // choosing a different row while the tool is up moves the gizmo there
+        // rather than leaving the mode lit with nothing under it.
+        if self.tool == Tool::Transform
+            && self.gizmo.is_none()
+            && let Err(why) = self.arm_gizmo()
+        {
+            self.status = why;
+            self.tool = Tool::Sculpt;
+        }
         self.publish_visibility();
         task
     }
@@ -6742,6 +7697,33 @@ impl Brokkr {
                 // silently drop the mode they are painting in. The next reader
                 // will want to add it here for symmetry; this paragraph is why
                 // not.
+                // Escape ABANDONS the gizmo, where choosing another tool
+                // commits it. Ahead of the cut in the cascade for the reason
+                // every card here is ordered by: this one is the answer to a
+                // question the user can see being asked -- a body sitting
+                // somewhere it was dragged to -- and the cut is a mode with
+                // nothing pending on screen.
+                //
+                // A LIVE drag is cancelled first and on its own, without
+                // disarming: Escape mid-drag means "not that one", not "not any
+                // of it", and the gesture is undone by throwing it away rather
+                // than by inverting it -- `pinned` is what the placement was
+                // before the button went down.
+                if let Some(gizmo) = &mut self.gizmo
+                    && gizmo.grabbed.is_some()
+                {
+                    gizmo.placement = gizmo.pinned;
+                    gizmo.grabbed = None;
+                    self.drag = None;
+                    self.refresh_gizmo();
+                    self.status = "cancelled the drag".to_string();
+                    return Task::none();
+                }
+                if self.tool == Tool::Transform {
+                    self.disarm_gizmo(false);
+                    self.tool = Tool::Sculpt;
+                    return Task::none();
+                }
                 if self.tool == Tool::Cut {
                     self.tool = Tool::Sculpt;
                 }
@@ -6778,6 +7760,22 @@ impl Brokkr {
             // makes one variant cover arming and disarming both.
             Message::ToolChanged(tool) => {
                 let tool = if tool == self.tool { Tool::Sculpt } else { tool };
+                // Leaving the gizmo COMMITS, where Escape abandons. That split
+                // is the convention every modelling tool already has, and it is
+                // the safe way round: choosing another tool is not a statement
+                // about the placement, and silently undoing it would throw away
+                // work the user can see on screen.
+                if self.tool == Tool::Transform && tool != Tool::Transform {
+                    self.disarm_gizmo(true);
+                }
+                if tool == Tool::Transform
+                    && let Err(why) = self.arm_gizmo()
+                {
+                    // Refused BEFORE the tool changes, so the strip does not
+                    // light a mode that has no gizmo under it.
+                    self.status = why;
+                    return Task::none();
+                }
                 // Through the swap so the mask's own strength is put away and
                 // the brush's is brought back, and vice versa. See `strengths`.
                 self.swap_strength(|app| app.tool = tool);
@@ -6788,6 +7786,9 @@ impl Brokkr {
                     }
                     Tool::Mask => "mask: drag to protect, ctrl or alt to unprotect, \
                                    shift to soften"
+                        .to_string(),
+                    Tool::Transform => "move: drag an arrow, a square or a ring — snapped to \
+                                        the voxel and to quarter turns, hold shift for free"
                         .to_string(),
                     Tool::Sculpt => String::new(),
                 };
@@ -6874,6 +7875,7 @@ impl Brokkr {
             // the `show_mask` field for the whole of that argument.
             Message::ShowMaskToggled => self.show_mask = !self.show_mask,
             Message::MaskTintChanged(tint) => self.mask_tint = tint.clamp(0.0, 1.0),
+            Message::CameraFramedOnActive => self.frame_active(),
             Message::MaskPeekStarted => self.mask_peek = true,
             Message::MaskPeekEnded => self.mask_peek = false,
             // And the verbs, which DO change protection and all of which are
@@ -7726,10 +8728,21 @@ mod tests {
         app.apply_view(&poisoned);
 
         let radius = app.doc.active_volume().content_radius().expect("the ball has bounds");
+        // **The floor assertion changed with the unit it is measured in, and
+        // the behaviour it pinned is the thing being fixed.** It used to demand
+        // `near * 10.0 > 1.0` -- 1.33 mm on this model -- as proof that the
+        // floor had been computed from the body rather than from the 30 mm
+        // starting ball. The floor is now two voxels, so it is the same
+        // closeness on every model by construction and cannot come from the
+        // wrong body at all; a fraction-of-the-radius floor was itself the
+        // reason detail work was impossible. What is still worth pinning is
+        // that the floor is a sane multiple of the lattice and that the
+        // restored distance clears it.
         assert!(
-            app.camera.near * 10.0 > 1.0,
-            "the zoom floor is {} -- it came from the 30 mm ball, not from a {radius} mm model",
-            app.camera.near * 10.0
+            (app.camera.min_distance() - app.doc.voxel_size() * 2.0).abs() < 1.0e-6,
+            "the zoom floor is {} on a {} mm lattice",
+            app.camera.min_distance(),
+            app.doc.voxel_size()
         );
         assert!(
             app.camera.target.distance(Vec3::ZERO) <= radius,
@@ -7737,10 +8750,10 @@ mod tests {
             app.camera.target.distance(Vec3::ZERO)
         );
         assert!(
-            app.camera.distance >= app.camera.near * 10.0,
+            app.camera.distance >= app.camera.min_distance(),
             "the restored distance {} is below its own floor {}",
             app.camera.distance,
-            app.camera.near * 10.0
+            app.camera.min_distance()
         );
         assert!(
             (app.camera.yaw - 42.6).abs() < 1.0e-3,
@@ -7756,7 +8769,7 @@ mod tests {
 
         // The whole point: a scroll now moves the camera by something you can see.
         let before = app.camera.distance;
-        app.camera.zoom(1.0);
+        app.camera.zoom_by(OrbitCamera::zoom_factor(1.0));
         assert!(
             (app.camera.distance - before).abs() > 1.0,
             "one notch of scroll moved {} mm",
@@ -10077,23 +11090,36 @@ mod tests {
         assert!(app.camera.view().to_cols_array().iter().all(|v| v.is_finite()));
     }
 
-    /// A click on Top asks for a pitch of ninety degrees, which is exactly where
-    /// the view matrix collapses. The flight interpolates the field directly, so
-    /// it has to respect the same limit the drag path does.
+    /// A click on Top asks for a pitch of exactly ninety degrees, which is
+    /// exactly where `look_at` used to collapse.
+    ///
+    /// **This replaces `flying_to_a_pole_stops_short_of_collapsing_the_view`,
+    /// and the inversion is the fix.** The old test asserted the camera did
+    /// NOT arrive at the pole -- because `PITCH_SAFE` stopped it 0.02 rad
+    /// short, so clicking "top" gave a view that was visibly not the top. The
+    /// composed basis is orthonormal there, so the assertion is now that the
+    /// camera lands exactly on the pole and the matrix survives it.
     #[test]
-    fn flying_to_a_pole_stops_short_of_collapsing_the_view() {
+    fn flying_to_a_pole_arrives_at_the_pole_with_the_view_intact() {
         for direction in [Vec3::Y, Vec3::NEG_Y] {
             let mut app = app();
             app.fly_to(crate::navcube::Part { direction, extremes: 1 });
             finish_flight(&mut app);
             assert!(app.flight.is_none());
             assert!(
-                app.camera.pitch.abs() < std::f32::consts::FRAC_PI_2,
-                "{direction:?} reached the pole: pitch {}",
+                (app.camera.pitch.abs() - std::f32::consts::FRAC_PI_2).abs() < 1.0e-4,
+                "{direction:?} did not reach the pole: pitch {}",
                 app.camera.pitch
+            );
+            // Straight down means the view direction is world up, exactly.
+            let looking = (app.camera.target - app.camera.eye()).normalize();
+            assert!(
+                looking.dot(-direction).abs() > 0.9999,
+                "{direction:?} did not end up looking along the axis: {looking:?}"
             );
             assert!(app.camera.view().to_cols_array().iter().all(|v| v.is_finite()));
             assert!((app.camera.right().length() - 1.0).abs() < 1.0e-4);
+            assert!(app.camera.right().dot(app.camera.up()).abs() < 1.0e-4);
         }
     }
 
@@ -15828,6 +16854,24 @@ mod mask_tool_tests {
         assert!(crate::viewport::shortcut("m", false, false, true).is_none());
     }
 
+    /// `w` reaches the transform gizmo, and only bare.
+    ///
+    /// ZBrush's, Blender's and Maya's key for Move, taken rather than invented.
+    /// Chorded it belongs to the toolkit: `ctrl+w` closes a window nearly
+    /// everywhere and this application has claimed neither form.
+    #[test]
+    fn the_w_key_decodes_to_the_transform_gizmo() {
+        assert!(
+            matches!(
+                crate::viewport::shortcut("w", false, false, false),
+                Some(Message::ToolChanged(Tool::Transform))
+            ),
+            "w does not reach the transform gizmo"
+        );
+        assert!(crate::viewport::shortcut("w", true, false, false).is_none());
+        assert!(crate::viewport::shortcut("w", false, false, true).is_none());
+    }
+
     /// `h` starts a peek, and only bare.
     ///
     /// ZBrush's own mask-visibility key, taken rather than invented. Chorded it
@@ -17242,11 +18286,11 @@ mod real_file_check {
             "target {:?}  distance {:.3}  floor {:.3}  far {:.1}",
             c.target,
             c.distance,
-            c.near * 10.0,
-            c.far
+            c.min_distance(),
+            c.far()
         );
         let before = app.camera.distance;
-        app.camera.zoom(1.0);
+        app.camera.zoom_by(OrbitCamera::zoom_factor(1.0));
         println!(
             "one scroll notch: {:.3} -> {:.3}  (moved {:.3} mm)",
             before,
@@ -17255,5 +18299,1417 @@ mod real_file_check {
         );
         assert!((app.camera.distance - before).abs() > 1.0, "scroll still does nothing");
         assert!(app.camera.target.distance(Vec3::ZERO) < 200.0, "still aimed at empty space");
+    }
+}
+
+/// The camera Thomas asked for: free to move, still focused on the sculpt.
+///
+/// These are the tests that measure the OUTCOME rather than the mechanism.
+/// Everything in `camera.rs` proves the arithmetic; this proves that driving
+/// the application the way a user drives it gets you next to a detail and back
+/// again without ending up inside the model or lost in space.
+#[cfg(test)]
+mod free_camera_tests {
+    use super::*;
+    use iced::Vector;
+
+    const SIZE: Vector = Vector { x: 800.0, y: 600.0 };
+
+    fn app() -> Brokkr {
+        Brokkr::with_tablet(crate::tablet::Tablet::inert())
+    }
+
+    /// A wheel notch, delivered the way the widget delivers one: the pointer
+    /// has moved there first, so the hover is current.
+    fn scroll(app: &mut Brokkr, at: Vector, amount: f32) {
+        app.on_pointer(PointerEvent::Moved { position: at, size: SIZE });
+        app.on_pointer(PointerEvent::Scrolled { amount, position: at, size: SIZE });
+    }
+
+    /// Off centre, so an anchored zoom and a target-centred one visibly differ.
+    fn off_centre() -> Vector {
+        Vector::new(SIZE.x / 2.0 + 70.0, SIZE.y / 2.0 - 50.0)
+    }
+
+    /// **The complaint, in one test.** "Now I can't zoom in close to the sculpt
+    /// to work on details."
+    ///
+    /// The eye travels toward the TARGET, and after a file is opened the target
+    /// is the centre of the model -- so scrolling in walks the camera into the
+    /// geometry, and every millimetre of "closer" is a millimetre further
+    /// inside. Raising or lowering the distance floor cannot fix that; it only
+    /// chooses how deep in you are allowed to get. What fixes it is zooming
+    /// toward the surface under the cursor.
+    ///
+    /// The assertion is the one that matters to a person: the eye is OUTSIDE
+    /// the solid, and it is a small number of voxels from the surface it was
+    /// pointed at.
+    #[test]
+    fn zooming_in_on_a_detail_ends_up_beside_the_surface_and_not_inside_it() {
+        let mut app = app();
+        let at = off_centre();
+        app.on_pointer(PointerEvent::Moved { position: at, size: SIZE });
+        let detail = app.hover.expect("the test point has to be on the model");
+
+        for _ in 0..60 {
+            scroll(&mut app, at, 1.0);
+        }
+
+        let eye = app.camera.eye();
+        let field = app.doc.active_volume().sample_world(eye);
+        assert!(field > 0.0, "the camera ended up inside the model: field {field} at {eye:?}");
+        assert!(
+            eye.distance(detail) < MODEL_RADIUS_MM * 0.25,
+            "the camera stopped {} mm from the detail it was aimed at",
+            eye.distance(detail)
+        );
+        assert!(
+            app.camera.distance <= app.camera.min_distance() * 1.01,
+            "sixty notches did not reach the floor: {}",
+            app.camera.distance
+        );
+        // And close means close: two voxels, not a hundredth of the model.
+        assert!(
+            app.camera.distance < 1.0,
+            "the closest the camera can get is {} mm",
+            app.camera.distance
+        );
+    }
+
+    /// The other half of the sentence: "but still focused on the sculpt".
+    ///
+    /// **The assertion is the one a person would make, and the one this test
+    /// used to make could be satisfied while the model was invisible.** It
+    /// asserted only that the target stayed inside the document ball -- a
+    /// statement about a number the user cannot see. What matters is that the
+    /// sculpt is still there to be worked on, so that is what is measured: the
+    /// middle of the document still lands inside the widget, and a pick at that
+    /// pixel still finds it. The second assertion is not redundant: with the
+    /// target drifting, the model went behind `far()`, which is the far plane
+    /// AND the pick reach, while still being inside the frustum sideways.
+    ///
+    /// **This is a guard rather than a reproduction.** It passes against the
+    /// code as it was, because the tight fence held the model inside `far()` by
+    /// accident. It exists because the first attempted fix -- widening the
+    /// fence in proportion to the distance -- broke it, and nothing else would
+    /// have noticed.
+    #[test]
+    fn a_long_scroll_out_over_empty_space_keeps_the_model_on_screen() {
+        let mut app = app();
+        // A corner, well clear of a sphere drawn in the middle.
+        let empty = Vector::new(20.0, 20.0);
+        app.on_pointer(PointerEvent::Moved { position: empty, size: SIZE });
+        assert!(app.hover.is_none(), "the corner was supposed to miss the model");
+
+        let (centre, _) = app.document_ball();
+        let pixel_of = |app: &Brokkr| {
+            let clip = app.camera.view_projection(SIZE.x / SIZE.y) * centre.extend(1.0);
+            (clip.w, Vec2::new(clip.x / clip.w, clip.y / clip.w))
+        };
+        for step in 0..200 {
+            scroll(&mut app, empty, -1.0);
+            let (w, ndc) = pixel_of(&app);
+            assert!(
+                w > 0.0 && ndc.x.abs() <= 1.0 && ndc.y.abs() <= 1.0,
+                "after {} notches out the middle of the document is at {ndc:?}, off screen",
+                step + 1
+            );
+        }
+
+        // And it is not merely inside the frustum sideways: the cursor still
+        // finds it there, which is what says it is inside the depth range too.
+        let (_, ndc) = pixel_of(&app);
+        let pixel = Vector::new((ndc.x + 1.0) * 0.5 * SIZE.x, (1.0 - ndc.y) * 0.5 * SIZE.y);
+        app.on_pointer(PointerEvent::Moved { position: pixel, size: SIZE });
+        assert!(app.hover.is_some(), "the model is drawn at {pixel:?} but nothing is pickable");
+    }
+
+    /// **The cost of the anchor rule, asserted rather than merely claimed.**
+    /// Zooming in is anchored on the surface under the cursor and zooming out
+    /// is anchored on the target, so a scroll in on a detail and back out
+    /// restores the distance exactly but leaves the view centred on that detail
+    /// rather than on wherever it started. That is the trade
+    /// [`Brokkr::navigation_anchor`] argues for, so the distance is asserted to
+    /// come back and the target deliberately is not.
+    ///
+    /// **This is a guard, not a reproduction**: it passes against the code as
+    /// it was, because in-then-out over the MODEL was never the broken order.
+    /// The broken one is
+    /// `scrolling_out_over_a_corner_and_back_in_returns_exactly`.
+    #[test]
+    fn scrolling_in_and_back_out_returns_the_distance_and_leaves_the_model_in_view() {
+        for notches in [4, 8, 12, 20, 30] {
+            let mut app = app();
+            let at = off_centre();
+            app.on_pointer(PointerEvent::Moved { position: at, size: SIZE });
+            assert!(app.hover.is_some(), "the test point has to be on the model");
+            let before = app.camera.distance;
+
+            for _ in 0..notches {
+                scroll(&mut app, at, 1.0);
+            }
+            for _ in 0..notches {
+                scroll(&mut app, at, -1.0);
+            }
+
+            assert!(
+                (app.camera.distance - before).abs() < 1.0e-2,
+                "{notches} notches in and back left the distance at {} instead of {before}",
+                app.camera.distance
+            );
+            // The complaint restated: the sculpt is under the middle of the
+            // viewport, where a person would look for it.
+            let centre = Vector::new(SIZE.x / 2.0, SIZE.y / 2.0);
+            app.on_pointer(PointerEvent::Moved { position: centre, size: SIZE });
+            assert!(
+                app.hover.is_some(),
+                "after {notches} in and back the model is not under the middle of the viewport"
+            );
+        }
+    }
+
+    /// Scrolling out is anchored on the target, so it cannot move the target at
+    /// all -- which is the property the drift used to violate and the one the
+    /// containment fence should never have to enforce.
+    #[test]
+    fn scrolling_out_does_not_move_the_target() {
+        let mut app = app();
+        for at in [off_centre(), Vector::new(20.0, 20.0)] {
+            app.on_pointer(PointerEvent::Moved { position: at, size: SIZE });
+            let before = app.camera.target;
+            for _ in 0..40 {
+                scroll(&mut app, at, -1.0);
+            }
+            assert!(
+                app.camera.target.distance(before) < 1.0e-4,
+                "scrolling out at {at:?} moved the target {} mm",
+                app.camera.target.distance(before)
+            );
+        }
+    }
+
+    /// A scroll with the cursor over nothing is the commonest gesture in the
+    /// application, and it must be exactly the target-centred zoom it has
+    /// always been -- in BOTH directions, so that it is perfectly reversible.
+    ///
+    /// The fallback this pins replaces the ray's crossing of the plane through
+    /// the target. That point is off the model, so zooming in about it drifts
+    /// the target off the model in proportion to the distance: measured, twelve
+    /// notches out and twelve back in over a corner left the target 188 mm from
+    /// a 69 mm document, hard into the fence and unrecoverable by the inverse
+    /// gesture.
+    #[test]
+    fn a_scroll_over_empty_background_is_the_zoom_it_has_always_been() {
+        let mut app = app();
+        let empty = Vector::new(20.0, 20.0);
+        app.on_pointer(PointerEvent::Moved { position: empty, size: SIZE });
+        assert!(app.hover.is_none(), "the corner was supposed to miss the model");
+        let before = (app.camera.target, app.camera.distance);
+
+        for amount in [1.0_f32, -1.0, -1.0, 1.0, 3.0, -3.0] {
+            let expected = app.camera.distance * OrbitCamera::zoom_factor(amount);
+            let target = app.camera.target;
+            scroll(&mut app, empty, amount);
+            assert!(
+                app.camera.target.distance(target) < 1.0e-6,
+                "a scroll over background moved the target to {:?}",
+                app.camera.target
+            );
+            assert!(
+                (app.camera.distance - expected).abs() < 1.0e-4,
+                "the distance went to {} rather than {expected}",
+                app.camera.distance
+            );
+        }
+        assert!(app.camera.target.distance(before.0) < 1.0e-6);
+        assert!((app.camera.distance - before.1).abs() < 1.0e-4);
+    }
+
+    /// The reported failure, in its exact shape: N notches out over empty
+    /// background then N back in, with the cursor parked in a corner. Twelve
+    /// and twelve used to leave the target 69.06 mm out -- the whole fence --
+    /// and the model no longer under the middle of the viewport.
+    ///
+    /// The target tolerance is float noise and not a budget: the fixed gesture
+    /// does not touch the target at all, at either end, so the honest claim is
+    /// that it is unchanged.
+    #[test]
+    fn scrolling_out_over_a_corner_and_back_in_returns_exactly() {
+        for notches in [4, 8, 12, 20, 30] {
+            let mut app = app();
+            let empty = Vector::new(20.0, 20.0);
+            app.on_pointer(PointerEvent::Moved { position: empty, size: SIZE });
+            assert!(app.hover.is_none(), "the corner was supposed to miss the model");
+            let before = (app.camera.target, app.camera.distance);
+
+            for _ in 0..notches {
+                scroll(&mut app, empty, -1.0);
+            }
+            for _ in 0..notches {
+                scroll(&mut app, empty, 1.0);
+            }
+
+            assert!(
+                app.camera.target.distance(before.0) < 1.0e-4,
+                "{notches} out and back left the target {} mm away",
+                app.camera.target.distance(before.0)
+            );
+            assert!(
+                (app.camera.distance - before.1).abs() < 1.0e-2,
+                "{notches} out and back left the distance at {} instead of {}",
+                app.camera.distance,
+                before.1
+            );
+            let centre = Vector::new(SIZE.x / 2.0, SIZE.y / 2.0);
+            app.on_pointer(PointerEvent::Moved { position: centre, size: SIZE });
+            assert!(
+                app.hover.is_some(),
+                "after {notches} out and back the model is not under the middle of the viewport"
+            );
+        }
+    }
+
+    /// The fence still has a job, and this is it: a target nowhere near the
+    /// document, at a distance that cannot see it, is pulled back.
+    #[test]
+    fn a_target_the_camera_could_not_possibly_see_is_pulled_back() {
+        let mut app = app();
+        app.camera.distance = 1.0;
+        app.camera.target = Vec3::new(-435.18, -12.09, 95.65);
+        app.publish_camera();
+
+        let (centre, radius) = app.document_ball();
+        assert!(
+            app.camera.target.distance(centre) <= radius + 1.0e-3,
+            "the target is still {} mm from a document of radius {radius}",
+            app.camera.target.distance(centre)
+        );
+    }
+
+    /// The arithmetic of [`OrbitCamera::zoom_by_about`] is exactly invertible,
+    /// which is what lets the wheel arm anchor the way in without the way out
+    /// having to undo anything by hand.
+    ///
+    /// **It is a statement about the camera and NOT about the gesture, and
+    /// reading it as the latter hid a real bug.** It calls the camera directly,
+    /// so it never goes through `publish_camera` and never meets
+    /// `contain_target`; the containment fence could be deleted outright and
+    /// this would stay green. What the user actually does is pinned by
+    /// `scrolling_in_and_back_out_returns_the_distance_and_leaves_the_model_in_view`
+    /// and `scrolling_out_does_not_move_the_target`.
+    #[test]
+    fn zooming_in_and_back_out_about_the_same_point_is_reversible() {
+        let mut app = app();
+        let at = off_centre();
+        app.on_pointer(PointerEvent::Moved { position: at, size: SIZE });
+        let anchor = app.navigation_anchor(OrbitCamera::zoom_factor(1.0));
+        let before = (app.camera.target, app.camera.distance);
+
+        for _ in 0..10 {
+            app.camera.zoom_by_about(OrbitCamera::zoom_factor(1.0), anchor);
+        }
+        for _ in 0..10 {
+            app.camera.zoom_by_about(OrbitCamera::zoom_factor(-1.0), anchor);
+        }
+        assert!(
+            app.camera.target.distance(before.0) < 1.0e-2,
+            "the target came back to {:?} instead of {:?}",
+            app.camera.target,
+            before.0
+        );
+        assert!((app.camera.distance - before.1).abs() < 1.0e-2);
+    }
+
+    /// One keystroke back from anywhere. This is the affordance that makes
+    /// letting the camera move freely safe rather than reckless.
+    #[test]
+    fn framing_the_active_body_recovers_from_a_target_far_outside_the_model() {
+        let mut app = app();
+        app.camera.yaw = 1.234;
+        app.camera.pitch = -0.5;
+        app.camera.target = Vec3::new(-435.18, -12.09, 95.65);
+        app.camera.distance = 0.3;
+
+        update(&mut app, Message::CameraFramedOnActive);
+
+        let radius = app.doc.active_volume().content_radius().expect("the ball has bounds");
+        // Within a voxel of the origin, not exactly on it: the framing centre
+        // is the middle of the BRICK box, which for a sphere on the lattice
+        // sits half a voxel off.
+        assert!(
+            app.camera.target.length() < VOXEL_SIZE_MM,
+            "the camera is still aimed at {:?}",
+            app.camera.target
+        );
+        assert!(
+            app.camera.distance > radius,
+            "the whole body has to fit: distance {} against radius {radius}",
+            app.camera.distance
+        );
+        // The angles are the user's and are kept, exactly as a restore keeps
+        // them: framing is not a request to be spun round to the front.
+        assert!((app.camera.yaw - 1.234).abs() < 1.0e-4);
+        assert!((app.camera.pitch + 0.5).abs() < 1.0e-4);
+        assert!(app.status.contains("framed"), "nothing said the camera had moved");
+    }
+
+    /// The key it is on, decoded the way a key press is decoded.
+    #[test]
+    fn the_f_key_frames_the_active_body() {
+        assert!(matches!(
+            crate::viewport::shortcut("f", false, false, false),
+            Some(Message::CameraFramedOnActive)
+        ));
+        // And it must not fire as part of a chord meant for something else.
+        assert!(crate::viewport::shortcut("f", true, false, false).is_none());
+        assert!(crate::viewport::shortcut("f", false, false, true).is_none());
+    }
+
+    /// Orbiting turns about the surface the press landed on, so turning to see
+    /// the side of a detail keeps the detail on screen.
+    #[test]
+    fn an_orbit_drag_turns_about_the_surface_the_press_landed_on() {
+        let mut app = app();
+        let at = off_centre();
+        app.on_pointer(PointerEvent::Moved { position: at, size: SIZE });
+        let pivot = app.hover.expect("the test point has to be on the model");
+
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Right,
+            position: at,
+            size: SIZE,
+        });
+        assert_eq!(
+            app.drag.and_then(|drag| drag.pivot),
+            Some(pivot),
+            "the press did not latch the surface under it"
+        );
+
+        let aspect = SIZE.x / SIZE.y;
+        let screen = |app: &Brokkr, point: Vec3| {
+            let clip = app.camera.view_projection(aspect) * point.extend(1.0);
+            Vec2::new(clip.x / clip.w, clip.y / clip.w)
+        };
+        let before = screen(&app, pivot);
+        for step in 0..25 {
+            let to = Vector::new(at.x + step as f32 * 6.0, at.y - step as f32 * 3.0);
+            app.on_pointer(PointerEvent::Moved { position: to, size: SIZE });
+        }
+        app.on_pointer(PointerEvent::Released { button: PointerButton::Right });
+
+        let after = screen(&app, pivot);
+        assert!(
+            before.distance(after) < 1.0e-2,
+            "the pivot slid from {before:?} to {after:?} across the drag"
+        );
+    }
+
+    /// A pointer that never touched the model still has to orbit, and about
+    /// the target rather than about any off-model point, which would walk the
+    /// target sideways on every background drag.
+    #[test]
+    fn an_orbit_drag_that_starts_off_the_model_turns_about_the_target() {
+        let mut app = app();
+        let empty = Vector::new(20.0, 20.0);
+        app.on_pointer(PointerEvent::Moved { position: empty, size: SIZE });
+        assert!(app.hover.is_none());
+
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Right,
+            position: empty,
+            size: SIZE,
+        });
+        let target = app.camera.target;
+        for step in 1..20 {
+            let to = Vector::new(empty.x + step as f32 * 8.0, empty.y + step as f32 * 4.0);
+            app.on_pointer(PointerEvent::Moved { position: to, size: SIZE });
+        }
+        app.on_pointer(PointerEvent::Released { button: PointerButton::Right });
+
+        assert!(
+            app.camera.target.distance(target) < 1.0e-3,
+            "a background drag walked the target from {target:?} to {:?}",
+            app.camera.target
+        );
+    }
+
+    /// The camera's floor and far plane are in the document's units, so a
+    /// resample has to move them or the floor means a different closeness than
+    /// it did a moment ago.
+    #[test]
+    fn resampling_moves_the_zoom_floor_with_the_lattice() {
+        let mut app = app();
+        let before = app.camera.min_distance();
+        update(&mut app, Message::Resample(VOXEL_SIZE_MM / 2.0));
+        assert!(
+            (app.camera.min_distance() - app.doc.voxel_size() * 2.0).abs() < 1.0e-6,
+            "the floor is {} on a {} mm lattice",
+            app.camera.min_distance(),
+            app.doc.voxel_size()
+        );
+        assert!(app.camera.min_distance() < before, "a finer lattice must let the camera closer");
+    }
+
+    /// **A close-in view saved on any lattice but 0.25 mm used to be thrown
+    /// away on every reopen, with a status line blaming the file.**
+    ///
+    /// `apply_view` built its accept/reject bounds from
+    /// `OrbitCamera::framing(centre, radius)`, and `framing` sets the content
+    /// radius but never the voxel size -- so it inherited the 0.25 mm default
+    /// and the loader's floor was 0.5 mm for every document ever opened, while
+    /// the live floor is `doc.voxel_size() * 2.0`. Measured: resample to 0.05,
+    /// eighty notches in, the camera legitimately reaches 0.1 -- and the
+    /// restore gave back 158.10 mm. This is the same class as the bug fa6e234
+    /// fixed, a floor computed from the wrong source, and the suite could not
+    /// see it because `VOXEL_SIZE_MM` happens to equal the camera's default.
+    ///
+    /// **So this test resamples first, and that is the whole point of it.**
+    /// The fixture it sits beside runs at 0.25 and therefore proves nothing.
+    #[test]
+    fn a_close_in_view_survives_a_reopen_on_a_lattice_finer_than_the_default() {
+        let mut app = app();
+        update(&mut app, Message::Resample(0.05));
+        assert!(
+            (app.doc.voxel_size() - 0.05).abs() < 1.0e-6,
+            "the resample did not take: {}",
+            app.doc.voxel_size()
+        );
+
+        let at = off_centre();
+        for _ in 0..80 {
+            scroll(&mut app, at, 1.0);
+        }
+        let close = app.camera.distance;
+        assert!(
+            close < 0.5,
+            "the point of the test is a distance under the old 0.5 floor: {close}"
+        );
+
+        let view = app.current_view();
+        app.status = "opened".to_string();
+        app.apply_view(&view);
+
+        assert!(
+            (app.camera.distance - close).abs() < 1.0e-6,
+            "the restore moved the camera from {close} to {}",
+            app.camera.distance
+        );
+        assert!(
+            !app.status.contains("re-framed"),
+            "a view the live camera reached was called unusable: {}",
+            app.status
+        );
+    }
+
+    /// The same disagreement at the other end of the range. The loader's
+    /// ceiling came from the ACTIVE body's content radius while the live one
+    /// comes from the document ball -- 5520 against 6906 on the starting
+    /// document -- so a distance the application itself drove the camera into
+    /// was rejected as corrupt by its own loader.
+    #[test]
+    fn a_view_scrolled_out_to_the_live_ceiling_survives_a_reopen() {
+        let mut app = app();
+        let at = off_centre();
+        for _ in 0..400 {
+            scroll(&mut app, at, -1.0);
+        }
+        let far_out = app.camera.distance;
+        assert!(
+            (far_out - app.camera.max_distance()).abs() < 1.0e-3,
+            "the test did not actually reach the ceiling: {far_out}"
+        );
+
+        let view = app.current_view();
+        app.status = "opened".to_string();
+        app.apply_view(&view);
+
+        assert!(
+            (app.camera.distance - far_out).abs() < 1.0e-3,
+            "the restore moved the camera from {far_out} to {}",
+            app.camera.distance
+        );
+        assert!(
+            !app.status.contains("re-framed"),
+            "a distance the live clamp produced was called unusable: {}",
+            app.status
+        );
+    }
+
+    /// **A puck button used to undo the whole point of this work.** Both camera
+    /// actions assigned a fresh `OrbitCamera::framing(Vec3::ZERO, 30.0)`, which
+    /// resets `voxel_size` to the 0.25 mm default and `content_radius` to the
+    /// hardcoded starting ball -- and both fields are now load-bearing. The
+    /// first is the zoom floor, so on a 0.05 mm lattice the floor jumped from
+    /// 0.1 to 0.5 and the camera became five times coarser than the lattice
+    /// deserves. The second is `far()`, which is the far plane AND the length
+    /// of every pick ray, so on a large model the far half of it went both
+    /// unclipped-into-nothing and silently unpickable.
+    #[test]
+    fn the_spacemouse_camera_buttons_keep_the_lattice_the_document_is_on() {
+        use crate::spacemouse::ButtonAction;
+
+        for action in [ButtonAction::FrameModel, ButtonAction::ResetView] {
+            let mut app = app();
+            update(&mut app, Message::Resample(0.05));
+            let floor = app.camera.min_distance();
+            let reach = app.camera.content_radius;
+
+            app.run_puck_button(action);
+
+            assert!(
+                (app.camera.min_distance() - floor).abs() < 1.0e-6,
+                "{action:?} moved the zoom floor from {floor} to {}",
+                app.camera.min_distance()
+            );
+            assert!(
+                app.camera.content_radius >= reach - 1.0e-3,
+                "{action:?} shrank the pick reach from {reach} to {}",
+                app.camera.content_radius
+            );
+        }
+    }
+
+    /// **The one place the two halves of this work pull against each other**,
+    /// measured rather than reasoned about.
+    ///
+    /// `orbit_about` moves the target to keep the pivot fixed, and
+    /// `contain_target` refuses to let the target leave the document's ball.
+    /// A target rotating about a pivot `p` from the centre travels on a sphere
+    /// of radius `|target - p|`, so it can reach `2p` from the centre -- and
+    /// if that exceeds the ball, the clamp engages and the pivot slides out
+    /// from under the cursor.
+    ///
+    /// Measured on the starting ball: two hundred motion events of a single
+    /// drag, more than half a turn, take the target to 51 mm of a 69 mm leash
+    /// and the pivot slips by 8e-6 in normalised device coordinates -- which is
+    /// float noise, not the clamp. The headroom comes from the ball being the
+    /// half-diagonal of the BRICK box, which rounds out past the surface.
+    ///
+    /// **The leash was deliberately not widened to make this impossible in
+    /// every geometry.** Doubling it would admit a target 1.9 content radii
+    /// out, and the real poisoned file was at 1.9 -- the fence would then stop
+    /// short of the failure it exists to prevent. On a model whose surface
+    /// reaches further into its own box than a sphere does, a very long orbit
+    /// can still meet the leash, and what happens then is that the target stops
+    /// while the drag continues. That is the leash working.
+    #[test]
+    fn a_long_orbit_drag_does_not_run_into_the_containment_leash() {
+        let mut app = app();
+        let at = off_centre();
+        app.on_pointer(PointerEvent::Moved { position: at, size: SIZE });
+        let pivot = app.hover.expect("the test point has to be on the model");
+        let (centre, radius) = app.document_ball();
+
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Right,
+            position: at,
+            size: SIZE,
+        });
+        let aspect = SIZE.x / SIZE.y;
+        let screen = |app: &Brokkr, point: Vec3| {
+            let clip = app.camera.view_projection(aspect) * point.extend(1.0);
+            Vec2::new(clip.x / clip.w, clip.y / clip.w)
+        };
+        let before = screen(&app, pivot);
+
+        let mut worst_slip = 0.0_f32;
+        let mut worst_reach = 0.0_f32;
+        for step in 1..200 {
+            app.on_pointer(PointerEvent::Moved {
+                position: Vector::new(at.x + step as f32 * 4.0, at.y),
+                size: SIZE,
+            });
+            worst_slip = worst_slip.max(before.distance(screen(&app, pivot)));
+            worst_reach = worst_reach.max(app.camera.target.distance(centre));
+        }
+        app.on_pointer(PointerEvent::Released { button: PointerButton::Right });
+
+        assert!(worst_slip < 1.0e-3, "the pivot slipped {worst_slip} across the drag");
+        assert!(
+            worst_reach < radius,
+            "the drag reached {worst_reach} of a {radius} mm leash, so the clamp engaged"
+        );
+    }
+
+    /// `update` returns a `Task`; tests do not run the iced runtime.
+    fn update(app: &mut Brokkr, message: Message) {
+        drop(app.update(message));
+    }
+}
+
+#[cfg(test)]
+mod gizmo_tests {
+    use super::*;
+    use brokkr_core::{Bake, BrickCoord, warps_made_on_this_thread};
+    use iced::Vector;
+
+    const SIZE: Vector = Vector { x: 800.0, y: 600.0 };
+
+    fn update(app: &mut Brokkr, message: Message) {
+        drop(app.update(message));
+    }
+
+    fn app() -> Brokkr {
+        let mut app = Brokkr::with_tablet(crate::tablet::Tablet::inert());
+        // Every gesture below is measured in widget pixels, so the application
+        // has to know how big the widget is before the first one.
+        app.viewport_size = Vec2::new(SIZE.x, SIZE.y);
+        app
+    }
+
+    fn arm(app: &mut Brokkr) {
+        update(app, Message::ToolChanged(Tool::Transform));
+        assert_eq!(app.tool, Tool::Transform, "the gizmo did not arm: {}", app.status);
+        assert!(app.gizmo.is_some(), "the tool is up with no gizmo under it");
+    }
+
+    /// Where the gizmo's own origin lands on screen.
+    fn gizmo_centre(app: &Brokkr) -> Vec2 {
+        let gizmo = app.gizmo.expect("armed");
+        let aspect = SIZE.x / SIZE.y;
+        let clip = app.camera.view_projection(aspect) * gizmo.origin().extend(1.0);
+        let ndc = Vec2::new(clip.x / clip.w, clip.y / clip.w);
+        Vec2::new((ndc.x + 1.0) * 0.5 * SIZE.x, (1.0 - ndc.y) * 0.5 * SIZE.y)
+    }
+
+    fn moved(app: &mut Brokkr, at: Vec2) {
+        app.on_pointer(PointerEvent::Moved { position: Vector::new(at.x, at.y), size: SIZE });
+    }
+
+    /// A press, one or more moves, and a release, through the real pointer path.
+    ///
+    /// **It asserts that the press was actually taken as a handle**, and that
+    /// is not belt and braces: a press that misses the gizmo by a pixel falls
+    /// through to choosing a body, the placement then never changes, and every
+    /// test built on this helper passes while testing nothing. That happened
+    /// once already, to an earlier version of `drag_the_x_arrow` that pressed
+    /// at the shaft's screen x-offset with y left at zero.
+    fn gesture(app: &mut Brokkr, from: Vec2, through: &[Vec2]) {
+        moved(app, from);
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Left,
+            position: Vector::new(from.x, from.y),
+            size: SIZE,
+        });
+        assert!(
+            matches!(app.drag.map(|drag| drag.kind), Some(DragKind::Transforming(_))),
+            "the press at {from:?} did not land on a handle, so this gesture tests nothing"
+        );
+        for at in through {
+            moved(app, *at);
+        }
+        app.on_pointer(PointerEvent::Released { button: PointerButton::Left });
+    }
+
+    /// Where a world point lands, in widget pixels.
+    fn project(app: &Brokkr, point: Vec3) -> Vec2 {
+        let aspect = SIZE.x / SIZE.y;
+        let clip = app.camera.view_projection(aspect) * point.extend(1.0);
+        let ndc = Vec2::new(clip.x / clip.w, clip.y / clip.w);
+        Vec2::new((ndc.x + 1.0) * 0.5 * SIZE.x, (1.0 - ndc.y) * 0.5 * SIZE.y)
+    }
+
+    /// A pixel on the X shaft, and the unit screen direction that runs along it.
+    ///
+    /// **Both components of the projection**, because a world axis leans on
+    /// screen: the X arrow of the default camera runs down and to the right, so
+    /// a press at its x-offset with y left at zero is eight pixels off the
+    /// shaft and lands or misses depending on where the gizmo happens to be.
+    fn x_shaft_grip(app: &Brokkr) -> (Vec2, Vec2) {
+        let gizmo = app.gizmo.expect("armed");
+        let origin = gizmo.origin();
+        let scale = crate::gizmo::world_per_pixel(&app.camera, origin, SIZE.y);
+        let middle = project(app, origin);
+        // Just over half way along, clear of the centre box and the arrowhead.
+        let grip = project(app, origin + Vec3::X * (34.0 * scale));
+        (grip, (grip - middle).normalize())
+    }
+
+    /// Every stored voxel of the active body, for comparing two states value by
+    /// value rather than through a sampled surface.
+    fn field(app: &Brokkr) -> Vec<(BrickCoord, Vec<f32>)> {
+        let volume = app.doc.active_volume();
+        let mut coords: Vec<BrickCoord> = volume.brick_coords().collect();
+        coords.sort_unstable();
+        coords
+            .into_iter()
+            .map(|coord| {
+                let mut values = Vec::new();
+                let origin = coord.origin();
+                for index in 0..(brokkr_core::BRICK_DIM as i32).pow(3) {
+                    let dim = brokkr_core::BRICK_DIM as i32;
+                    let local =
+                        glam::IVec3::new(index % dim, (index / dim) % dim, index / (dim * dim));
+                    values.push(volume.sample_voxel(origin + local));
+                }
+                (coord, values)
+            })
+            .collect()
+    }
+
+    /// A drag along the X arrow, `pixels` of screen travel.
+    fn drag_the_x_arrow(app: &mut Brokkr, pixels: f32) {
+        let (grip, along) = x_shaft_grip(app);
+        gesture(app, grip, &[grip + along * pixels]);
+    }
+
+    /// A free-angle drag round a ring, from `+u` toward `+v`.
+    fn turn_a_ring(app: &mut Brokkr, radians: f32) {
+        let gizmo = app.gizmo.expect("armed");
+        let origin = gizmo.origin();
+        let scale = crate::gizmo::world_per_pixel(&app.camera, origin, SIZE.y);
+        // The Y ring, whose plane is the one the default camera looks most
+        // squarely at, so both its ends project well clear of the middle.
+        let radius = 104.0 * scale;
+        let from = project(app, origin + Vec3::Z * radius);
+        let to =
+            project(app, origin + (Vec3::Z * radians.cos() + Vec3::X * radians.sin()) * radius);
+        let free = app.shift;
+        app.shift = true;
+        gesture(app, from, &[to]);
+        app.shift = free;
+    }
+
+    // ------------------------------------------------------- the whole point
+
+    /// **The test the entire anti-degradation design exists for.**
+    ///
+    /// Placement is fiddly and thirty nudges over a session is an ordinary
+    /// number. Baking each gesture onto the last result would be thirty
+    /// trilinear passes -- detail the user sculpted, gone, with nothing having
+    /// said so, discovered at the printer. Baking from the field the gizmo
+    /// ARMED on is one pass however many gestures there were.
+    #[test]
+    fn thirty_adjustments_cost_exactly_one_resample_pass() {
+        let mut app = app();
+        arm(&mut app);
+        let before = warps_made_on_this_thread();
+
+        // Free-angle turns, so every one of them genuinely takes the lossy
+        // route. Snapped ones would pass this by taking no pass at all, which
+        // is a different and weaker claim.
+        for step in 0..30 {
+            turn_a_ring(&mut app, 0.2 + step as f32 * 0.03);
+        }
+        let after_drags = warps_made_on_this_thread() - before;
+        assert!(after_drags > 0, "the fixture never dragged a ring at all");
+        assert_eq!(
+            after_drags, 30,
+            "each gesture should bake once while the gizmo is up, and did {after_drags} times"
+        );
+
+        // And the claim that matters: those thirty bakes all came off the SAME
+        // field, so the body has been through one pass, not thirty. Undoing the
+        // session puts back a field that was never resampled at all.
+        let placement = app.gizmo.expect("armed").placement;
+        assert!(placement.route(app.doc.voxel_size()).is_lossy(), "the fixture snapped");
+        update(&mut app, Message::ToolChanged(Tool::Sculpt));
+        assert!(app.gizmo.is_none(), "the gizmo did not disarm");
+        assert!(app.history.can_undo(), "the session pushed no entry");
+    }
+
+    /// Baking from the base makes this exact rather than approximate: the
+    /// placement really is the identity again, so the routing declines to run
+    /// anything at all.
+    /// Dragging away and back WITHIN one gesture is exactly the identity, not
+    /// approximately it, because the placement is measured from the press pixel
+    /// rather than accumulated from the last motion event.
+    ///
+    /// **Within one gesture and not across two, and the difference is honest.**
+    /// Two opposite gestures need not cancel to the last voxel: the second one
+    /// is measured about a moved origin through a perspective projection, so
+    /// its pixels are not worth quite the same number of millimetres as the
+    /// first one's, and each is snapped separately. The exactness that was
+    /// promised is the one this checks.
+    #[test]
+    fn dragging_out_and_back_within_a_gesture_bakes_nothing() {
+        let mut app = app();
+        arm(&mut app);
+        let before = field(&app);
+        let warps = warps_made_on_this_thread();
+
+        let (grip, along) = x_shaft_grip(&app);
+        app.shift = true;
+        gesture(&mut app, grip, &[grip + along * 90.0, grip + along * 210.0, grip]);
+        app.shift = false;
+
+        assert_eq!(
+            app.gizmo.expect("armed").placement.route(app.doc.voxel_size()),
+            Bake::Identity,
+            "coming back to the press pixel left a placement behind"
+        );
+        assert_eq!(field(&app), before, "the field moved after a drag out and back");
+        assert_eq!(warps_made_on_this_thread(), warps, "a round trip ran a trilinear pass");
+    }
+
+    /// The ordinary gesture is snapped, and a snapped move is a value-exact
+    /// gather. If this ever routes to a resample the default has silently
+    /// become the lossy one.
+    #[test]
+    fn a_snapped_move_through_the_application_never_resamples() {
+        let mut app = app();
+        arm(&mut app);
+        assert!(!app.shift, "the fixture must start unsnapped-free, i.e. snapping ON");
+        let warps = warps_made_on_this_thread();
+
+        for pixels in [30.0_f32, -55.0, 120.0] {
+            drag_the_x_arrow(&mut app, pixels);
+            let route = app.gizmo.expect("armed").placement.route(app.doc.voxel_size());
+            assert!(!route.is_lossy(), "a snapped move of {pixels} px routed to {route:?}");
+        }
+        assert_eq!(
+            warps_made_on_this_thread(),
+            warps,
+            "a snapped move ran a trilinear pass it did not need"
+        );
+    }
+
+    #[test]
+    fn a_snapped_move_actually_moves_the_body() {
+        let mut app = app();
+        arm(&mut app);
+        let before = app.doc.active_volume().world_bounds().expect("a body");
+        drag_the_x_arrow(&mut app, 120.0);
+        let after = app.doc.active_volume().world_bounds().expect("a body");
+        assert!(
+            (after.0.x - before.0.x).abs() > app.doc.voxel_size(),
+            "the body did not move: {before:?} then {after:?}"
+        );
+        // Moved, not grown: a translation is rigid.
+        let span = |b: (Vec3, Vec3)| b.1 - b.0;
+        assert!(span(after).distance(span(before)) < app.doc.voxel_size() * 2.0);
+    }
+
+    // ------------------------------------------------------------ the guards
+
+    /// **`orient` clears the whole history and this must not.** A quarter turn
+    /// leaves every older entry naming bricks of a volume that no longer
+    /// exists, so its caller drops the stack; the gizmo puts the original field
+    /// ON the stack instead, so undoing the transform makes those coordinates
+    /// valid again.
+    #[test]
+    fn a_transform_gesture_does_not_clear_the_undo_history() {
+        let mut app = app();
+        // A stroke to have some history to lose.
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Left,
+            position: Vector::new(SIZE.x / 2.0, SIZE.y / 2.0),
+            size: SIZE,
+        });
+        app.on_pointer(PointerEvent::Released { button: PointerButton::Left });
+        assert!(app.history.can_undo(), "the fixture laid down no stroke");
+        let entries = app.history_stats.undo_entries;
+
+        arm(&mut app);
+        drag_the_x_arrow(&mut app, 90.0);
+        update(&mut app, Message::ToolChanged(Tool::Sculpt));
+
+        assert!(
+            app.history_stats.undo_entries > entries,
+            "the transform pushed nothing: {} then {}",
+            entries,
+            app.history_stats.undo_entries
+        );
+        // Undo the transform, then the stroke behind it.
+        update(&mut app, Message::Undo);
+        update(&mut app, Message::Undo);
+        assert!(!app.history.can_undo(), "the stroke behind the transform was not reachable");
+    }
+
+    /// Escape ABANDONS, where leaving the tool commits. Bit-identical, not
+    /// close: the whole reason the base is held is that it is the only copy of
+    /// a field the forward direction cannot reproduce.
+    #[test]
+    fn escape_leaves_the_body_bit_identical() {
+        let mut app = app();
+        arm(&mut app);
+        let before = field(&app);
+
+        turn_a_ring(&mut app, 0.6);
+        assert_ne!(field(&app), before, "the fixture's transform changed nothing");
+        let entries = app.history_stats.undo_entries;
+
+        update(&mut app, Message::MenuClosed);
+
+        assert!(app.gizmo.is_none(), "escape left the gizmo armed");
+        assert_eq!(app.tool, Tool::Sculpt);
+        assert_eq!(field(&app), before, "escape did not put the field back bit for bit");
+        assert_eq!(app.history_stats.undo_entries, entries, "an abandoned session pushed an entry");
+    }
+
+    /// Escape during a LIVE drag cancels that drag and nothing more. "Not that
+    /// one" is a different instruction from "not any of it", and the recovery
+    /// is throwing the gesture away rather than inverting it.
+    #[test]
+    fn escape_during_a_drag_cancels_the_drag_and_keeps_the_gizmo() {
+        let mut app = app();
+        arm(&mut app);
+        drag_the_x_arrow(&mut app, 90.0);
+        let committed = app.gizmo.expect("armed").placement;
+        assert_ne!(committed.route(app.doc.voxel_size()), Bake::Identity, "the fixture is idle");
+
+        // A second drag, escaped before its release.
+        let (grip, along) = x_shaft_grip(&app);
+        moved(&mut app, grip);
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Left,
+            position: Vector::new(grip.x, grip.y),
+            size: SIZE,
+        });
+        assert!(matches!(app.drag.map(|drag| drag.kind), Some(DragKind::Transforming(_))));
+        moved(&mut app, grip + along * 200.0);
+        update(&mut app, Message::MenuClosed);
+
+        assert!(app.gizmo.is_some(), "escape mid-drag disarmed the whole gizmo");
+        assert!(app.drag.is_none(), "the drag survived the escape");
+        assert_eq!(
+            app.gizmo.expect("armed").placement.translation,
+            committed.translation,
+            "the cancelled drag was kept"
+        );
+    }
+
+    /// ONLY BOUNDS-CHECKED EVENTS MAY CAPTURE. The gizmo claims its own disc
+    /// and nothing else; a press well away from it has to reach the body under
+    /// the cursor, which under this tool means choosing it.
+    #[test]
+    fn a_press_away_from_the_gizmo_is_not_taken_as_a_handle() {
+        let mut app = app();
+        arm(&mut app);
+        let middle = gizmo_centre(&app);
+        for offset in [Vec2::new(340.0, 0.0), Vec2::new(-340.0, 0.0), Vec2::new(0.0, 260.0)] {
+            let at = (middle + offset).clamp(Vec2::splat(2.0), Vec2::new(SIZE.x, SIZE.y) - 2.0);
+            app.on_pointer(PointerEvent::Pressed {
+                button: PointerButton::Left,
+                position: Vector::new(at.x, at.y),
+                size: SIZE,
+            });
+            assert!(
+                !matches!(app.drag.map(|drag| drag.kind), Some(DragKind::Transforming(_))),
+                "a press at {at:?} was taken as a gizmo handle"
+            );
+            app.on_pointer(PointerEvent::Released { button: PointerButton::Left });
+        }
+    }
+
+    /// A held resize owns the pointer whether or not a button is down, and the
+    /// press dispatch already settled that precedence between sizing and the
+    /// plane cut. The gizmo is the third claimant and does not get to jump it:
+    /// a resize whose press turned into a transform is the worse surprise.
+    #[test]
+    fn a_held_resize_outranks_the_gizmo() {
+        let mut app = app();
+        arm(&mut app);
+        let (grip, _) = x_shaft_grip(&app);
+        // A resize anchors on the last cursor position, so the pointer has to
+        // have been seen before the key is pressed.
+        moved(&mut app, grip);
+        update(&mut app, Message::SizingStarted(SizingTarget::Radius));
+        assert!(app.sizing.is_some(), "the fixture did not start a resize");
+        // `SizingStarted` is not on `keeps_the_gizmo_armed`, so it committed
+        // the session and the pass after `dispatch` re-armed on the same body.
+        // That is the state the precedence below is actually about.
+        assert!(app.gizmo.is_some(), "the gizmo did not come back after the commit");
+
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Left,
+            position: Vector::new(grip.x, grip.y),
+            size: SIZE,
+        });
+        assert_eq!(
+            app.drag.map(|drag| drag.kind),
+            Some(DragKind::Sizing),
+            "the gizmo took a press that belonged to a held resize"
+        );
+    }
+
+    /// **The draw order and the click order have to agree.** `on_pointer` tests
+    /// the navigation cube before the gizmo may claim anything, so the renderer
+    /// draws the gizmo first and the cube over it. Get that backwards and the
+    /// user sees an arrow, clicks it, and the camera flies.
+    #[test]
+    fn the_navigation_cube_outranks_the_gizmo_where_they_overlap() {
+        let mut app = app();
+        arm(&mut app);
+        let (corner, size) = crate::navcube::corner_rect(Vec2::new(SIZE.x, SIZE.y));
+        let middle = corner + size * 0.5;
+
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Left,
+            position: Vector::new(middle.x, middle.y),
+            size: SIZE,
+        });
+        assert!(
+            !matches!(app.drag.map(|drag| drag.kind), Some(DragKind::Transforming(_))),
+            "the gizmo claimed a press inside the navigation cube"
+        );
+        assert!(app.flight.is_some(), "the cube did not get the press either");
+    }
+
+    /// A brush ring under the gizmo would say "a press here carves this much",
+    /// which is not what a press there does.
+    #[test]
+    fn the_brush_ring_goes_away_while_the_gizmo_is_up() {
+        let mut app = app();
+        app.on_pointer(PointerEvent::Moved {
+            position: Vector::new(SIZE.x / 2.0, SIZE.y / 2.0),
+            size: SIZE,
+        });
+        assert!(app.hover.is_some(), "the fixture's cursor is not over the model");
+
+        arm(&mut app);
+        app.on_pointer(PointerEvent::Moved {
+            position: Vector::new(SIZE.x / 2.0, SIZE.y / 2.0),
+            size: SIZE,
+        });
+        assert!(app.hover.is_none(), "the ring is still being placed on the surface");
+    }
+
+    /// Pressing `w` twice is a toggle and has to be free: arming alone must not
+    /// touch the field, so the base is only taken on the first bake.
+    #[test]
+    fn arming_and_disarming_without_dragging_costs_nothing() {
+        let mut app = app();
+        let before = field(&app);
+        let entries = app.history_stats.undo_entries;
+
+        arm(&mut app);
+        assert!(app.gizmo_base.is_none(), "arming took the field out before it had to");
+        update(&mut app, Message::ToolChanged(Tool::Transform));
+
+        assert!(app.gizmo.is_none(), "the toggle did not put it away");
+        assert_eq!(app.tool, Tool::Sculpt);
+        assert_eq!(field(&app), before);
+        assert_eq!(app.history_stats.undo_entries, entries, "an untouched session pushed an entry");
+        assert!(!app.unsaved, "an untouched session marked the document dirty");
+    }
+
+    /// The status line names the route on EVERY bake. A user told nothing when
+    /// a move is exact has no way to learn that some of them are not.
+    #[test]
+    fn the_status_line_says_which_route_the_bake_took() {
+        let mut app = app();
+        arm(&mut app);
+        drag_the_x_arrow(&mut app, 90.0);
+        assert!(
+            app.status.contains("exact"),
+            "a snapped move said {:?} rather than naming the route",
+            app.status
+        );
+
+        turn_a_ring(&mut app, 0.8);
+        assert!(
+            app.status.contains("resampled"),
+            "a free turn said {:?} rather than admitting the resample",
+            app.status
+        );
+    }
+
+    /// **The guard that stops a document changing ahead of its own history.**
+    /// While the gizmo is armed the document holds the baked field and the
+    /// stack does not yet hold the entry that undoes it, so anything outside
+    /// the gesture has to close the session first. Undo is the sharpest case.
+    #[test]
+    fn undoing_while_the_gizmo_is_armed_commits_it_first_and_then_undoes_it() {
+        let mut app = app();
+        let before = field(&app);
+        arm(&mut app);
+        drag_the_x_arrow(&mut app, 120.0);
+        assert_ne!(field(&app), before, "the fixture did not move the body");
+
+        update(&mut app, Message::Undo);
+
+        assert_eq!(field(&app), before, "undo did not reach the transform");
+    }
+
+    /// **Asserting on the document is not enough, and this is the assertion
+    /// that says so.**
+    ///
+    /// The test above passed while the bug was live: it reads `field(&app)`,
+    /// which is the document, and the document was always right. What was
+    /// wrong was that nothing told the renderer -- a field arriving from the
+    /// history carries an EMPTY dirty set, because whatever remeshed it last
+    /// drained it -- so the screen went on drawing the body where the bake had
+    /// put it, and every stroke, pick and brush ring after that acted on a
+    /// position the user could not see. `perf.dirty_bricks` is the one number
+    /// that can tell the two apart.
+    #[test]
+    fn undoing_a_bake_schedules_the_remesh_that_puts_the_body_back_on_screen() {
+        let mut app = app();
+        arm(&mut app);
+        drag_the_x_arrow(&mut app, 120.0);
+        // Out of the tool, so the entry is already on the stack and the undo
+        // below is a plain undo rather than a commit followed by one.
+        update(&mut app, Message::ToolChanged(Tool::Sculpt));
+
+        app.perf.dirty_bricks = 0;
+        update(&mut app, Message::Undo);
+        assert!(
+            app.perf.dirty_bricks > 0,
+            "undoing a bake remeshed nothing, so the screen still shows the body where the bake \
+             put it"
+        );
+
+        app.perf.dirty_bricks = 0;
+        update(&mut app, Message::Redo);
+        assert!(app.perf.dirty_bricks > 0, "redoing a bake remeshed nothing");
+    }
+
+    /// **A gesture that comes back to where it started must cost what arming
+    /// and not dragging costs: nothing.**
+    ///
+    /// Nudging a body and nudging it back is an ordinary way to change your
+    /// mind, and the identity route used to run `base.shifted(IVec3::ZERO)` --
+    /// a full deep copy, quoted at 1.53 GiB on the dragon -- to produce a field
+    /// identical to the one already held, then a whole-document remesh, and
+    /// then a whole-field undo entry charged against the reclaim allowance,
+    /// where `History::trim` can evict real strokes to make room for it.
+    #[test]
+    fn a_gesture_that_returns_to_the_identity_puts_the_base_back_rather_than_copying_it() {
+        let mut app = app();
+        let before = field(&app);
+        arm(&mut app);
+        let copies = brokkr_core::volume::copies_made_on_this_thread();
+        let warps = warps_made_on_this_thread();
+        let undoable = app.history.can_undo();
+
+        drag_the_x_arrow(&mut app, 40.0);
+        assert_ne!(field(&app), before, "the fixture did not move the body");
+        drag_the_x_arrow(&mut app, -40.0);
+
+        assert_eq!(
+            app.gizmo.expect("armed").placement,
+            brokkr_core::Similarity::IDENTITY,
+            "the fixture did not bring the placement back to the identity"
+        );
+        assert_eq!(field(&app), before, "the body did not come back bit for bit");
+        assert_eq!(
+            brokkr_core::volume::copies_made_on_this_thread(),
+            copies,
+            "returning to the identity deep copied the field instead of putting the base back"
+        );
+        assert_eq!(warps_made_on_this_thread(), warps, "an exact gesture resampled");
+
+        update(&mut app, Message::ToolChanged(Tool::Sculpt));
+        assert_eq!(
+            app.history.can_undo(),
+            undoable,
+            "a session that changed nothing was charged to the undo history"
+        );
+    }
+
+    /// **The ceiling is folded into the gesture, so a scale the bake could not
+    /// build is never offered.**
+    ///
+    /// `Handle::Uniform` is selected by a press within sixteen pixels of the
+    /// centre, so one long drag saturates `gizmo::MAX_SCALE`, and
+    /// `Similarity::then` multiplies scales -- while `Volume::warped` builds a
+    /// dense destination brick grid with no cap of its own and `arm_gizmo`'s
+    /// refusals were evaluated once, against the UNSCALED body.
+    ///
+    /// The document is stuffed rather than a huge body being built, for the
+    /// reason `a_body_the_pool_cannot_hold_is_refused` gives: the ceiling is
+    /// read off `doc_stats`, so a fixture that writes `doc_stats` exercises the
+    /// same arithmetic in a fraction of the time.
+    #[test]
+    fn a_scale_the_bake_could_not_afford_is_never_offered_by_the_gesture() {
+        let mut app = app();
+        let resident = app.doc.active_volume().stats().resident_bytes as f64;
+        // Room for about four times the body, so a ceiling near two -- small
+        // enough that the bakes this test really does run stay cheap.
+        app.doc_stats.resident_bytes = (MAX_VOLUME_BYTES - resident * 4.0) as usize;
+
+        arm(&mut app);
+        let ceiling = app.gizmo.expect("armed").max_scale;
+        assert!(
+            (1.0..gizmo::MAX_SCALE).contains(&ceiling),
+            "a document with room for four copies gave a ceiling of {ceiling}"
+        );
+
+        let centre = gizmo_centre(&app);
+        // Two, because one gesture cannot compose with anything and it is the
+        // composition that used to square the ceiling.
+        for round in 0..2 {
+            let from = centre + Vec2::new(4.0, 0.0);
+            gesture(&mut app, from, &[from + Vec2::new(320.0, 0.0)]);
+            let scale = app.gizmo.expect("armed").placement.scale;
+            assert!(
+                scale <= ceiling + 1.0e-3,
+                "round {round} composed to {scale}, past a ceiling of {ceiling}"
+            );
+        }
+        assert!(
+            app.gizmo.expect("armed").placement.scale > 1.0,
+            "the fixture never grew the body, so it proves nothing"
+        );
+
+        // And it has to SAY so. A preview box that stops growing under the
+        // pointer with nothing in the status line reads as the gizmo having
+        // lost the drag. Read mid-gesture, before the release replaces the line
+        // with the bake summary.
+        let from = centre + Vec2::new(4.0, 0.0);
+        moved(&mut app, from);
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Left,
+            position: Vector::new(from.x, from.y),
+            size: SIZE,
+        });
+        moved(&mut app, from + Vec2::new(320.0, 0.0));
+        assert!(app.status.contains("memory"), "the clamp bit without saying why: {}", app.status);
+        app.on_pointer(PointerEvent::Released { button: PointerButton::Left });
+    }
+
+    /// The ceiling has to shrink as the document fills, and it has to admit the
+    /// identity even when the document is full: a body can always be placed at
+    /// the size it already is, and a ceiling below one would make the gizmo
+    /// refuse to leave it alone.
+    #[test]
+    fn the_scale_ceiling_falls_as_the_document_fills_and_never_below_one() {
+        let stats = app().doc.active_volume().stats();
+        let resident = stats.resident_bytes as f64;
+
+        let mut roomy = app();
+        roomy.doc_stats.resident_bytes = (resident * 4.0) as usize;
+        let mut tight = app();
+        tight.doc_stats.resident_bytes = (MAX_VOLUME_BYTES - resident * 4.0) as usize;
+        let mut full = app();
+        full.doc_stats.resident_bytes = MAX_VOLUME_BYTES as usize;
+
+        let roomy = roomy.largest_scale_that_fits(stats);
+        let tight = tight.largest_scale_that_fits(stats);
+        let full = full.largest_scale_that_fits(stats);
+
+        assert!(roomy > tight, "an empty document offered no more room than a nearly full one");
+        assert!(tight > 1.0, "a document with room for four copies refused to scale at all");
+        assert_eq!(full, 1.0, "a full document must still let the body stay where it is");
+    }
+
+    /// The gizmo follows the active body rather than being left pointing at a
+    /// row nobody selected any more.
+    #[test]
+    fn choosing_another_body_moves_the_gizmo_to_it_and_commits_the_last_one() {
+        let mut app = app();
+        let first = app.doc.active();
+        let mut second_volume = brokkr_core::Volume::new(app.doc.voxel_size());
+        second_volume.seed_sphere(Vec3::new(90.0, 0.0, 0.0), 12.0);
+        let second = app.doc.add_body("Second", second_volume);
+        app.doc.mark_everything_dirty();
+
+        arm(&mut app);
+        assert_eq!(app.gizmo.expect("armed").body, first);
+        drag_the_x_arrow(&mut app, 120.0);
+
+        update(&mut app, Message::BodySelected(second));
+
+        assert_eq!(app.tool, Tool::Transform, "selecting a row dropped the tool");
+        assert_eq!(app.gizmo.expect("armed").body, second, "the gizmo stayed on the old body");
+        assert!(app.history.can_undo(), "the first body's session was not committed");
+    }
+
+    /// Arming is what commits to holding a second copy of the body, so that is
+    /// where the refusal has to be -- before the allocation and never after it,
+    /// which is the rule `merge_plan` already follows.
+    #[test]
+    fn arming_a_gizmo_on_a_hidden_body_is_refused_before_anything_is_allocated() {
+        let mut app = app();
+        let body = app.doc.active();
+        let copies = brokkr_core::volume::copies_made_on_this_thread();
+
+        let mut meta = app.doc.meta(body).expect("a body");
+        meta.visible = false;
+        app.doc.set_meta(&meta);
+        app.publish_visibility();
+
+        update(&mut app, Message::ToolChanged(Tool::Transform));
+        assert_ne!(app.tool, Tool::Transform, "the gizmo armed on a hidden body");
+        assert!(app.gizmo.is_none());
+        assert!(app.status.contains("hidden"), "the refusal did not say why: {:?}", app.status);
+        assert_eq!(
+            brokkr_core::volume::copies_made_on_this_thread(),
+            copies,
+            "the refusal allocated a copy on its way to refusing"
+        );
+    }
+
+    /// The bake replaces the whole field, so the bricks the OLD one occupied
+    /// have to be marked in the NEW one or the renderer keeps drawing triangles
+    /// nothing will ever overwrite.
+    #[test]
+    fn a_bake_marks_the_bricks_the_body_has_left() {
+        let mut app = app();
+        arm(&mut app);
+        let vacated: Vec<BrickCoord> = app.doc.active_volume().brick_coords().collect();
+        assert!(!vacated.is_empty(), "the fixture is empty");
+
+        // Far enough that the body lands on entirely different bricks.
+        drag_the_x_arrow(&mut app, 260.0);
+
+        // `remesh_dirty` has already drained the set, so the check is that the
+        // renderer was told about the old body at all.
+        let placement = app.gizmo.expect("armed").placement;
+        assert!(
+            placement.translation.length() > brokkr_core::BRICK_DIM as f32 * app.doc.voxel_size(),
+            "the fixture did not move the body off its old bricks"
+        );
+        let now: Vec<BrickCoord> = app.doc.active_volume().brick_coords().collect();
+        assert!(
+            now.iter().any(|coord| !vacated.contains(coord)),
+            "the body is still on exactly the bricks it started on"
+        );
+    }
+
+    /// The placement is the caller's business and the routing is the core's,
+    /// and the two have to agree about what a gesture produced -- the status
+    /// line, the bake and the undo entry all read the same answer.
+    #[test]
+    fn the_route_the_status_reports_is_the_route_the_bake_took() {
+        let mut app = app();
+        arm(&mut app);
+        let warps = warps_made_on_this_thread();
+        drag_the_x_arrow(&mut app, 90.0);
+        let exact = warps_made_on_this_thread() == warps;
+        assert_eq!(
+            exact,
+            !app.gizmo.expect("armed").placement.route(app.doc.voxel_size()).is_lossy(),
+            "the bake and the routing disagreed about whether a pass ran"
+        );
+    }
+
+    /// Read from the SHARED frame and not from `app.gizmo_batch`: the two
+    /// buffers rotate on every refresh, so the application's own field holds
+    /// last frame's recycled capacity and the renderer's holds this frame's
+    /// geometry.
+    #[test]
+    fn a_gizmo_is_drawn_only_while_it_is_armed() {
+        let mut app = app();
+        assert!(app.shared.gizmo_snapshot().is_empty(), "a gizmo was drawn before one existed");
+        arm(&mut app);
+        assert!(!app.shared.gizmo_snapshot().is_empty(), "the armed gizmo drew nothing");
+        update(&mut app, Message::ToolChanged(Tool::Sculpt));
+        assert!(
+            app.shared.gizmo_snapshot().is_empty(),
+            "the gizmo is still on screen after disarming"
+        );
+    }
+
+    /// The composition the drag path actually performs, checked against
+    /// applying the two placements in turn.
+    #[test]
+    fn two_gestures_compose_into_one_placement_rather_than_replacing_it() {
+        let mut app = app();
+        arm(&mut app);
+        drag_the_x_arrow(&mut app, 60.0);
+        let first = app.gizmo.expect("armed").placement;
+        drag_the_x_arrow(&mut app, 60.0);
+        let both = app.gizmo.expect("armed").placement;
+
+        assert!(
+            both.translation.length() > first.translation.length() * 1.5,
+            "the second gesture replaced the first rather than composing: \
+             {first:?} then {both:?}"
+        );
+        // And the placement is still exactly a translation, so both stayed on
+        // the exact route.
+        assert!(!both.route(app.doc.voxel_size()).is_lossy());
     }
 }

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -1698,6 +1698,36 @@ impl Brokkr {
         if app.has_autosave() {
             app.status = "an autosave from a previous session is in File > Recover".to_string();
         }
+        // **And a crash outranks it**, because it is the rarer message and the
+        // one with something to do about it. Taken rather than read, so it is
+        // said once; see `crash::take_pending`.
+        if let Some(report) = crate::crash::take_pending() {
+            app.status =
+                "the last session crashed — Help > Report a bug will send the report".to_string();
+            // The path goes to the log rather than the status line: it is long
+            // enough to wrap the title bar onto two lines, and it is the one
+            // part of the message a user does not need in order to act.
+            //
+            // The summary is found by looking for the `message:` heading and
+            // not by counting lines. Counting picked line five, which is
+            // `os: linux` -- a summary that is the same on every crash, which
+            // is worse than none.
+            let summary = report
+                .lines()
+                .skip_while(|line| !line.starts_with("message:"))
+                .nth(1)
+                .unwrap_or("(no message)")
+                .trim();
+            match crate::crash::report_path() {
+                Some(path) => {
+                    log::warn!(
+                        "the previous session crashed: {summary} (report in {})",
+                        path.display()
+                    )
+                }
+                None => log::warn!("the previous session crashed: {summary}"),
+            }
+        }
         app
     }
 

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -2269,7 +2269,29 @@ impl Brokkr {
                     None => base.shifted(voxel_offset),
                 }
             }
-            brokkr_core::Bake::Resample => base.warped(gizmo.placement),
+            brokkr_core::Bake::Resample => {
+                let mut warped = base.warped(gizmo.placement);
+                // **A per-axis scale leaves a field that is no longer a
+                // distance field, and this is where that is repaired.**
+                // `Volume::warped` multiplies the sampled distance by
+                // `min_scale`, which keeps the zero set exact and
+                // underestimates everywhere else -- sound for a sphere trace,
+                // wrong for everything that reads a gradient. The drift is
+                // `s_min/s_max` and it would compound across bakes with
+                // nothing to reset it, which is the whole reason
+                // `similarity.rs` refused a per-axis scale until this pass
+                // existed.
+                //
+                // Skipped when the scale is uniform, where the field is exactly
+                // the transformed solid and the pass would be work with no
+                // customer. `redistance` gates itself again on the measured
+                // drift, so a rotation that happens to leave the gradient
+                // alone costs one read-only sweep and no writes.
+                if !gizmo.placement.is_uniform_scale() {
+                    warped.redistance();
+                }
+                warped
+            }
         };
         // The bricks the outgoing field occupied, marked in the INCOMING one:
         // without this the renderer keeps drawing triangles nothing will ever
@@ -2325,8 +2347,20 @@ impl Brokkr {
         if degrees.abs() > 0.05 {
             what.push(format!("turned {:.0}°", degrees.abs()));
         }
-        if (placement.scale - 1.0).abs() > 1.0e-4 {
-            what.push(format!("scaled to {:.0}%", placement.scale * 100.0));
+        if (placement.scale - glam::Vec3::ONE).abs().max_element() > 1.0e-4 {
+            // Named per axis when they differ, because "scaled to 60%" over a
+            // squash that only touched Z is the status line telling the user
+            // something that did not happen.
+            if placement.is_uniform_scale() {
+                what.push(format!("scaled to {:.0}%", placement.scale.x * 100.0));
+            } else {
+                what.push(format!(
+                    "resized to {:.0}/{:.0}/{:.0}%",
+                    placement.scale.x * 100.0,
+                    placement.scale.y * 100.0,
+                    placement.scale.z * 100.0
+                ));
+            }
         }
         if what.is_empty() {
             what.push("put back where it started".to_string());
@@ -4101,8 +4135,8 @@ impl Brokkr {
         // **The clamp says so.** A preview box that stops growing under the
         // pointer with nothing said reads as the gizmo having lost the drag.
         // Naming the ceiling is what turns it into an answer.
-        let capped = handle == gizmo::Handle::Uniform
-            && placement.scale >= gizmo.max_scale - 1.0e-3
+        let capped = matches!(handle, gizmo::Handle::Uniform | gizmo::Handle::Scale(_))
+            && placement.scale.max_element() >= gizmo.max_scale - 1.0e-3
             && gizmo.max_scale < gizmo::MAX_SCALE;
         if capped {
             self.status = format!(
@@ -19128,13 +19162,59 @@ mod gizmo_tests {
     }
 
     /// A free-angle drag round a ring, from `+u` toward `+v`.
+    /// **A per-axis scale, through the real pointer path.**
+    ///
+    /// The handle is easy to ship dead: the variant existed for one build with
+    /// nothing constructing it, which the compiler said out loud, and then the
+    /// hit-test that constructed it swallowed every ring press instead. So this
+    /// drives a press on the box, asserts the press was TAKEN as that handle,
+    /// and then asserts the body actually changed shape rather than size.
+    #[test]
+    fn a_per_axis_drag_squashes_one_axis_and_leaves_the_others() {
+        let mut app = app();
+        arm(&mut app);
+        let gizmo = app.gizmo.expect("armed");
+        let origin = gizmo.origin();
+        let scale = crate::gizmo::world_per_pixel(&app.camera, origin, SIZE.y);
+
+        // The X box, at SCALE_BOX_PX along X.
+        let axis = Vec3::X;
+        let at = project(&app, origin + axis * (92.0 * scale));
+        assert_eq!(
+            crate::gizmo::pick(&app.camera, Vec2::new(SIZE.x, SIZE.y), &gizmo, at),
+            Some(crate::gizmo::Handle::Scale(0)),
+            "the press did not land on the per-axis box, so this tests nothing"
+        );
+
+        let before = app.doc.active_volume().world_bounds().expect("a body");
+        // Inward along the axis: a squash.
+        let to = project(&app, origin + axis * (46.0 * scale));
+        gesture(&mut app, at, &[to]);
+        let after = app.doc.active_volume().world_bounds().expect("a body");
+
+        let span = |b: (Vec3, Vec3)| b.1 - b.0;
+        let (was, now) = (span(before), span(after));
+        assert!(now.x < was.x - app.doc.voxel_size(), "x did not squash: {was:?} then {now:?}");
+        assert!(
+            (now.y - was.y).abs() < was.y * 0.15 && (now.z - was.z).abs() < was.z * 0.15,
+            "a per-axis scale changed the other two axes: {was:?} then {now:?}"
+        );
+        assert!(
+            app.status.contains("resized"),
+            "the status line called a per-axis scale something else: {}",
+            app.status
+        );
+    }
+
     fn turn_a_ring(app: &mut Brokkr, radians: f32) {
         let gizmo = app.gizmo.expect("armed");
         let origin = gizmo.origin();
         let scale = crate::gizmo::world_per_pixel(&app.camera, origin, SIZE.y);
         // The Y ring, whose plane is the one the default camera looks most
         // squarely at, so both its ends project well clear of the middle.
-        let radius = 104.0 * scale;
+        // From the constant, not a literal: the ring moved once already and a
+        // stale copy here would silently aim this at empty space.
+        let radius = crate::gizmo::RING_PX * scale;
         let from = project(app, origin + Vec3::Z * radius);
         let to =
             project(app, origin + (Vec3::Z * radians.cos() + Vec3::X * radians.sin()) * radius);
@@ -19608,12 +19688,12 @@ mod gizmo_tests {
             gesture(&mut app, from, &[from + Vec2::new(320.0, 0.0)]);
             let scale = app.gizmo.expect("armed").placement.scale;
             assert!(
-                scale <= ceiling + 1.0e-3,
+                scale.max_element() <= ceiling + 1.0e-3,
                 "round {round} composed to {scale}, past a ceiling of {ceiling}"
             );
         }
         assert!(
-            app.gizmo.expect("armed").placement.scale > 1.0,
+            app.gizmo.expect("armed").placement.scale.max_element() > 1.0,
             "the fixture never grew the body, so it proves nothing"
         );
 

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -18932,44 +18932,6 @@ mod mask_generator_tests {
     }
 }
 
-#[cfg(test)]
-mod real_file_check {
-    use super::*;
-
-    #[test]
-    #[ignore]
-    fn the_dragonstone_project_opens_on_a_camera_that_can_move() {
-        let path = std::path::Path::new(
-            "/home/thomash/Downloads/Meshy_AI_Dragonstone_Carver_0823214323_generate_obj/Brokkr.brokkr",
-        );
-        if !path.exists() {
-            println!("absent, skipping");
-            return;
-        }
-        let mut app = Brokkr::with_tablet(crate::tablet::Tablet::inert());
-        app.open_project(path);
-        let c = app.camera;
-        println!("status: {}", app.status);
-        println!(
-            "target {:?}  distance {:.3}  floor {:.3}  far {:.1}",
-            c.target,
-            c.distance,
-            c.min_distance(),
-            c.far()
-        );
-        let before = app.camera.distance;
-        app.camera.zoom_by(OrbitCamera::zoom_factor(1.0));
-        println!(
-            "one scroll notch: {:.3} -> {:.3}  (moved {:.3} mm)",
-            before,
-            app.camera.distance,
-            (app.camera.distance - before).abs()
-        );
-        assert!((app.camera.distance - before).abs() > 1.0, "scroll still does nothing");
-        assert!(app.camera.target.distance(Vec3::ZERO) < 200.0, "still aimed at empty space");
-    }
-}
-
 /// The camera Thomas asked for: free to move, still focused on the sculpt.
 ///
 /// These are the tests that measure the OUTCOME rather than the mechanism.

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -590,6 +590,13 @@ pub struct Brokkr {
     gizmo_baked: Option<brokkr_core::Similarity>,
     /// Whether the welcome screen is up. See [`crate::welcome`].
     welcome: bool,
+    /// Whether it opens by itself next time.
+    ///
+    /// Held rather than read where it is drawn: the tick is inside `view()`,
+    /// which runs every frame, and `welcome::on_startup` opens and parses a
+    /// file. Every other setting in this application is loaded once into state
+    /// the same way -- see `recent` above and `spacemouse.config`.
+    welcome_on_startup: bool,
     /// The TinkerAtlas articles that screen shows. See [`crate::articles`] for
     /// why this is fetched only while the screen is actually up.
     feed: crate::articles::Feed,
@@ -1560,7 +1567,15 @@ fn keeps_the_rename_open(message: &Message) -> bool {
 }
 
 impl Brokkr {
-    pub fn new() -> Self {
+    /// The application, and whatever it must do before the first frame.
+    ///
+    /// **Returns a `Task` because iced takes one**: `IntoBoot` is implemented
+    /// for `(State, Task<Message>)`, so there is a place in construction to
+    /// start work from. The first version of this claimed otherwise and put a
+    /// guard in `update` instead, which meant re-entering the one function
+    /// every message passes through -- so every other guard in it had to be
+    /// safe against running twice, to serve one request at startup.
+    pub fn new() -> (Self, Task<Message>) {
         let mut app = Self::with_devices(Tablet::start(), SpaceMouse::start());
         // **Read here and not in `with_devices`, which is what the tests
         // build through.** The welcome screen is modal, so an application
@@ -1573,8 +1588,12 @@ impl Brokkr {
         // Set last, so it opens over a document that is already whole: it ranks
         // above every other card, and anything raised during construction would
         // be drawn underneath it and be unreachable.
-        app.welcome = crate::welcome::on_startup();
-        app
+        app.welcome_on_startup = crate::welcome::on_startup();
+        app.welcome = app.welcome_on_startup;
+        // The screen is up, so its articles are wanted. The only other place
+        // that raises it, `Message::WelcomeOpened`, asks for them too.
+        let boot = if app.welcome { app.fetch_articles() } else { Task::none() };
+        (app, boot)
     }
 
     /// Build with a given pressure source and an inert puck, which is what
@@ -1677,6 +1696,7 @@ impl Brokkr {
             gizmo_base: None,
             gizmo_baked: None,
             welcome: false,
+            welcome_on_startup: true,
             feed: crate::articles::Feed::default(),
             cube_hover: None,
             flight: None,
@@ -2358,29 +2378,6 @@ impl Brokkr {
     /// The base is taken out of the document on the FIRST bake rather than at
     /// arming, so that arming alone never touches the field -- pressing `w` and
     /// pressing it again has to be free.
-    /// Whether two placements would bake to the same field.
-    ///
-    /// **Not `==`, and that was tried first.** `transform_to` recomputes the
-    /// placement through `Similarity::then` on every `Moved` event, and that
-    /// arithmetic is not bit-reproducible: a press and release on a single
-    /// pixel produces a placement whose translation and scale deltas are
-    /// EXACTLY zero and whose quaternion differs in the last bits. An exact
-    /// comparison therefore never fired once, and the re-bake it was meant to
-    /// skip went on happening.
-    ///
-    /// The tolerances sit far below anything a real gesture can produce -- one
-    /// pixel of drag moves the translation by `world_per_pixel`, which is
-    /// millimetres on an ordinary camera, against a thousandth of a voxel here
-    /// -- so this cannot swallow a sub-slop drag the user meant. That matters:
-    /// `Drag::moved` is only set past `CLICK_SLOP_PX` while `transform_to` runs
-    /// on every event, so gating on `moved` instead would silently discard a
-    /// small deliberate nudge.
-    fn same_bake(a: brokkr_core::Similarity, b: brokkr_core::Similarity, voxel_size: f32) -> bool {
-        (a.translation - b.translation).length() <= voxel_size * 1.0e-3
-            && (a.scale - b.scale).abs().max_element() <= 1.0e-5
-            && a.rotation.dot(b.rotation).abs() >= 1.0 - 1.0e-6
-    }
-
     fn rebake_gizmo(&mut self) {
         let Some(gizmo) = self.gizmo else {
             return;
@@ -2420,8 +2417,7 @@ impl Brokkr {
         // Already baked, and nothing has moved since. Covers a press and
         // release on a handle with no motion, and a drag out and back across
         // two presses.
-        if self.gizmo_baked.is_some_and(|baked| Self::same_bake(baked, gizmo.placement, voxel_size))
-        {
+        if self.gizmo_baked.is_some_and(|baked| baked.same_bake(gizmo.placement, voxel_size)) {
             return;
         }
 
@@ -7245,6 +7241,24 @@ impl Brokkr {
         self.refresh_overlay();
     }
 
+    /// Ask TinkerAtlas for its articles, unless a request is already out.
+    ///
+    /// **Only ever called while the welcome screen is up**, which is what makes
+    /// the tick on that screen an honest control over it: turn the screen off
+    /// and this stops happening, with no second setting to find. See
+    /// [`crate::articles`].
+    ///
+    /// Re-fetched each time the screen opens rather than cached for the
+    /// session, because the whole point of the panel is that it is current, and
+    /// a user who opens it twice in a day has asked twice.
+    fn fetch_articles(&mut self) -> Task<Message> {
+        if matches!(self.feed, crate::articles::Feed::Loading) {
+            return Task::none();
+        }
+        self.feed = crate::articles::Feed::Loading;
+        Task::perform(async { crate::articles::fetch() }, Message::ArticlesLoaded)
+    }
+
     /// Whether a modal card is up, and therefore owns the input.
     ///
     /// One list, read by both halves of the guard: `on_key` for the keyboard
@@ -7271,24 +7285,6 @@ impl Brokkr {
     /// The warning still stands for whatever modeless overlay does eventually
     /// take the pointer: **split this function in two at that point rather than
     /// widening it and quietly killing the drag.**
-    /// Ask TinkerAtlas for its articles, unless a request is already out.
-    ///
-    /// **Only ever called while the welcome screen is up**, which is what makes
-    /// the tick on that screen an honest control over it: turn the screen off
-    /// and this stops happening, with no second setting to find. See
-    /// [`crate::articles`].
-    ///
-    /// Re-fetched each time the screen opens rather than cached for the
-    /// session, because the whole point of the panel is that it is current, and
-    /// a user who opens it twice in a day has asked twice.
-    fn fetch_articles(&mut self) -> Task<Message> {
-        if matches!(self.feed, crate::articles::Feed::Loading) {
-            return Task::none();
-        }
-        self.feed = crate::articles::Feed::Loading;
-        Task::perform(async { crate::articles::fetch() }, Message::ArticlesLoaded)
-    }
-
     fn modal_open(&self) -> bool {
         self.welcome
             || self.confirm.is_some()
@@ -7787,20 +7783,6 @@ impl Brokkr {
         // same set, and that set is not a list anyone can keep correct.
         // Asking the question once, before the message is acted on, cannot go
         // out of date.
-        // **The startup fetch.** `Brokkr::new` returns a `Self` and not a
-        // `Task`, so there is nowhere in construction to start one from --
-        // and asking here rather than at each place that raises the screen
-        // means no path can forget. It runs once because the state moves off
-        // `Idle` immediately.
-        if self.welcome
-            && matches!(self.feed, crate::articles::Feed::Idle)
-            && !matches!(message, Message::ArticlesLoaded(_))
-        {
-            let fetch = self.fetch_articles();
-            let rest = self.update(message);
-            return Task::batch([fetch, rest]);
-        }
-
         // Before the gizmo guard and before dispatch, so that a card this
         // message goes on to raise is drawn over a screen that has already
         // gone rather than under one that has not.
@@ -7907,8 +7889,14 @@ impl Brokkr {
                     self.status = why;
                 }
             }
-            Message::WelcomeClosed => self.welcome = false,
-            Message::WelcomeOnStartupSet(show) => crate::welcome::set_on_startup(show),
+            // Nothing to do: `dismisses_the_welcome` already cleared the flag
+            // before dispatch, which is what closes it for every other button
+            // on the card too.
+            Message::WelcomeClosed => {}
+            Message::WelcomeOnStartupSet(show) => {
+                self.welcome_on_startup = show;
+                crate::welcome::set_on_startup(show);
+            }
             Message::SymmetryAxisToggled(axis) => self.toggle_mirror(axis),
             Message::PatternChanged(kind) => self.brush.pattern.kind = kind,
             Message::PatternScaleChanged(scale) => self.brush.pattern.scale_mm = scale,
@@ -8611,8 +8599,11 @@ impl Brokkr {
 }
 
 impl Default for Brokkr {
+    /// The application without its boot task, which is what a `Default` can
+    /// promise. `Brokkr::new` is what `main` uses, and it returns the work to
+    /// be done before the first frame as well.
     fn default() -> Self {
-        Self::new()
+        Self::new().0
     }
 }
 

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -590,6 +590,9 @@ pub struct Brokkr {
     gizmo_baked: Option<brokkr_core::Similarity>,
     /// Whether the welcome screen is up. See [`crate::welcome`].
     welcome: bool,
+    /// The TinkerAtlas articles that screen shows. See [`crate::articles`] for
+    /// why this is fetched only while the screen is actually up.
+    feed: crate::articles::Feed,
     /// The cube part under the pointer, lit so a click's effect is visible
     /// before the click.
     cube_hover: Option<navcube::Part>,
@@ -1674,6 +1677,7 @@ impl Brokkr {
             gizmo_base: None,
             gizmo_baked: None,
             welcome: false,
+            feed: crate::articles::Feed::default(),
             cube_hover: None,
             flight: None,
             menu: None,
@@ -7267,6 +7271,24 @@ impl Brokkr {
     /// The warning still stands for whatever modeless overlay does eventually
     /// take the pointer: **split this function in two at that point rather than
     /// widening it and quietly killing the drag.**
+    /// Ask TinkerAtlas for its articles, unless a request is already out.
+    ///
+    /// **Only ever called while the welcome screen is up**, which is what makes
+    /// the tick on that screen an honest control over it: turn the screen off
+    /// and this stops happening, with no second setting to find. See
+    /// [`crate::articles`].
+    ///
+    /// Re-fetched each time the screen opens rather than cached for the
+    /// session, because the whole point of the panel is that it is current, and
+    /// a user who opens it twice in a day has asked twice.
+    fn fetch_articles(&mut self) -> Task<Message> {
+        if matches!(self.feed, crate::articles::Feed::Loading) {
+            return Task::none();
+        }
+        self.feed = crate::articles::Feed::Loading;
+        Task::perform(async { crate::articles::fetch() }, Message::ArticlesLoaded)
+    }
+
     fn modal_open(&self) -> bool {
         self.welcome
             || self.confirm.is_some()
@@ -7765,6 +7787,20 @@ impl Brokkr {
         // same set, and that set is not a list anyone can keep correct.
         // Asking the question once, before the message is acted on, cannot go
         // out of date.
+        // **The startup fetch.** `Brokkr::new` returns a `Self` and not a
+        // `Task`, so there is nowhere in construction to start one from --
+        // and asking here rather than at each place that raises the screen
+        // means no path can forget. It runs once because the state moves off
+        // `Idle` immediately.
+        if self.welcome
+            && matches!(self.feed, crate::articles::Feed::Idle)
+            && !matches!(message, Message::ArticlesLoaded(_))
+        {
+            let fetch = self.fetch_articles();
+            let rest = self.update(message);
+            return Task::batch([fetch, rest]);
+        }
+
         // Before the gizmo guard and before dispatch, so that a card this
         // message goes on to raise is drawn over a screen that has already
         // gone rather than under one that has not.
@@ -7854,6 +7890,22 @@ impl Brokkr {
                 // the screen is dismissed.
                 self.top_menu = None;
                 self.welcome = true;
+                return self.fetch_articles();
+            }
+            Message::ArticlesRetried => return self.fetch_articles(),
+            Message::ArticlesLoaded(answer) => {
+                self.feed = match answer {
+                    Ok(articles) => crate::articles::Feed::Ready(articles),
+                    Err(why) => crate::articles::Feed::Failed(why),
+                };
+            }
+            Message::ArticleOpened(link) => {
+                // The screen stays up: reading an article is not choosing what
+                // to do with the application, and coming back to a dismissed
+                // welcome screen would be a surprise.
+                if let Err(why) = crate::articles::open_in_browser(&link) {
+                    self.status = why;
+                }
             }
             Message::WelcomeClosed => self.welcome = false,
             Message::WelcomeOnStartupSet(show) => crate::welcome::set_on_startup(show),
@@ -9709,21 +9761,34 @@ mod tests {
         );
     }
 
-    /// The tick must not dismiss the screen it is a setting for.
+    /// The tick must not dismiss the screen it is a setting for, and neither
+    /// must reading an article.
+    ///
+    /// **Asked of the rule and not by sending the message**, deliberately.
+    /// `WelcomeOnStartupSet` writes through to the real
+    /// `$XDG_CONFIG_HOME/brokkrsculpt/welcome.conf`, so driving it here would
+    /// reach into the config of whoever is running the suite -- and two such
+    /// tests in parallel would race on one file. `dismisses_the_welcome` is a
+    /// pure function of the message, so it can be asked directly; that the
+    /// preference round-trips is
+    /// `welcome::tests::the_preference_survives_being_written_and_read_back`,
+    /// which uses a path of its own for the same reason.
     #[test]
-    fn the_startup_tick_does_not_dismiss_the_welcome_screen() {
-        let mut app = app();
-        app.welcome = true;
+    fn the_screens_own_controls_do_not_dismiss_it() {
+        assert!(!dismisses_the_welcome(&Message::WelcomeOnStartupSet(false)));
+        assert!(!dismisses_the_welcome(&Message::WelcomeOnStartupSet(true)));
+        assert!(
+            !dismisses_the_welcome(&Message::ArticleOpened("https://tinkeratlas.com/x".into())),
+            "reading an article closed the screen it was read from"
+        );
+        assert!(!dismisses_the_welcome(&Message::ArticlesRetried));
+        assert!(!dismisses_the_welcome(&Message::ArticlesLoaded(Ok(Vec::new()))));
 
-        // Read the preference back rather than trusting the write: this is the
-        // one control whose whole job is to persist.
-        let was = crate::welcome::on_startup();
-        update(&mut app, Message::WelcomeOnStartupSet(!was));
-        assert!(app.welcome, "ticking the box closed the screen it belongs to");
-        assert_eq!(crate::welcome::on_startup(), !was, "the tick did not persist");
-
-        update(&mut app, Message::WelcomeOnStartupSet(was));
-        assert_eq!(crate::welcome::on_startup(), was, "the fixture did not put the setting back");
+        // And the ones that must: every button that starts real work.
+        assert!(dismisses_the_welcome(&Message::NewSculpt));
+        assert!(dismisses_the_welcome(&Message::OpenRequested));
+        assert!(dismisses_the_welcome(&Message::ImportRequested));
+        assert!(dismisses_the_welcome(&Message::WelcomeClosed));
     }
 
     /// No shortcut may reach the document through the welcome screen.

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -588,6 +588,8 @@ pub struct Brokkr {
     /// sub-slop drag really does change the placement, and dropping it would be
     /// silently discarding something the user asked for.
     gizmo_baked: Option<brokkr_core::Similarity>,
+    /// Whether the welcome screen is up. See [`crate::welcome`].
+    welcome: bool,
     /// The cube part under the pointer, lit so a click's effect is visible
     /// before the click.
     cube_hover: Option<navcube::Part>,
@@ -1509,6 +1511,40 @@ fn keeps_the_gizmo_armed(message: &Message) -> bool {
     }
 }
 
+/// Whether a message is one of the welcome screen's own actions, and so
+/// dismisses it.
+///
+/// **It is a starting point, not a mode.** Pressing New sculpt has answered the
+/// question the screen was asking -- which is why SindriCAD's buttons call
+/// `close()` before their action rather than after. It is not only tidiness:
+/// the welcome card ranks above every other card, so leaving it up draws the
+/// unsaved-work prompt that `New sculpt` raises UNDERNEATH it, raised,
+/// unanswerable and invisible.
+///
+/// **Asked as "what closes it" and NOT as "what keeps it open", which is the
+/// opposite of the gizmo's guard beside it.** That one denies by default
+/// because an armed gizmo holds a gesture that must not survive an unrelated
+/// message. This holds nothing, so the two failure directions are not
+/// symmetric: a screen that lingers one message too long is a click, and a
+/// screen that never appears is invisible. Written the other way round it was
+/// dismissed before it could be seen -- by `TimelineResized`, a LAYOUT message
+/// the window emits as it lays itself out, which no allow-list would have
+/// thought to name.
+///
+/// The list is knowable and complete by construction: the card is `opaque`, so
+/// while it is up nothing else on screen can produce a message at all, and
+/// these are exactly the controls it offers.
+fn dismisses_the_welcome(message: &Message) -> bool {
+    matches!(
+        message,
+        Message::WelcomeClosed
+            | Message::NewSculpt
+            | Message::OpenRequested
+            | Message::ImportRequested
+            | Message::OpenRecent(_)
+    )
+}
+
 fn keeps_the_rename_open(message: &Message) -> bool {
     match message {
         Message::BodyRenameEdited(_) => true,
@@ -1522,7 +1558,20 @@ fn keeps_the_rename_open(message: &Message) -> bool {
 
 impl Brokkr {
     pub fn new() -> Self {
-        Self::with_devices(Tablet::start(), SpaceMouse::start())
+        let mut app = Self::with_devices(Tablet::start(), SpaceMouse::start());
+        // **Read here and not in `with_devices`, which is what the tests
+        // build through.** The welcome screen is modal, so an application
+        // constructed with it up has every keyboard and pointer path blocked by
+        // `modal_open` -- and a test that built one would silently stop
+        // sculpting. Worse, it would do so depending on whether the developer
+        // running the suite happens to have dismissed the screen, which is a
+        // test outcome that varies by machine.
+        //
+        // Set last, so it opens over a document that is already whole: it ranks
+        // above every other card, and anything raised during construction would
+        // be drawn underneath it and be unreachable.
+        app.welcome = crate::welcome::on_startup();
+        app
     }
 
     /// Build with a given pressure source and an inert puck, which is what
@@ -1624,6 +1673,7 @@ impl Brokkr {
             gizmo: None,
             gizmo_base: None,
             gizmo_baked: None,
+            welcome: false,
             cube_hover: None,
             flight: None,
             menu: None,
@@ -7218,7 +7268,8 @@ impl Brokkr {
     /// take the pointer: **split this function in two at that point rather than
     /// widening it and quietly killing the drag.**
     fn modal_open(&self) -> bool {
-        self.confirm.is_some()
+        self.welcome
+            || self.confirm.is_some()
             || self.orient_prompt.is_some()
             || self.bug_report.is_some()
             || self.pending_delete.is_some()
@@ -7245,6 +7296,14 @@ impl Brokkr {
             // the user typed, and throwing it away on a stray Escape is the
             // same class of loss the confirm prompt exists to prevent.
             iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape) => {
+                // The welcome screen first, and unlike the bug report it DOES
+                // go on Escape: it holds nothing the user typed, so there is
+                // nothing to lose by dismissing it, and a modal with no
+                // keyboard exit is the one thing worse than no modal.
+                if self.welcome {
+                    self.welcome = false;
+                    return Task::none();
+                }
                 self.update(Message::MenuClosed)
             }
             iced::keyboard::Key::Character(character) => {
@@ -7706,6 +7765,12 @@ impl Brokkr {
         // same set, and that set is not a list anyone can keep correct.
         // Asking the question once, before the message is acted on, cannot go
         // out of date.
+        // Before the gizmo guard and before dispatch, so that a card this
+        // message goes on to raise is drawn over a screen that has already
+        // gone rather than under one that has not.
+        if self.welcome && dismisses_the_welcome(&message) {
+            self.welcome = false;
+        }
         if self.gizmo.is_some() && !keeps_the_gizmo_armed(&message) {
             self.disarm_gizmo(true);
         }
@@ -7783,6 +7848,15 @@ impl Brokkr {
                 let slot = self.live_strength_slot();
                 self.strengths[slot] = strength;
             }
+            Message::WelcomeOpened => {
+                // The menu it was chosen from has to go, or it is left drawn
+                // beneath the scrim: reachable to nothing, and still there when
+                // the screen is dismissed.
+                self.top_menu = None;
+                self.welcome = true;
+            }
+            Message::WelcomeClosed => self.welcome = false,
+            Message::WelcomeOnStartupSet(show) => crate::welcome::set_on_startup(show),
             Message::SymmetryAxisToggled(axis) => self.toggle_mirror(axis),
             Message::PatternChanged(kind) => self.brush.pattern.kind = kind,
             Message::PatternScaleChanged(scale) => self.brush.pattern.scale_mm = scale,
@@ -9612,6 +9686,78 @@ mod tests {
     /// reads or they prove nothing.
     fn ctrl() -> iced::keyboard::Modifiers {
         iced::keyboard::Modifiers::CTRL
+    }
+
+    /// **An action from the welcome screen dismisses it.**
+    ///
+    /// It is a starting point and not a mode: pressing New sculpt has answered
+    /// the question the screen was asking. And because the welcome card ranks
+    /// above every other card, leaving it up draws the unsaved-work prompt that
+    /// `New sculpt` raises UNDERNEATH it -- raised, unanswerable and invisible.
+    /// Seen exactly that way in the running application before this landed.
+    #[test]
+    fn an_action_from_the_welcome_screen_dismisses_it_so_its_prompt_is_reachable() {
+        let mut app = app_with_unsaved_work();
+        app.welcome = true;
+
+        update(&mut app, Message::NewSculpt);
+
+        assert!(!app.welcome, "the welcome screen survived an action taken from it");
+        assert!(
+            app.confirm.is_some(),
+            "the fixture raised no prompt, so this does not test what it names"
+        );
+    }
+
+    /// The tick must not dismiss the screen it is a setting for.
+    #[test]
+    fn the_startup_tick_does_not_dismiss_the_welcome_screen() {
+        let mut app = app();
+        app.welcome = true;
+
+        // Read the preference back rather than trusting the write: this is the
+        // one control whose whole job is to persist.
+        let was = crate::welcome::on_startup();
+        update(&mut app, Message::WelcomeOnStartupSet(!was));
+        assert!(app.welcome, "ticking the box closed the screen it belongs to");
+        assert_eq!(crate::welcome::on_startup(), !was, "the tick did not persist");
+
+        update(&mut app, Message::WelcomeOnStartupSet(was));
+        assert_eq!(crate::welcome::on_startup(), was, "the fixture did not put the setting back");
+    }
+
+    /// No shortcut may reach the document through the welcome screen.
+    ///
+    /// It is modal like every other card, and `modal_open` is the one place
+    /// that is decided -- a card missing from that list is a card the keyboard
+    /// reaches straight through.
+    #[test]
+    fn no_shortcut_fires_while_the_welcome_screen_is_up() {
+        let mut app = app();
+        app.welcome = true;
+        let before = app.brush.kind;
+
+        key(&mut app, "3", bare());
+        key(&mut app, "x", bare());
+
+        assert_eq!(app.brush.kind, before, "a brush number changed the tool behind the screen");
+        assert!(!app.symmetry.axis(MirrorAxis::X), "a mirror plane toggled behind the screen");
+        assert!(app.welcome, "a shortcut dismissed the screen instead of being swallowed");
+    }
+
+    /// Escape closes it, unlike the bug report, which holds typed text.
+    #[test]
+    fn escape_closes_the_welcome_screen() {
+        let mut app = app();
+        app.welcome = true;
+        update(
+            &mut app,
+            Message::KeyPressed {
+                key: iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape),
+                modifiers: bare(),
+            },
+        );
+        assert!(!app.welcome, "Escape left the screen up, so it has no keyboard exit");
     }
 
     /// The undo that used to reach through the card.

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -36,7 +36,7 @@ use crate::viewport::{SharedFrame, ThumbRequest};
 ///
 /// A 60 mm ball at a quarter millimetre voxel is 240 voxels across, which is
 /// the 256 cubed effective volume the milestones are measured against.
-const MODEL_RADIUS_MM: f32 = 30.0;
+pub(crate) const MODEL_RADIUS_MM: f32 = 30.0;
 const VOXEL_SIZE_MM: f32 = 0.25;
 
 /// The point every enabled mirror plane passes through: the lattice origin.
@@ -573,6 +573,21 @@ pub struct Brokkr {
     /// gizmo is up is twice the body, which is what
     /// [`Brokkr::arm_gizmo`] checks for before it allocates anything.
     gizmo_base: Option<Box<brokkr_core::Volume>>,
+    /// The placement [`Brokkr::rebake_gizmo`] last actually baked.
+    ///
+    /// A press and release that moves nothing still reaches the Released arm,
+    /// and the bake always restarts from `gizmo_base`, so without this it
+    /// reproduces a bit-identical field at full price -- 159 ms of warp and
+    /// 7.1 s of repair on the largest arm-able body, for an accidental click.
+    /// `Bake::Identity` does not cover it: after any earlier transform in the
+    /// same session the placement is not the identity, it is merely the same
+    /// one that was baked a moment ago.
+    ///
+    /// Deliberately NOT gated on `Drag::moved`, which is only set past
+    /// `CLICK_SLOP_PX` while `transform_to` runs on every `Moved` event -- a
+    /// sub-slop drag really does change the placement, and dropping it would be
+    /// silently discarding something the user asked for.
+    gizmo_baked: Option<brokkr_core::Similarity>,
     /// The cube part under the pointer, lit so a click's effect is visible
     /// before the click.
     cube_hover: Option<navcube::Part>,
@@ -1608,6 +1623,7 @@ impl Brokkr {
             gizmo_batch: brokkr_gpu::OverlayBatch::default(),
             gizmo: None,
             gizmo_base: None,
+            gizmo_baked: None,
             cube_hover: None,
             flight: None,
             menu: None,
@@ -1840,6 +1856,37 @@ impl Brokkr {
         // a drag.
         self.contain_target();
         self.shared.set_camera(self.camera);
+
+        // **A live transform drag has to be re-pinned when the camera moves.**
+        //
+        // `gizmo::drag` rebuilds both rays from the CURRENT camera, so moving
+        // the camera under a held handle re-interprets the pixel the button
+        // went down on and the body walks with nothing touching the pointer.
+        // Measured on the standard fixture with a stationary pointer: the
+        // X-axis offset drifted 5.4696 mm to 6.5737 mm for a 0.4 radian yaw
+        // nudge. Three paths reach this without a second button going down --
+        // the SpaceMouse, the scroll wheel, and a navigation-cube flight still
+        // in the air when the drag started -- so guarding the pointer handler
+        // would have missed all three. This is the one place a camera becomes
+        // legal, so it is the one place that has to know.
+        //
+        // Re-pinned rather than frozen: the gesture stays continuous and the
+        // two-handed SpaceMouse-and-stylus workflow the application is built
+        // around survives. Freezing the puck mid-drag is a larger behavioural
+        // change than the bug.
+        let repin = self.cursor.filter(|_| {
+            self.drag.is_some_and(|drag| matches!(drag.kind, DragKind::Transforming(_)))
+                && self.gizmo.is_some_and(|gizmo| gizmo.grabbed.is_some())
+        });
+        if let Some(cursor) = repin {
+            if let Some(drag) = self.drag.as_mut() {
+                drag.origin = cursor;
+            }
+            if let Some(live) = self.gizmo.as_mut() {
+                live.pinned = live.placement;
+            }
+        }
+
         // The cube shows the camera's orientation, so it is stale the moment the
         // camera moves. This is the one place that knows that happened.
         self.refresh_cube();
@@ -1919,6 +1966,30 @@ impl Brokkr {
             .world_bounds()
             .map_or(MODEL_RADIUS_MM, |(low, high)| ((high - low).length() * 0.5).max(1.0e-3));
         self.camera.set_lattice(self.doc.voxel_size(), radius);
+
+        // **The bounds moved, so the distance has to be brought inside them.**
+        //
+        // `set_lattice` writes the two figures the floor and the ceiling are
+        // derived from and never re-checks the distance against them, so a
+        // camera already sitting on the old floor is left UNDER the new one.
+        // One press of "coarser" from 0.25 mm takes the floor from 0.500 to
+        // 2.000 with the camera still at 0.500, and the next wheel notch INWARD
+        // then jumps it out to 2.000 and drags the target four times away from
+        // whatever it was anchored on -- a zoom in that flies backwards.
+        //
+        // The clamp alone would be incomplete in the way this project has been
+        // bitten before: neither `resample` nor `remove_body` publishes a
+        // camera, and `Message::Frame` only publishes when a flight is running,
+        // so the corrected distance would sit in `self.camera` while
+        // `SharedFrame` still held the old one. `publish_camera` is what closes
+        // that, and it is safe to call from here because it does not itself
+        // call back into this function.
+        let clamped =
+            self.camera.distance.clamp(self.camera.min_distance(), self.camera.max_distance());
+        if clamped != self.camera.distance {
+            self.camera.distance = clamped;
+            self.publish_camera();
+        }
     }
 
     /// Frame the active body, which is the one keystroke that recovers from any
@@ -2074,6 +2145,8 @@ impl Brokkr {
         if self.gizmo.is_some() {
             return Ok(());
         }
+        // A fresh session has baked nothing, whatever the last one baked.
+        self.gizmo_baked = None;
         let body = self.doc.active();
         if !self.active_is_drawn() {
             return Err("that body is hidden — turn its eye on to move it".to_string());
@@ -2201,6 +2274,29 @@ impl Brokkr {
     /// The base is taken out of the document on the FIRST bake rather than at
     /// arming, so that arming alone never touches the field -- pressing `w` and
     /// pressing it again has to be free.
+    /// Whether two placements would bake to the same field.
+    ///
+    /// **Not `==`, and that was tried first.** `transform_to` recomputes the
+    /// placement through `Similarity::then` on every `Moved` event, and that
+    /// arithmetic is not bit-reproducible: a press and release on a single
+    /// pixel produces a placement whose translation and scale deltas are
+    /// EXACTLY zero and whose quaternion differs in the last bits. An exact
+    /// comparison therefore never fired once, and the re-bake it was meant to
+    /// skip went on happening.
+    ///
+    /// The tolerances sit far below anything a real gesture can produce -- one
+    /// pixel of drag moves the translation by `world_per_pixel`, which is
+    /// millimetres on an ordinary camera, against a thousandth of a voxel here
+    /// -- so this cannot swallow a sub-slop drag the user meant. That matters:
+    /// `Drag::moved` is only set past `CLICK_SLOP_PX` while `transform_to` runs
+    /// on every event, so gating on `moved` instead would silently discard a
+    /// small deliberate nudge.
+    fn same_bake(a: brokkr_core::Similarity, b: brokkr_core::Similarity, voxel_size: f32) -> bool {
+        (a.translation - b.translation).length() <= voxel_size * 1.0e-3
+            && (a.scale - b.scale).abs().max_element() <= 1.0e-5
+            && a.rotation.dot(b.rotation).abs() >= 1.0 - 1.0e-6
+    }
+
     fn rebake_gizmo(&mut self) {
         let Some(gizmo) = self.gizmo else {
             return;
@@ -2233,6 +2329,15 @@ impl Brokkr {
             self.restore_base(body);
             self.status =
                 Self::bake_summary(&gizmo.placement, route, voxel_size, started.elapsed());
+            self.gizmo_baked = None;
+            return;
+        }
+
+        // Already baked, and nothing has moved since. Covers a press and
+        // release on a handle with no motion, and a drag out and back across
+        // two presses.
+        if self.gizmo_baked.is_some_and(|baked| Self::same_bake(baked, gizmo.placement, voxel_size))
+        {
             return;
         }
 
@@ -2282,14 +2387,22 @@ impl Brokkr {
                 // `similarity.rs` refused a per-axis scale until this pass
                 // existed.
                 //
-                // Skipped when the scale is uniform, where the field is exactly
-                // the transformed solid and the pass would be work with no
-                // customer. `redistance` gates itself again on the measured
-                // drift, so a rotation that happens to leave the gradient
-                // alone costs one read-only sweep and no writes.
-                if !gizmo.placement.is_uniform_scale() {
-                    warped.redistance();
-                }
+                // Run on EVERY resample, uniform scale included. The tempting
+                // reading is that a uniform scale leaves the field exactly the
+                // transformed solid and so needs nothing -- that is true of the
+                // measured distances and false of the band. `Volume::warped`
+                // writes the saturation plateau back at the band edge rather
+                // than scaling it, which is a deliberate cliff, and this pass
+                // is what re-solves the band outward from the interface and
+                // removes it. Skipping it for a uniform scale left one drag of
+                // the centre handle with a field whose plateau had been carried
+                // from 3.0 voxels down to 0.15 and nothing to put it back.
+                //
+                // Costing nothing when it is not needed is `redistance`'s own
+                // job: it gates on measured drift and returns `None` after one
+                // read-only sweep, which is the cost the rotation-only case
+                // already accepts a few lines above.
+                warped.redistance();
                 warped
             }
         };
@@ -2301,6 +2414,7 @@ impl Brokkr {
         }
         self.doc.replace_volume(body, baked);
         self.gizmo_base = Some(base);
+        self.gizmo_baked = Some(gizmo.placement);
 
         // The slots the old field held are in nobody's dirty set now -- the
         // bricks are at new coordinates -- so they have to be let go, and the
@@ -2408,6 +2522,7 @@ impl Brokkr {
         let body = gizmo.body;
 
         if commit {
+            self.gizmo_baked = None;
             let base = self.gizmo_base.take().expect("checked just above");
             let before = self.history.stats();
             self.history.push(brokkr_core::Entry::new(vec![brokkr_core::Change::WholeVolume {
@@ -2435,6 +2550,7 @@ impl Brokkr {
     ///
     /// Answers whether there was a base to put back.
     fn restore_base(&mut self, body: NodeId) -> bool {
+        self.gizmo_baked = None;
         let Some(base) = self.gizmo_base.take() else {
             return false;
         };
@@ -3922,6 +4038,19 @@ impl Brokkr {
         } else {
             self.status = self.mirror_refusal(axis, "refused");
         }
+        // **The planes are part of what the overlay draws, so changing them has
+        // to rebuild it.** `refresh_overlay`'s own doc already lists "a brush or
+        // mirror setting" among its callers and this was not one of them, so the
+        // planes lagged a toggle behind: whatever the last refresh had built
+        // stayed on screen until some unrelated pointer motion rebuilt it.
+        // Turning X OFF left its plane drawn, and turning it back ON drew
+        // nothing until the next interaction. Observed by driving the running
+        // application; no test could see it, because the assertion everyone
+        // writes is on `self.symmetry`, which was right the whole time.
+        //
+        // Here rather than at the two call sites, so the keyboard and the strip
+        // cannot drift apart.
+        self.refresh_overlay();
     }
 
     /// Rebuild the brush ring and mirror planes and hand them to the renderer.
@@ -6163,8 +6292,9 @@ impl Brokkr {
     /// under-prompting costs the sculpt.
     fn undo(&mut self) {
         let shown = self.saved_nodes();
+        let before = self.body_ids();
         match self.history.undo(&mut self.doc, &shown) {
-            UndoOutcome::Applied(_) => self.after_history_step(),
+            UndoOutcome::Applied(_) => self.after_history_step(&before),
             UndoOutcome::Refused(node) => self.refuse_history_step("undo", node),
             UndoOutcome::Nothing => {}
         }
@@ -6172,11 +6302,18 @@ impl Brokkr {
 
     fn redo(&mut self) {
         let shown = self.saved_nodes();
+        let before = self.body_ids();
         match self.history.redo(&mut self.doc, &shown) {
-            UndoOutcome::Applied(_) => self.after_history_step(),
+            UndoOutcome::Applied(_) => self.after_history_step(&before),
             UndoOutcome::Refused(node) => self.refuse_history_step("redo", node),
             UndoOutcome::Nothing => {}
         }
+    }
+
+    /// Every body the document currently holds, for comparing across a history
+    /// step. Bodies only -- a folder owns no slots in the mesh pool.
+    fn body_ids(&self) -> Vec<NodeId> {
+        self.doc.nodes().iter().filter(|node| node.is_body()).map(|node| node.id).collect()
     }
 
     /// Which rows the FILE would keep, indexed by node position.
@@ -6968,11 +7105,46 @@ impl Brokkr {
     /// planes are built from the field: sixteen other sites already refresh
     /// them, and undo not doing so has been a staleness bug the whole time
     /// there has been one body to see it on.
-    fn after_history_step(&mut self) {
+    fn after_history_step(&mut self, bodies_before: &[NodeId]) {
+        // **A body the step REMOVED has to be forgotten, or it is drawn for
+        // ever.** Undoing an added primitive applies `Change::NodeAdded`, which
+        // takes the node back out of the document -- and its bricks are then in
+        // nobody's dirty set, so `remesh_dirty` below never touches them and
+        // the pool goes on drawing a body the BODIES list no longer shows.
+        // Reported from the running application: add a primitive, ctrl+Z, and
+        // the cube leaves the list and stays on screen.
+        //
+        // `remove_body` has always done this; the history had no equivalent
+        // because `UndoOutcome::Applied` names only the FIRST node an entry
+        // touched, which is not the same question.
+        //
+        // **Diffed against the document rather than read off the `Change`s**,
+        // deliberately. A match on `Change::NodeAdded` would cover the reported
+        // case and quietly miss redo-of-a-delete, an entry mixing removals with
+        // other changes, and whatever the next variant is; the diff is a
+        // function of what actually happened and cannot drift from the enum.
+        // It is a walk over at most 128 nodes, once per keystroke.
+        let mut forgot = false;
+        for id in bodies_before {
+            if self.doc.node(*id).is_none() {
+                self.shared.forget_body(*id);
+                forgot = true;
+            }
+        }
+        if forgot {
+            // The other half, for the reason `remove_body` records: freeing
+            // pool space without re-offering everything takes the pool-full
+            // banner down while leaving the geometry it refused missing.
+            self.doc.mark_everything_dirty();
+        }
+
         self.history_stats = self.history.stats();
         self.unsaved = true;
         self.remesh_dirty();
         self.refresh_overlay();
+        if forgot {
+            self.refresh_model_radius();
+        }
     }
 
     /// Say which body is in the way, and change nothing else.
@@ -7103,6 +7275,39 @@ impl Brokkr {
                 self.viewport_size = Vec2::new(size.x, size.y);
                 let position = Vec2::new(position.x, position.y);
                 self.cursor = Some(position);
+
+                // **A second button down during a live transform abandons it.**
+                //
+                // There was no `self.drag.is_some()` guard here, so a right or
+                // middle press assigned an Orbit or Pan drag straight over a
+                // live `Transforming` one while `gizmo.grabbed` and the partial
+                // `placement` survived. The right release then took the Orbit
+                // arm, so the Transforming arm never ran and the left release
+                // found no drag at all: the handle stayed lit, the preview box
+                // went on drawing, and the gizmo visibly floated away from its
+                // body.
+                //
+                // The abandoned gesture was not merely cosmetic. It is not
+                // committed by the next `disarm_gizmo` -- that pushes the
+                // pre-arm base against whatever the document already holds --
+                // but by the NEXT gizmo drag's release, because that press
+                // latches `pinned = placement` and adopts the stray placement
+                // as its starting point.
+                //
+                // Cancelled exactly as Escape cancels, rather than ignoring the
+                // press: ignoring it leaves the user in a modal drag with no
+                // exit that anything on screen tells them about.
+                if let Some(live) = &mut self.gizmo
+                    && live.grabbed.is_some()
+                    && self.drag.is_some_and(|drag| drag.button != button)
+                {
+                    live.placement = live.pinned;
+                    live.grabbed = None;
+                    self.drag = None;
+                    self.refresh_gizmo();
+                    self.status = "cancelled the drag".to_string();
+                    return;
+                }
 
                 // An open menu swallows the next press: closing it is what the
                 // click was for, and sculpting as well would be a surprise.
@@ -7475,6 +7680,17 @@ impl Brokkr {
             self.disarm_gizmo(true);
         }
         let task = self.dispatch(message);
+        // **Visibility is published BEFORE the re-arm, and the order is load
+        // bearing.** `arm_gizmo` refuses a body that is not drawn, and it asks
+        // `active_is_drawn`, which indexes `self.shown` by the node's position
+        // -- and `publish_visibility` is the only thing that writes it. Run the
+        // other way round, the message that ADDS a body arms against a `shown`
+        // that is one entry short, `get(index)` is `None`, `unwrap_or(false)`
+        // says hidden, and adding a cube with the Transform tool up refused
+        // with "that body is hidden -- turn its eye on to move it" and dropped
+        // the user back to Sculpt. The body was in the list, visible, eye on.
+        // Observed in the running application.
+        self.publish_visibility();
         // And the gizmo follows the active body. The guard above committed
         // whatever was in flight; this re-arms on whatever is active NOW, so
         // choosing a different row while the tool is up moves the gizmo there
@@ -7486,7 +7702,6 @@ impl Brokkr {
             self.status = why;
             self.tool = Tool::Sculpt;
         }
-        self.publish_visibility();
         task
     }
 
@@ -14150,6 +14365,158 @@ mod body_panel_tests {
         );
     }
 
+    /// **Toggling a mirror must rebuild the overlay, not just the flag.**
+    ///
+    /// `toggle_mirror` set `self.symmetry` and stopped. The planes are drawn by
+    /// `cursor::build` through `refresh_overlay`, which nothing called here, so
+    /// what stayed on screen was whatever the last refresh had produced --
+    /// turning X OFF left its plane drawn, and turning it back ON drew nothing
+    /// until some unrelated pointer motion rebuilt the batch. The planes were a
+    /// toggle behind.
+    ///
+    /// **`cursor.rs` already has `only_the_enabled_mirror_planes_are_drawn` and
+    /// it passed throughout**, because the geometry function was never wrong --
+    /// nothing checked that the hot path calls it. That is this project's
+    /// documented failure mode: a repair that is real, correct, unit-tested and
+    /// dead. So this asserts on what the RENDERER was handed, not on
+    /// `self.symmetry`, which was right the whole time.
+    #[test]
+    fn toggling_a_mirror_rebuilds_the_planes_the_renderer_holds() {
+        let mut app = app();
+        // A pointer event first, so there is a settled overlay to compare
+        // against rather than an empty one.
+        update(&mut app, Message::SymmetryAxisToggled(MirrorAxis::X));
+        let with_x = app.shared.overlay_snapshot();
+        assert!(app.symmetry.axis(MirrorAxis::X), "the fixture did not turn the mirror on");
+        assert!(
+            !with_x.is_empty(),
+            "the renderer holds no overlay at all after a mirror was turned on"
+        );
+
+        update(&mut app, Message::SymmetryAxisToggled(MirrorAxis::X));
+        let without_x = app.shared.overlay_snapshot();
+        assert!(!app.symmetry.axis(MirrorAxis::X), "the fixture did not turn the mirror off");
+        assert!(
+            without_x.surfaces.len() < with_x.surfaces.len(),
+            "the renderer still holds {} overlay surface vertices with the mirror off against {} with \
+             it on, so the plane is still being drawn for an axis that is now off",
+            without_x.surfaces.len(),
+            with_x.surfaces.len(),
+        );
+    }
+
+    /// **A body added with the Transform tool up must arm, not be called hidden.**
+    ///
+    /// `arm_gizmo` refuses a body that is not drawn, asking `active_is_drawn`,
+    /// which indexes `self.shown` by node position -- and `publish_visibility`
+    /// is the only thing that writes `self.shown`. It used to run AFTER the
+    /// re-arm, so the message that added a body armed against a `shown` one
+    /// entry short: `get(index)` was `None`, `unwrap_or(false)` said hidden,
+    /// and the add refused with "that body is hidden -- turn its eye on to move
+    /// it" and dropped the user back to Sculpt.
+    ///
+    /// Found by driving the running application: add a cube with the gizmo up
+    /// and the status says the body is hidden while the body is plainly in the
+    /// list, visible, with its eye on.
+    ///
+    /// The tool assertion is the one that matters. A wrong status line is
+    /// annoying; being silently thrown out of the mode you were working in is
+    /// the actual damage.
+    #[test]
+    fn adding_a_body_with_the_transform_tool_up_arms_on_it() {
+        let mut app = app();
+        update(&mut app, Message::ToolChanged(Tool::Transform));
+        assert!(app.gizmo.is_some(), "the fixture never armed on the first body");
+
+        update(&mut app, Message::PrimitiveAdded(PrimitiveKind::Cube));
+
+        assert_eq!(
+            app.tool,
+            Tool::Transform,
+            "adding a body threw the user out of the Transform tool: {}",
+            app.status
+        );
+        let armed = app.gizmo.expect("the gizmo should have re-armed on the new body");
+        assert_eq!(
+            armed.body,
+            app.doc.active(),
+            "the gizmo armed on something other than the body that was just added"
+        );
+        assert!(
+            !app.status.contains("hidden"),
+            "a visible body with its eye on was called hidden: {}",
+            app.status
+        );
+    }
+
+    /// **Undoing an added body must tell the renderer, or it is drawn for ever.**
+    ///
+    /// Reported from the running application: add a primitive, press ctrl+Z,
+    /// and the body leaves the BODIES list and stays on screen. Undo applies
+    /// `Change::NodeAdded`, which takes the node back out of the document; its
+    /// bricks are then in nobody's dirty set, so the remesh never touches them
+    /// and the pool goes on drawing a body nothing owns.
+    ///
+    /// `remove_body` had always forgotten a body it deleted. The history had no
+    /// equivalent, because `UndoOutcome::Applied` names only the FIRST node an
+    /// entry touched -- which is a different question from "what did this step
+    /// remove".
+    ///
+    /// **This is the mirror of the bug that shipped**, and it asserts the same
+    /// thing that one taught: what the RENDERER was told. A test that checked
+    /// only `doc.node(cube).is_none()` -- the DATA -- passes on the broken
+    /// build, because the data was never in doubt.
+    #[test]
+    fn undoing_an_added_body_tells_the_renderer_to_drop_it() {
+        let mut app = app();
+        update(&mut app, Message::PrimitiveAdded(PrimitiveKind::Cube));
+        let cube = app.doc.active();
+        let survivor = app.doc.nodes()[0].id;
+        // Whatever the add queued is not what is being measured.
+        let _ = app.shared.take_forgotten_for_tests();
+
+        update(&mut app, Message::Undo);
+
+        assert!(
+            app.doc.node(cube).is_none(),
+            "the fixture did not actually undo the add, so nothing below is exercised"
+        );
+        assert_eq!(
+            app.shared.take_forgotten_for_tests(),
+            vec![cube],
+            "undo removed the body from the document and left its slots in the pool, so it is \
+             still drawn with nothing in the BODIES list owning it"
+        );
+        assert!(
+            app.dirty.iter().any(|(body, _)| *body == survivor),
+            "the undo did not re-offer the surviving body, so a brick the pool refused while \
+             it was full stays missing with the banner gone"
+        );
+    }
+
+    /// And redo must put it back on screen, not merely back in the list.
+    #[test]
+    fn redoing_an_added_body_draws_it_again() {
+        let mut app = app();
+        update(&mut app, Message::PrimitiveAdded(PrimitiveKind::Cube));
+        let cube = app.doc.active();
+        update(&mut app, Message::Undo);
+        let _ = app.shared.take_forgotten_for_tests();
+
+        update(&mut app, Message::Redo);
+
+        assert!(app.doc.node(cube).is_some(), "redo did not put the body back in the document");
+        assert!(
+            app.shared.take_forgotten_for_tests().is_empty(),
+            "redo told the renderer to forget the body it had just restored"
+        );
+        assert!(
+            app.dirty.iter().any(|(body, _)| *body == cube),
+            "the restored body was never offered to the pool, so it is in the list and not on \
+             screen -- the same defect the other way round"
+        );
+    }
+
     /// **A delete owes the renderer two things, and neither is visible on
     /// screen if it is missing.**
     ///
@@ -19225,6 +19592,306 @@ mod gizmo_tests {
     }
 
     // ------------------------------------------------------- the whole point
+
+    /// **Coarsening the lattice must pull the camera up to the new floor.**
+    ///
+    /// `set_lattice` writes the voxel size and the content radius, from which
+    /// the distance floor and ceiling are derived, and never re-checked the
+    /// distance against them. One press of "coarser" from 0.25 mm takes the
+    /// floor from 0.500 to 2.000 with a floored camera still at 0.500, and the
+    /// next wheel notch INWARD then jumps it out to 2.000 and drags the target
+    /// four times away from its anchor -- a zoom in that flies backwards.
+    ///
+    /// The clamp also publishes, because neither `resample` nor `remove_body`
+    /// does and `Message::Frame` only publishes while a flight is running, so
+    /// the corrected distance would otherwise sit in `self.camera` while
+    /// `SharedFrame` held the old one. There is no camera getter on
+    /// `SharedFrame` to assert that through, so it is stated here rather than
+    /// claimed as a check.
+    #[test]
+    fn coarsening_the_lattice_pulls_the_camera_up_to_the_new_floor() {
+        let mut app = app();
+
+        // Put the camera on its floor at the current lattice.
+        app.camera.distance = app.camera.min_distance();
+        app.publish_camera();
+        let floor_before = app.camera.min_distance();
+        let sat_on_the_floor = app.camera.distance;
+
+        let coarse = app.doc.voxel_size() * 4.0;
+        app.doc.resample(coarse);
+        app.refresh_camera_lattice();
+
+        let floor_after = app.camera.min_distance();
+        assert!(
+            floor_after > floor_before * 2.0,
+            "the fixture did not actually raise the floor: {floor_before} then {floor_after}"
+        );
+        assert!(
+            sat_on_the_floor < floor_after,
+            "the camera was not under the new floor to begin with, so this tests nothing"
+        );
+        assert!(
+            app.camera.distance >= floor_after - 1.0e-6,
+            "the camera is at {} against a floor of {floor_after}, so the next notch inward \
+             will jump it outward",
+            app.camera.distance
+        );
+    }
+
+    /// **A squash after a turn must land on the axis the handle was drawn on.**
+    ///
+    /// `Similarity::then` composes `R2 R1 S2 S1`, so a scale composed onto a
+    /// rotation already in `pinned` squashes along the BODY's axes -- while the
+    /// gizmo drew its boxes, and took its drag direction, from the WORLD axes.
+    /// Measured on an ordinary quarter-turn-then-squash-to-0.6 with an
+    /// off-origin pivot: 8.49 mm between where the handle said the material
+    /// would go and where it went.
+    ///
+    /// **The default gesture reaches this.** `ROTATION_SNAP` is a quarter turn,
+    /// so an unshifted ring drag leaves a non-identity rotation in `placement`;
+    /// the next press latches it into `pinned` and any scale drag after that
+    /// composes onto it.
+    ///
+    /// Asserts the composed placement against the STEPWISE definition -- turn,
+    /// then squash along the body -- rather than against whatever the code
+    /// produces, because a test written the other way round canonises the bug.
+    #[test]
+    fn a_squash_after_a_quarter_turn_lands_on_the_axis_the_handle_was_drawn_on() {
+        let mut app = app();
+        arm(&mut app);
+
+        // A snapped quarter turn, which is the default unshifted ring drag.
+        turn_a_ring(&mut app, std::f32::consts::FRAC_PI_2);
+        let turned = app.gizmo.expect("armed").placement;
+        assert!(
+            turned.rotation.angle_between(glam::Quat::IDENTITY) > 0.1,
+            "the fixture did not actually turn the body: {:?}",
+            turned.rotation
+        );
+
+        let origin = app.gizmo.expect("armed").origin();
+        let scale = crate::gizmo::world_per_pixel(&app.camera, origin, SIZE.y);
+
+        // **The Y box, not the X one.** `turn_a_ring` grabs `Ring(0)` and so
+        // turns about X, which leaves X exactly where it was -- a fixture
+        // aimed at the X box passes on a broken build, which is what the first
+        // version of this test did.
+        let body_y = turned.rotation * Vec3::Y;
+        assert!(
+            body_y.distance(Vec3::Y) * (92.0 * scale) > 20.0 * scale,
+            "the turn moved the Y box by less than a grab radius, so the two placements are \
+             indistinguishable and this test cannot fail"
+        );
+
+        let at = project(&app, origin + body_y * (92.0 * scale));
+        assert_eq!(
+            crate::gizmo::pick(
+                &app.camera,
+                Vec2::new(SIZE.x, SIZE.y),
+                &app.gizmo.expect("armed"),
+                at
+            ),
+            Some(crate::gizmo::Handle::Scale(1)),
+            "after a turn the Y scale box is not where the body's own Y points, so the handle \
+             is drawn somewhere the squash will not go"
+        );
+    }
+
+    /// **A composed scale must not pass the floor on any axis.**
+    ///
+    /// The uniform handle bounded its floor against
+    /// `pinned.scale.max_element()`. After a per-axis squash to (1, 1, 0.05)
+    /// that reads 1.0 again, so the floor was computed as though nothing had
+    /// been squashed -- and `Similarity::then` multiplies scales component by
+    /// component, so the next uniform shrink composed to (0.05, 0.05, 0.0025):
+    /// twenty times under `MIN_SCALE`, which is precisely the state that
+    /// constant exists to prevent.
+    ///
+    /// The existing floor test drives `Handle::Uniform` only, so it cannot
+    /// reach this: the bug needs a per-axis squash FIRST to make the smallest
+    /// and largest axes disagree.
+    #[test]
+    fn a_squash_then_a_uniform_shrink_never_passes_the_floor_on_any_axis() {
+        let mut app = app();
+        arm(&mut app);
+        let origin = app.gizmo.expect("armed").origin();
+        let scale = crate::gizmo::world_per_pixel(&app.camera, origin, SIZE.y);
+
+        // Squash X as far inward as the handle allows.
+        let box_at = project(&app, origin + Vec3::X * (92.0 * scale));
+        let inward = project(&app, origin + Vec3::X * (0.5 * scale));
+        gesture(&mut app, box_at, &[inward]);
+        let squashed = app.gizmo.expect("armed").placement.scale;
+        assert!(
+            squashed.min_element() < 0.5,
+            "the fixture did not actually squash an axis: {squashed:?}"
+        );
+
+        // Then drag the centre handle inward, which composes onto it. The
+        // press has to land within `CENTRE_PX + GRAB_PX` of the middle to
+        // select `Uniform` at all, so the shrink is the RATIO of two short
+        // radii rather than a long sweep.
+        let centre = project(&app, origin);
+        gesture(&mut app, centre + Vec2::new(14.0, 0.0), &[centre + Vec2::new(1.0, 0.0)]);
+
+        let composed = app.gizmo.expect("armed").placement.scale;
+        assert!(
+            composed.min_element() >= crate::gizmo::MIN_SCALE - 1.0e-6,
+            "the composed scale {composed:?} fell to {} on its smallest axis, under the {} floor",
+            composed.min_element(),
+            crate::gizmo::MIN_SCALE,
+        );
+    }
+
+    /// **A second button down during a live transform abandons it.**
+    ///
+    /// There was no `self.drag.is_some()` guard on `Pressed`, so a right press
+    /// assigned an Orbit drag over a live `Transforming` one while
+    /// `gizmo.grabbed` and the partial `placement` survived. The right release
+    /// then took the Orbit arm, the Transforming arm never ran, and the left
+    /// release found no drag: the handle stayed lit and the gizmo floated away
+    /// from its body.
+    ///
+    /// The stray placement is not committed by the next `disarm_gizmo` -- that
+    /// pushes the pre-arm base -- but by the NEXT drag's release, because that
+    /// press latches `pinned = placement` and adopts it.
+    #[test]
+    fn a_second_button_during_a_transform_drag_abandons_it() {
+        let mut app = app();
+        arm(&mut app);
+        let pinned = app.gizmo.expect("armed").pinned;
+
+        let origin = app.gizmo.expect("armed").origin();
+        let scale = crate::gizmo::world_per_pixel(&app.camera, origin, SIZE.y);
+        let radius = crate::gizmo::RING_PX * scale;
+        let from = project(&app, origin + Vec3::Z * radius);
+        let to = project(&app, origin + (Vec3::Z * 0.9f32.cos() + Vec3::X * 0.9f32.sin()) * radius);
+
+        moved(&mut app, from);
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Left,
+            position: Vector::new(from.x, from.y),
+            size: SIZE,
+        });
+        moved(&mut app, to);
+        assert!(
+            app.gizmo.expect("armed").grabbed.is_some(),
+            "the fixture never grabbed a handle, so nothing below is exercised"
+        );
+
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Right,
+            position: Vector::new(to.x, to.y),
+            size: SIZE,
+        });
+
+        let live = app.gizmo.expect("still armed");
+        assert!(live.grabbed.is_none(), "the handle is still held after a second button went down");
+        assert_eq!(live.placement, pinned, "the abandoned gesture survived in the placement");
+        assert!(app.drag.is_none(), "a drag survived the cancel");
+    }
+
+    /// **Moving the camera under a held handle must not move the body.**
+    ///
+    /// `gizmo::drag` rebuilds both rays from the current camera, so a scroll, a
+    /// SpaceMouse nudge or a navigation-cube flight still in the air
+    /// re-interprets the pixel the button went down on. Measured before the
+    /// fix: the X-axis offset walked 5.4696 mm to 6.5737 mm for a 0.4 radian
+    /// yaw with the pointer stationary.
+    ///
+    /// **The axis arrow, not a ring, and shift is held.** `Ring(1)` under a
+    /// pure yaw orbit is exactly immune -- yaw is a rotation about that ring's
+    /// own axis -- so a ring fixture passes on a broken build, which is what
+    /// the first version of this test did. And with snapping on, a drift
+    /// smaller than half a snap step rounds away and hides the same bug.
+    #[test]
+    fn a_camera_nudge_during_a_transform_drag_does_not_move_the_body() {
+        let mut app = app();
+        arm(&mut app);
+
+        let (grip, along) = x_shaft_grip(&app);
+        let free = app.shift;
+        app.shift = true;
+        moved(&mut app, grip);
+        app.on_pointer(PointerEvent::Pressed {
+            button: PointerButton::Left,
+            position: Vector::new(grip.x, grip.y),
+            size: SIZE,
+        });
+        moved(&mut app, grip + along * 40.0);
+        assert!(
+            app.gizmo.expect("armed").grabbed.is_some(),
+            "the fixture never grabbed the axis arrow, so nothing below is exercised"
+        );
+        let before = app.gizmo.expect("armed").placement.translation;
+        assert!(
+            before.length() > 0.5,
+            "the drag moved the body by {} mm, too little to see a drift against",
+            before.length()
+        );
+
+        // The camera moves, and then the SAME pixel is reported again. The
+        // placement only changes on a `Moved` event, so the damage does not
+        // appear at the moment the camera turns -- it appears on the next
+        // pointer report, when `gizmo::drag` re-interprets the press pixel
+        // through the new camera. A test that only orbits and looks passes on
+        // a broken build, which is what the first version of this did.
+        app.camera.orbit_radians(Vec2::new(0.4, 0.0));
+        app.publish_camera();
+        moved(&mut app, grip + along * 40.0);
+        let after = app.gizmo.expect("armed").placement.translation;
+
+        assert!(
+            (after - before).length() <= 1.0e-3,
+            "the body moved {} mm because the camera did, with the pointer stationary \
+             ({before:?} then {after:?})",
+            (after - before).length()
+        );
+        app.shift = free;
+    }
+
+    /// **A press and release that moved nothing must not touch the field.**
+    ///
+    /// The Released arm calls `rebake_gizmo` for any `Transforming` drag with
+    /// no reference to whether anything moved, and the bake always restarts
+    /// from `gizmo_base` -- so an accidental click reproduced a bit-identical
+    /// field at full price: 159 ms of warp and 7.1 s of repair on the largest
+    /// arm-able body, plus a document-wide remesh and a stale thumbnail.
+    ///
+    /// `Bake::Identity` does not cover this. It fires only when the placement
+    /// is the identity outright; after any earlier transform in the session the
+    /// placement is a real one that simply has not changed since it was baked.
+    /// So this fixture turns a ring FIRST, and only then does the empty press.
+    #[test]
+    fn a_press_and_release_with_no_motion_does_not_re_bake_the_body() {
+        let mut app = app();
+        arm(&mut app);
+
+        // Put a real, non-identity placement in first, or the pre-existing
+        // identity short circuit would carry this test and it would pass on a
+        // build without the fix.
+        turn_a_ring(&mut app, 0.35);
+        let placement = app.gizmo.expect("armed").placement;
+        assert!(
+            placement.route(app.doc.voxel_size()).is_lossy(),
+            "the fixture snapped to the identity, so the cheap path would cover it anyway"
+        );
+
+        let before = warps_made_on_this_thread();
+        // A press and release on the same pixel, on a handle.
+        let gizmo = app.gizmo.expect("armed");
+        let origin = gizmo.origin();
+        let scale = crate::gizmo::world_per_pixel(&app.camera, origin, SIZE.y);
+        let at = project(&app, origin + Vec3::Z * (crate::gizmo::RING_PX * scale));
+        gesture(&mut app, at, &[at]);
+
+        assert_eq!(
+            warps_made_on_this_thread() - before,
+            0,
+            "a press and release that moved nothing still re-baked the body"
+        );
+    }
 
     /// **The test the entire anti-degradation design exists for.**
     ///

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -192,6 +192,15 @@ impl Brokkr {
         .spacing(theme::S3)
         .padding(theme::S3);
 
+        // **Above everything**, and it is the only card that can be. It is
+        // raised at startup before any other state can ask for a card, and
+        // reopened only from the Help menu, so nothing it could cover is
+        // waiting on an answer. Ranking it lower would let the unsaved-work
+        // prompt draw over a screen that has not been dismissed yet.
+        if self.welcome {
+            return stack![body, self.welcome_card(), self.resize_frame()].into();
+        }
+
         // The unsaved-work prompt outranks an open menu: it is modal, and a
         // menu drawn over it would be reachable while the prompt is not.
         if let Some(pending) = &self.confirm {
@@ -471,6 +480,157 @@ impl Brokkr {
         modal_layer(card)
     }
 
+    /// The welcome screen.
+    ///
+    /// Two columns, as SindriCAD's is: what to do down the left, something to
+    /// read down the right, "show this on startup" along the foot. See
+    /// [`crate::welcome`] for what did not come across from that one and why --
+    /// briefly, there is no webview to put its remote pane in and no sign-in to
+    /// put its account row in.
+    ///
+    /// The right column is the substitution that matters. SindriCAD's is a
+    /// news page fetched from TinkerAtlas; this is the keys, because there is
+    /// no manual yet and a beta is the moment people meet them for the first
+    /// time. It is deliberately short: a wall of text on a modal is read by
+    /// nobody, and everything here is also discoverable in the interface.
+    fn welcome_card(&self) -> Element<'_, Message> {
+        let lockup = row![
+            crate::logo::mark(32.0),
+            rich_text::<(), Message, _, _>([
+                span("Brokkr").color(theme::TEXT),
+                span("SCULPT").color(theme::ACCENT),
+            ])
+            .size(theme::TEXT_SIZE),
+        ]
+        .spacing(theme::S3)
+        .align_y(Alignment::Center);
+
+        type ButtonStyle = fn(&iced::Theme, button::Status) -> button::Style;
+        let action = |label: &'static str, message: Message, style: ButtonStyle| {
+            button(text(label).size(theme::TEXT_SIZE))
+                .width(Length::Fill)
+                .padding(Padding {
+                    top: theme::S2,
+                    bottom: theme::S2,
+                    left: theme::S4,
+                    right: theme::S4,
+                })
+                .style(style)
+                .on_press(message)
+        };
+
+        let mut left = column![
+            action("New sculpt", Message::NewSculpt, theme::tool_button_active),
+            action("Open…", Message::OpenRequested, theme::tool_button),
+            action("Import mesh…", Message::ImportRequested, theme::tool_button),
+        ]
+        .spacing(theme::S2)
+        .width(Length::Fixed(220.0));
+
+        // The recent list, exactly as SindriCAD presents it: the file name
+        // first and the directory under it, because the name is what anyone
+        // scans for and the directory is only ever the tiebreak.
+        let recent = self.recent.paths();
+        if !recent.is_empty() {
+            left = left.push(space::vertical().height(theme::S3));
+            left = left.push(text("Recent").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM));
+            for path in recent.iter().take(6) {
+                let name = shorten(
+                    &path
+                        .file_name()
+                        .map(|name| name.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| path.to_string_lossy().into_owned()),
+                );
+                let folder = shorten(
+                    &path
+                        .parent()
+                        .map(|dir| dir.to_string_lossy().into_owned())
+                        .unwrap_or_default(),
+                );
+                left = left.push(
+                    button(
+                        column![
+                            text(name).size(theme::TEXT_SIZE).color(theme::TEXT),
+                            text(folder).size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+                        ]
+                        .spacing(1),
+                    )
+                    .width(Length::Fill)
+                    .padding(Padding {
+                        top: theme::S2,
+                        bottom: theme::S2,
+                        left: theme::S3,
+                        right: theme::S3,
+                    })
+                    .style(theme::tool_button)
+                    .on_press(Message::OpenRecent(path.clone())),
+                );
+            }
+        }
+
+        let key = |keys: &'static str, what: &'static str| {
+            row![
+                container(text(keys).size(theme::TEXT_SIZE_SMALL).color(theme::ACCENT))
+                    .width(Length::Fixed(96.0)),
+                text(what).size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+            ]
+            .spacing(theme::S2)
+        };
+
+        let right = column![
+            text("A sculpting tool for people who print what they make.")
+                .size(theme::TEXT_SIZE)
+                .color(theme::TEXT),
+            space::vertical().height(theme::S2),
+            key("1 – 7", "pick a brush"),
+            key("shift", "smooth, while held"),
+            key("ctrl / alt", "carve instead of add"),
+            key("[ and ]", "brush size"),
+            key("s / u drag", "size and strength"),
+            key("x y z", "mirror across a plane"),
+            key("w", "move, turn and scale a body"),
+            key("m", "mask, to protect what you have"),
+            key("ctrl+Z", "undo, one whole stroke at a time"),
+            space::vertical().height(theme::S2),
+            text(
+                "Right-click the model for the current tool's settings, and the cube \
+                  top-right to look from a named direction."
+            )
+            .size(theme::TEXT_SIZE_SMALL)
+            .color(theme::TEXT_DIM),
+        ]
+        .spacing(theme::S1)
+        .width(Length::Fixed(320.0));
+
+        let foot = row![
+            checkbox(crate::welcome::on_startup())
+                .label("Show this screen on startup")
+                .on_toggle(Message::WelcomeOnStartupSet)
+                .text_size(theme::TEXT_SIZE_SMALL),
+            space::horizontal(),
+            button(text("Close").size(theme::TEXT_SIZE))
+                .padding(Padding {
+                    top: theme::S2,
+                    bottom: theme::S2,
+                    left: theme::S5,
+                    right: theme::S5
+                })
+                .style(theme::tool_button)
+                .on_press(Message::WelcomeClosed),
+        ]
+        .align_y(Alignment::Center)
+        .spacing(theme::S3);
+
+        let card = container(
+            column![lockup, row![left, right].spacing(theme::S5), foot,].spacing(theme::S5),
+        )
+        .padding(theme::S5)
+        .max_width(640.0)
+        .style(theme::menu_card);
+
+        modal_layer(card)
+    }
+
     /// The bug report dialog.
     ///
     /// It shows the payload rather than describing it. `diagnostics` was
@@ -670,6 +830,7 @@ impl Brokkr {
                     .color(theme::TEXT_MUTE),
                 text("AGPL-3.0-only").size(theme::CAPTION_SIZE).color(theme::TEXT_MUTE),
                 separator(),
+                entry("Welcome screen", Message::WelcomeOpened),
                 entry("Copy diagnostics", Message::DiagnosticsCopied),
                 entry("Report a bug…", Message::BugReportOpened),
                 entry("Open the issue tracker", Message::IssueOpened),
@@ -2999,6 +3160,27 @@ impl Brokkr {
 ///
 /// The window's resize strips are stacked *above* the card in `view`, so they
 /// keep working: reverse traversal reaches them first.
+/// Cut a path down so it cannot push a column wider than it was given.
+///
+/// **iced has no ellipsis and a `Length::Fixed` column does not clip its
+/// children**, so a long path is not merely ugly -- it grows the row and shoves
+/// the column beside it off its own layout. Observed on the welcome screen with
+/// a recent file under `/mnt/.../Meshy_AI_Dragonstone_Carver_08232143232…`,
+/// which ran straight through the keys listed next to it.
+///
+/// The TAIL is kept, because that is the informative end of a path: the leaf
+/// directory says which project, and the root says only that it is on a disk.
+fn shorten(text: &str) -> String {
+    /// Roughly what fits in the recent column at `TEXT_SIZE_SMALL`.
+    const MAX_CHARS: usize = 34;
+    let count = text.chars().count();
+    if count <= MAX_CHARS {
+        return text.to_string();
+    }
+    let tail: String = text.chars().skip(count - (MAX_CHARS - 1)).collect();
+    format!("…{tail}")
+}
+
 fn modal_layer<'a>(card: impl Into<Element<'a, Message>>) -> Element<'a, Message> {
     opaque(
         container(card)

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -627,15 +627,16 @@ impl Brokkr {
                     .width(Length::Fill);
 
                     let inside: Element<'_, Message> = match &article.thumbnail {
-                        Some(thumb) => row![
+                        // Cloning the HANDLE and not the pixels: it is
+                        // refcounted and keeps its id, so the renderer's atlas
+                        // entry survives the frame. Building a handle here
+                        // instead would mint a new id every frame and re-upload
+                        // every thumbnail. See `articles::Article::thumbnail`.
+                        Some(handle) => row![
                             container(
-                                iced::widget::image(iced::widget::image::Handle::from_rgba(
-                                    thumb.width,
-                                    thumb.height,
-                                    thumb.rgba.clone(),
-                                ))
-                                .width(Length::Fixed(THUMB_PX))
-                                .content_fit(iced::ContentFit::Cover),
+                                iced::widget::image(handle.clone())
+                                    .width(Length::Fixed(THUMB_PX))
+                                    .content_fit(iced::ContentFit::Cover),
                             )
                             .clip(true)
                             .width(Length::Fixed(THUMB_PX))
@@ -677,7 +678,7 @@ impl Brokkr {
         .width(Length::Fixed(340.0));
 
         let foot = row![
-            checkbox(crate::welcome::on_startup())
+            checkbox(self.welcome_on_startup)
                 .label("Show this screen on startup")
                 .on_toggle(Message::WelcomeOnStartupSet)
                 .text_size(theme::TEXT_SIZE_SMALL),
@@ -3244,30 +3245,6 @@ impl Brokkr {
     }
 }
 
-/// Centre a modal card on a layer that dims the application and swallows the
-/// presses that would otherwise reach it.
-///
-/// # The dimming was never the part that made it modal
-///
-/// Every one of the three cards used to build this shape itself, with a
-/// comment saying the scrim "swallows presses". It did not. `theme::scrim` is
-/// a `container` *style*, and `container::update`
-/// (`iced_widget-0.14.2/src/container.rs:298`) forwards the event to its child
-/// and returns — it never calls `shell.capture_event`, so a press over the
-/// dimmed area travelled straight on to the shader widget underneath and
-/// sculpted the model the card was asking about. `iced::widget::opaque` is the
-/// piece that was missing: it captures mouse presses inside its bounds
-/// (`helpers.rs:577`), and `Stack::update` walks its children topmost-first and
-/// stops at the first capture (`stack.rs:249-264`), so the layers below never
-/// see it.
-///
-/// This is a legal capture under the rule the viewport is written to: **only
-/// bounds-checked events may capture**. `opaque` captures presses only, only
-/// when the cursor is over it — never a move and never a release, so a drag
-/// that started before the card appeared still ends properly.
-///
-/// The window's resize strips are stacked *above* the card in `view`, so they
-/// keep working: reverse traversal reaches them first.
 /// How wide an article thumbnail is drawn, in logical pixels.
 ///
 /// Half what the server is asked for, so the picture still has pixels to spare
@@ -3295,6 +3272,30 @@ fn shorten(text: &str) -> String {
     format!("…{tail}")
 }
 
+/// Centre a modal card on a layer that dims the application and swallows the
+/// presses that would otherwise reach it.
+///
+/// # The dimming was never the part that made it modal
+///
+/// Every one of the three cards used to build this shape itself, with a
+/// comment saying the scrim "swallows presses". It did not. `theme::scrim` is
+/// a `container` *style*, and `container::update`
+/// (`iced_widget-0.14.2/src/container.rs:298`) forwards the event to its child
+/// and returns — it never calls `shell.capture_event`, so a press over the
+/// dimmed area travelled straight on to the shader widget underneath and
+/// sculpted the model the card was asking about. `iced::widget::opaque` is the
+/// piece that was missing: it captures mouse presses inside its bounds
+/// (`helpers.rs:577`), and `Stack::update` walks its children topmost-first and
+/// stops at the first capture (`stack.rs:249-264`), so the layers below never
+/// see it.
+///
+/// This is a legal capture under the rule the viewport is written to: **only
+/// bounds-checked events may capture**. `opaque` captures presses only, only
+/// when the cursor is over it — never a move and never a release, so a drag
+/// that started before the card appeared still ends properly.
+///
+/// The window's resize strips are stacked *above* the card in `view`, so they
+/// keep working: reverse traversal reaches them first.
 fn modal_layer<'a>(card: impl Into<Element<'a, Message>>) -> Element<'a, Message> {
     opaque(
         container(card)

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -568,39 +568,86 @@ impl Brokkr {
             }
         }
 
-        let key = |keys: &'static str, what: &'static str| {
-            row![
-                container(text(keys).size(theme::TEXT_SIZE_SMALL).color(theme::ACCENT))
-                    .width(Length::Fixed(96.0)),
-                text(what).size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+        // **The articles, which is what SindriCAD's right column is.** It
+        // embeds the site in an iframe; there is no webview here, so the same
+        // articles arrive as data and are drawn with the same widgets as
+        // everything else. Three states, as that one has: asking, answered, and
+        // unreachable with a retry.
+        let right: Element<'_, Message> = match &self.feed {
+            crate::articles::Feed::Idle | crate::articles::Feed::Loading => column![
+                text("From TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+                text("Fetching the latest articles…")
+                    .size(theme::TEXT_SIZE_SMALL)
+                    .color(theme::TEXT_MUTE),
             ]
             .spacing(theme::S2)
+            .into(),
+            crate::articles::Feed::Failed(why) => column![
+                text("From TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+                // Says which way it failed rather than "offline": a 503 and no
+                // route are different problems and only one of them is yours.
+                text(why.clone()).size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_MUTE),
+                button(text("Try again").size(theme::TEXT_SIZE_SMALL))
+                    .padding(Padding {
+                        top: theme::S1,
+                        bottom: theme::S1,
+                        left: theme::S3,
+                        right: theme::S3
+                    })
+                    .style(theme::tool_button)
+                    .on_press(Message::ArticlesRetried),
+            ]
+            .spacing(theme::S2)
+            .into(),
+            crate::articles::Feed::Ready(articles) if articles.is_empty() => column![
+                text("From TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+                text("Nothing published yet.").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_MUTE),
+            ]
+            .spacing(theme::S2)
+            .into(),
+            crate::articles::Feed::Ready(articles) => {
+                let mut list = column![
+                    text("From TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+                ]
+                .spacing(theme::S2);
+                for article in articles {
+                    list = list.push(
+                        button(
+                            column![
+                                text(article.title.clone())
+                                    .size(theme::TEXT_SIZE)
+                                    .color(theme::TEXT),
+                                text(article.summary.clone())
+                                    .size(theme::CAPTION_SIZE)
+                                    .color(theme::TEXT_DIM),
+                                text(article.date.clone())
+                                    .size(theme::CAPTION_SIZE)
+                                    .color(theme::TEXT_MUTE),
+                            ]
+                            .spacing(2),
+                        )
+                        .width(Length::Fill)
+                        .padding(Padding {
+                            top: theme::S2,
+                            bottom: theme::S2,
+                            left: theme::S3,
+                            right: theme::S3,
+                        })
+                        .style(theme::tool_button)
+                        .on_press(Message::ArticleOpened(article.link.clone())),
+                    );
+                }
+                list.into()
+            }
         };
-
         let right = column![
             text("A sculpting tool for people who print what they make.")
                 .size(theme::TEXT_SIZE)
                 .color(theme::TEXT),
-            space::vertical().height(theme::S2),
-            key("1 – 7", "pick a brush"),
-            key("shift", "smooth, while held"),
-            key("ctrl / alt", "carve instead of add"),
-            key("[ and ]", "brush size"),
-            key("s / u drag", "size and strength"),
-            key("x y z", "mirror across a plane"),
-            key("w", "move, turn and scale a body"),
-            key("m", "mask, to protect what you have"),
-            key("ctrl+Z", "undo, one whole stroke at a time"),
-            space::vertical().height(theme::S2),
-            text(
-                "Right-click the model for the current tool's settings, and the cube \
-                  top-right to look from a named direction."
-            )
-            .size(theme::TEXT_SIZE_SMALL)
-            .color(theme::TEXT_DIM),
+            right,
         ]
-        .spacing(theme::S1)
-        .width(Length::Fixed(320.0));
+        .spacing(theme::S3)
+        .width(Length::Fixed(340.0));
 
         let foot = row![
             checkbox(crate::welcome::on_startup())
@@ -621,8 +668,42 @@ impl Brokkr {
         .align_y(Alignment::Center)
         .spacing(theme::S3);
 
+        // **The keys stay.** They are the one thing a first-time user cannot get
+        // anywhere else -- there is no manual -- and they are cheap here: a
+        // strip under the two columns rather than a third column, so neither
+        // the actions nor the articles lose width to them.
+        let key = |keys: &'static str, what: &'static str| {
+            row![
+                container(text(keys).size(theme::CAPTION_SIZE).color(theme::ACCENT))
+                    .width(Length::Fixed(72.0)),
+                text(what).size(theme::CAPTION_SIZE).color(theme::TEXT_DIM),
+            ]
+            .spacing(theme::S2)
+        };
+        let keys = row![
+            column![
+                key("1 – 7", "pick a brush"),
+                key("shift", "smooth, while held"),
+                key("ctrl / alt", "carve instead of add"),
+                key("[ and ]", "brush size"),
+                key("s / u drag", "size and strength"),
+            ]
+            .spacing(2)
+            .width(Length::Fill),
+            column![
+                key("x y z", "mirror across a plane"),
+                key("w", "move, turn and scale a body"),
+                key("m", "mask, to protect what you have"),
+                key("ctrl+Z", "undo, a whole stroke at a time"),
+                key("right-click", "the current tool's settings"),
+            ]
+            .spacing(2)
+            .width(Length::Fill),
+        ]
+        .spacing(theme::S4);
+
         let card = container(
-            column![lockup, row![left, right].spacing(theme::S5), foot,].spacing(theme::S5),
+            column![lockup, row![left, right].spacing(theme::S5), keys, foot,].spacing(theme::S4),
         )
         .padding(theme::S5)
         .max_width(640.0)

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -611,30 +611,57 @@ impl Brokkr {
                 ]
                 .spacing(theme::S2);
                 for article in articles {
+                    // **The picture and the headline, and no summary.** The
+                    // summary is what made this a wall of text: four articles
+                    // of prose in a column beside three buttons reads as
+                    // something to get past rather than something to look at.
+                    // The page this mirrors shows a thumbnail, a title and a
+                    // date, and that is the whole row.
+                    let words = column![
+                        text(article.title.clone()).size(theme::TEXT_SIZE).color(theme::TEXT),
+                        text(article.date.clone())
+                            .size(theme::CAPTION_SIZE)
+                            .color(theme::TEXT_MUTE),
+                    ]
+                    .spacing(2)
+                    .width(Length::Fill);
+
+                    let inside: Element<'_, Message> = match &article.thumbnail {
+                        Some(thumb) => row![
+                            container(
+                                iced::widget::image(iced::widget::image::Handle::from_rgba(
+                                    thumb.width,
+                                    thumb.height,
+                                    thumb.rgba.clone(),
+                                ))
+                                .width(Length::Fixed(THUMB_PX))
+                                .content_fit(iced::ContentFit::Cover),
+                            )
+                            .clip(true)
+                            .width(Length::Fixed(THUMB_PX))
+                            .height(Length::Fixed(THUMB_PX * 9.0 / 16.0)),
+                            words,
+                        ]
+                        .spacing(theme::S3)
+                        .align_y(Alignment::Center)
+                        .into(),
+                        // No picture is an ordinary outcome, so the row simply
+                        // has none rather than a placeholder that would draw
+                        // the eye to what is missing.
+                        None => words.into(),
+                    };
+
                     list = list.push(
-                        button(
-                            column![
-                                text(article.title.clone())
-                                    .size(theme::TEXT_SIZE)
-                                    .color(theme::TEXT),
-                                text(article.summary.clone())
-                                    .size(theme::CAPTION_SIZE)
-                                    .color(theme::TEXT_DIM),
-                                text(article.date.clone())
-                                    .size(theme::CAPTION_SIZE)
-                                    .color(theme::TEXT_MUTE),
-                            ]
-                            .spacing(2),
-                        )
-                        .width(Length::Fill)
-                        .padding(Padding {
-                            top: theme::S2,
-                            bottom: theme::S2,
-                            left: theme::S3,
-                            right: theme::S3,
-                        })
-                        .style(theme::tool_button)
-                        .on_press(Message::ArticleOpened(article.link.clone())),
+                        button(inside)
+                            .width(Length::Fill)
+                            .padding(Padding {
+                                top: theme::S2,
+                                bottom: theme::S2,
+                                left: theme::S2,
+                                right: theme::S3,
+                            })
+                            .style(theme::tool_button)
+                            .on_press(Message::ArticleOpened(article.link.clone())),
                     );
                 }
                 list.into()
@@ -3241,6 +3268,12 @@ impl Brokkr {
 ///
 /// The window's resize strips are stacked *above* the card in `view`, so they
 /// keep working: reverse traversal reaches them first.
+/// How wide an article thumbnail is drawn, in logical pixels.
+///
+/// Half what the server is asked for, so the picture still has pixels to spare
+/// on a HiDPI output. See `articles::THUMB_WIDTH`.
+const THUMB_PX: f32 = 120.0;
+
 /// Cut a path down so it cannot push a column wider than it was given.
 ///
 /// **iced has no ellipsis and a `Length::Fixed` column does not clip its

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -1392,81 +1392,95 @@ impl Brokkr {
         let (move_style, move_ink) = theme::tool_toggle(self.tool == Tool::Transform);
 
         container(
-            column![
-                text("TOOL").size(theme::CAPTION_SIZE).color(theme::TEXT_MUTE),
-                brushes,
-                text("MIRROR").size(theme::CAPTION_SIZE).color(theme::TEXT_MUTE),
-                mirrors,
-                text("MODE").size(theme::CAPTION_SIZE).color(theme::TEXT_MUTE),
-                // The live state is shown in the strip, not just in the status
-                // line, because **these are the two modes that change what a
-                // left drag does, and only one of the two is destructive.**
-                // (That sentence used to read "this is the one mode", here and
-                // in `handoff.md`; masking made both halves false.) That
-                // asymmetry is also why Escape clears the cut and not the mask:
-                // a cut is a pending destructive thing, a mask is expensive
-                // work with no undo entry until the stroke lands.
-                //
-                // The words stay for exactly that reason: "armed" versus
-                // "plane" is a state, and an icon says which tool this is, not
-                // whether it is about to go off.
-                button(
-                    column![
-                        icon::icon(icon::IconName::CutPlane, theme::ICON_TOOL, cut_ink),
-                        text(if self.tool == Tool::Cut { "armed" } else { "plane" })
+            scrollable(
+                column![
+                    text("TOOL").size(theme::CAPTION_SIZE).color(theme::TEXT_MUTE),
+                    brushes,
+                    text("MIRROR").size(theme::CAPTION_SIZE).color(theme::TEXT_MUTE),
+                    mirrors,
+                    text("MODE").size(theme::CAPTION_SIZE).color(theme::TEXT_MUTE),
+                    // The live state is shown in the strip, not just in the status
+                    // line, because **these are the two modes that change what a
+                    // left drag does, and only one of the two is destructive.**
+                    // (That sentence used to read "this is the one mode", here and
+                    // in `handoff.md`; masking made both halves false.) That
+                    // asymmetry is also why Escape clears the cut and not the mask:
+                    // a cut is a pending destructive thing, a mask is expensive
+                    // work with no undo entry until the stroke lands.
+                    //
+                    // The words stay for exactly that reason: "armed" versus
+                    // "plane" is a state, and an icon says which tool this is, not
+                    // whether it is about to go off.
+                    button(
+                        column![
+                            icon::icon(icon::IconName::CutPlane, theme::ICON_TOOL, cut_ink),
+                            text(if self.tool == Tool::Cut { "armed" } else { "plane" })
+                                .size(theme::TEXT_SIZE_SMALL),
+                        ]
+                        .width(Length::Fill)
+                        .spacing(0)
+                        .align_x(Alignment::Center)
+                    )
+                    .width(Length::Fill)
+                    .style(cut_style)
+                    .on_press(Message::ToolChanged(Tool::Cut)),
+                    button(
+                        column![
+                            icon::icon(icon::IconName::Mask, theme::ICON_TOOL, mask_ink),
+                            // The same live substitution the brush buttons make for
+                            // Smooth: while shift is held a mask drag blurs, so the
+                            // button says what the next drag will actually do.
+                            text(match (self.tool == Tool::Mask, smoothing) {
+                                (true, true) => "blur",
+                                (true, false) => "on",
+                                (false, _) => "mask",
+                            })
                             .size(theme::TEXT_SIZE_SMALL),
-                    ]
+                        ]
+                        .width(Length::Fill)
+                        .spacing(0)
+                        .align_x(Alignment::Center)
+                    )
                     .width(Length::Fill)
-                    .spacing(0)
-                    .align_x(Alignment::Center)
-                )
-                .width(Length::Fill)
-                .style(cut_style)
-                .on_press(Message::ToolChanged(Tool::Cut)),
-                button(
-                    column![
-                        icon::icon(icon::IconName::Mask, theme::ICON_TOOL, mask_ink),
-                        // The same live substitution the brush buttons make for
-                        // Smooth: while shift is held a mask drag blurs, so the
-                        // button says what the next drag will actually do.
-                        text(match (self.tool == Tool::Mask, smoothing) {
-                            (true, true) => "blur",
-                            (true, false) => "on",
-                            (false, _) => "mask",
-                        })
-                        .size(theme::TEXT_SIZE_SMALL),
-                    ]
+                    .style(mask_style)
+                    .on_press(Message::ToolChanged(Tool::Mask)),
+                    // The third mode that changes what a left drag does. The word
+                    // under it says whether the next release will cost the surface
+                    // anything, which is the one thing about this tool a user
+                    // cannot see by looking at the model.
+                    button(
+                        column![
+                            icon::icon(icon::IconName::Gizmo, theme::ICON_TOOL, move_ink),
+                            text(match self.tool == Tool::Transform {
+                                true if smoothing => "free",
+                                true => "snap",
+                                false => "move",
+                            })
+                            .size(theme::TEXT_SIZE_SMALL),
+                        ]
+                        .width(Length::Fill)
+                        .spacing(0)
+                        .align_x(Alignment::Center)
+                    )
                     .width(Length::Fill)
-                    .spacing(0)
-                    .align_x(Alignment::Center)
-                )
-                .width(Length::Fill)
-                .style(mask_style)
-                .on_press(Message::ToolChanged(Tool::Mask)),
-                // The third mode that changes what a left drag does. The word
-                // under it says whether the next release will cost the surface
-                // anything, which is the one thing about this tool a user
-                // cannot see by looking at the model.
-                button(
-                    column![
-                        icon::icon(icon::IconName::Gizmo, theme::ICON_TOOL, move_ink),
-                        text(match self.tool == Tool::Transform {
-                            true if smoothing => "free",
-                            true => "snap",
-                            false => "move",
-                        })
-                        .size(theme::TEXT_SIZE_SMALL),
-                    ]
-                    .width(Length::Fill)
-                    .spacing(0)
-                    .align_x(Alignment::Center)
-                )
-                .width(Length::Fill)
-                .style(move_style)
-                .on_press(Message::ToolChanged(Tool::Transform)),
-            ]
-            .spacing(theme::S3)
-            .align_x(Alignment::Center),
+                    .style(move_style)
+                    .on_press(Message::ToolChanged(Tool::Transform)),
+                ]
+                .spacing(theme::S3)
+                .align_x(Alignment::Center),
+            )
+            // **The strip outgrew the window and the last button was clipped to
+            // a sliver.** Its own doc comment above predicted this -- "one
+            // screenshot at 768 settles it properly and none has been taken" --
+            // and then the gizmo added a fourth mode button and the prediction
+            // came true: Thomas found the tool only by noticing the sliver.
+            //
+            // Scrollable rather than smaller, for the same reason the
+            // properties panel is: shrinking type or dropping the words under
+            // the icons would bet the tool picker on telling clay from draw at
+            // eighteen pixels, which the brush buttons above explicitly refuse
+            // to do. The scrollbar is only reachable when it is needed.
+            .height(Length::Fill),
         )
         .padding(theme::S3)
         .width(Length::Fixed(76.0))

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -573,17 +573,14 @@ impl Brokkr {
         // articles arrive as data and are drawn with the same widgets as
         // everything else. Three states, as that one has: asking, answered, and
         // unreachable with a retry.
-        let right: Element<'_, Message> = match &self.feed {
-            crate::articles::Feed::Idle | crate::articles::Feed::Loading => column![
-                text("From TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+        let feed: Element<'_, Message> = match &self.feed {
+            crate::articles::Feed::Idle | crate::articles::Feed::Loading => {
                 text("Fetching the latest articles…")
                     .size(theme::TEXT_SIZE_SMALL)
-                    .color(theme::TEXT_MUTE),
-            ]
-            .spacing(theme::S2)
-            .into(),
+                    .color(theme::TEXT_MUTE)
+                    .into()
+            }
             crate::articles::Feed::Failed(why) => column![
-                text("From TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
                 // Says which way it failed rather than "offline": a 503 and no
                 // route are different problems and only one of them is yours.
                 text(why.clone()).size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_MUTE),
@@ -599,83 +596,113 @@ impl Brokkr {
             ]
             .spacing(theme::S2)
             .into(),
-            crate::articles::Feed::Ready(articles) if articles.is_empty() => column![
-                text("From TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
-                text("Nothing published yet.").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_MUTE),
-            ]
-            .spacing(theme::S2)
-            .into(),
+            crate::articles::Feed::Ready(articles) if articles.is_empty() => {
+                text("Nothing published yet.")
+                    .size(theme::TEXT_SIZE_SMALL)
+                    .color(theme::TEXT_MUTE)
+                    .into()
+            }
             crate::articles::Feed::Ready(articles) => {
-                let mut list = column![
-                    text("From TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
-                ]
-                .spacing(theme::S2);
-                for article in articles {
-                    // **The picture and the headline, and no summary.** The
-                    // summary is what made this a wall of text: four articles
-                    // of prose in a column beside three buttons reads as
-                    // something to get past rather than something to look at.
-                    // The page this mirrors shows a thumbnail, a title and a
-                    // date, and that is the whole row.
-                    let words = column![
-                        text(article.title.clone()).size(theme::TEXT_SIZE).color(theme::TEXT),
-                        text(article.date.clone())
-                            .size(theme::CAPTION_SIZE)
-                            .color(theme::TEXT_MUTE),
-                    ]
-                    .spacing(2)
-                    .width(Length::Fill);
-
-                    let inside: Element<'_, Message> = match &article.thumbnail {
+                // **Two to a row, picture on top.** The single narrow column
+                // this replaced could only carry a thumbnail beside the words,
+                // which left the picture too small to be worth its bytes and
+                // the text too narrow to carry a summary. Two wide cards give
+                // both, and match the page these articles come from.
+                let mut grid = column![].spacing(theme::S3);
+                for pair in articles.chunks(GRID_COLUMNS) {
+                    let mut line = row![].spacing(theme::S3);
+                    for article in pair {
+                        let mut card = column![].spacing(theme::S1).width(Length::Fill);
                         // Cloning the HANDLE and not the pixels: it is
                         // refcounted and keeps its id, so the renderer's atlas
                         // entry survives the frame. Building a handle here
                         // instead would mint a new id every frame and re-upload
                         // every thumbnail. See `articles::Article::thumbnail`.
-                        Some(handle) => row![
-                            container(
-                                iced::widget::image(handle.clone())
-                                    .width(Length::Fixed(THUMB_PX))
-                                    .content_fit(iced::ContentFit::Cover),
-                            )
-                            .clip(true)
-                            .width(Length::Fixed(THUMB_PX))
-                            .height(Length::Fixed(THUMB_PX * 9.0 / 16.0)),
-                            words,
-                        ]
-                        .spacing(theme::S3)
-                        .align_y(Alignment::Center)
-                        .into(),
-                        // No picture is an ordinary outcome, so the row simply
-                        // has none rather than a placeholder that would draw
-                        // the eye to what is missing.
-                        None => words.into(),
-                    };
-
-                    list = list.push(
-                        button(inside)
-                            .width(Length::Fill)
-                            .padding(Padding {
-                                top: theme::S2,
-                                bottom: theme::S2,
-                                left: theme::S2,
-                                right: theme::S3,
-                            })
-                            .style(theme::tool_button)
-                            .on_press(Message::ArticleOpened(article.link.clone())),
-                    );
+                        //
+                        // No picture is an ordinary outcome, so the card simply
+                        // has none rather than a placeholder that would draw the
+                        // eye to what is missing.
+                        if let Some(handle) = &article.thumbnail {
+                            card = card.push(
+                                container(
+                                    iced::widget::image(handle.clone())
+                                        .width(Length::Fill)
+                                        .content_fit(iced::ContentFit::Cover),
+                                )
+                                .clip(true)
+                                .width(Length::Fill)
+                                .height(Length::Fixed(CARD_THUMB_PX)),
+                            );
+                        }
+                        card = card.push(
+                            text(article.title.clone()).size(theme::TEXT_SIZE).color(theme::TEXT),
+                        );
+                        card = card.push(
+                            text(article.summary.clone())
+                                .size(theme::TEXT_SIZE_SMALL)
+                                .color(theme::TEXT_DIM),
+                        );
+                        card = card.push(
+                            text(article.date.clone())
+                                .size(theme::CAPTION_SIZE)
+                                .color(theme::TEXT_MUTE),
+                        );
+                        line = line.push(
+                            button(card)
+                                .width(Length::Fill)
+                                .padding(theme::S2)
+                                .style(theme::tool_button)
+                                .on_press(Message::LinkOpened(article.link.clone())),
+                        );
+                    }
+                    // A last row with one article in it must not stretch that
+                    // card across the width the pair would have had.
+                    for _ in pair.len()..GRID_COLUMNS {
+                        line = line.push(space::horizontal());
+                    }
+                    grid = grid.push(line);
                 }
-                list.into()
+                scrollable(grid).height(Length::Fixed(GRID_HEIGHT_PX)).into()
             }
         };
+
+        // **The two buttons, which are the point of the panel.** The articles
+        // say what the community is doing; these are how someone acts on it.
+        // Both go through the same one-host check every article link does, so
+        // neither can be turned into a way to open something else.
+        let atlas = |label: &'static str, link: &'static str, style: ButtonStyle| {
+            button(text(label).size(theme::TEXT_SIZE))
+                .padding(Padding {
+                    top: theme::S2,
+                    bottom: theme::S2,
+                    left: theme::S4,
+                    right: theme::S4,
+                })
+                .style(style)
+                .on_press(Message::LinkOpened(link.to_string()))
+        };
+        let heading = row![
+            column![
+                text("Welcome to BrokkrSculpt").size(theme::TITLE_SIZE).color(theme::TEXT),
+                text("A sculpting tool for people who print what they make.")
+                    .size(theme::TEXT_SIZE)
+                    .color(theme::TEXT_DIM),
+            ]
+            .spacing(theme::S1)
+            .width(Length::Fill),
+            atlas("Join TinkerAtlas", crate::articles::JOIN_URL, theme::tool_button_active),
+            atlas("Visit TinkerAtlas", crate::articles::VISIT_URL, theme::tool_button),
+        ]
+        .spacing(theme::S2)
+        .align_y(Alignment::Center);
+
         let right = column![
-            text("A sculpting tool for people who print what they make.")
-                .size(theme::TEXT_SIZE)
-                .color(theme::TEXT),
-            right,
+            heading,
+            text("Latest from TinkerAtlas").size(theme::TEXT_SIZE_SMALL).color(theme::TEXT_DIM),
+            feed,
         ]
         .spacing(theme::S3)
-        .width(Length::Fixed(340.0));
+        .width(Length::Fill);
 
         let foot = row![
             checkbox(self.welcome_on_startup)
@@ -734,7 +761,11 @@ impl Brokkr {
             column![lockup, row![left, right].spacing(theme::S5), keys, foot,].spacing(theme::S4),
         )
         .padding(theme::S5)
-        .max_width(640.0)
+        // **Wide enough for two article cards side by side**, which is what
+        // sets it: 220 for the actions, 16 of gap, two ~330 cards and the
+        // padding. The narrow card this replaced could only stack articles in
+        // one column, and that column could not carry a picture worth showing.
+        .max_width(960.0)
         .style(theme::menu_card);
 
         modal_layer(card)
@@ -3245,11 +3276,28 @@ impl Brokkr {
     }
 }
 
-/// How wide an article thumbnail is drawn, in logical pixels.
+/// How tall an article thumbnail is drawn on its card, in logical pixels.
 ///
-/// Half what the server is asked for, so the picture still has pixels to spare
-/// on a HiDPI output. See `articles::THUMB_WIDTH`.
-const THUMB_PX: f32 = 120.0;
+/// The picture spans the card's whole width, so only the height is fixed here;
+/// `ContentFit::Cover` crops to fill it whatever the source aspect is.
+///
+/// **Sized down from 16:9 so four cards and the key strip fit a 768-high
+/// window**, which is the size `tool_strip`'s header records as the one that
+/// must keep working. At 170 the card ran about eighty pixels past the bottom
+/// of the window and took the Close button with it -- seen on screen, not in a
+/// test, because nothing in the suite lays this out.
+const CARD_THUMB_PX: f32 = 120.0;
+
+/// How tall the article grid may be before it scrolls, in logical pixels.
+///
+/// Two rows of cards at [`CARD_THUMB_PX`] come to about this. It is a bound
+/// rather than a fit: a summary that wraps to a third line, or a fifth article
+/// if [`crate::articles::MAX_SHOWN`] ever grows, scrolls instead of pushing the
+/// footer off the screen. The page this mirrors scrolls its article column too.
+const GRID_HEIGHT_PX: f32 = 440.0;
+
+/// How many article cards sit side by side.
+const GRID_COLUMNS: usize = 2;
 
 /// Cut a path down so it cannot push a column wider than it was given.
 ///

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -1389,6 +1389,7 @@ impl Brokkr {
 
         let (cut_style, cut_ink) = theme::tool_toggle(self.tool == Tool::Cut);
         let (mask_style, mask_ink) = theme::tool_toggle(self.tool == Tool::Mask);
+        let (move_style, move_ink) = theme::tool_toggle(self.tool == Tool::Transform);
 
         container(
             column![
@@ -1442,6 +1443,27 @@ impl Brokkr {
                 .width(Length::Fill)
                 .style(mask_style)
                 .on_press(Message::ToolChanged(Tool::Mask)),
+                // The third mode that changes what a left drag does. The word
+                // under it says whether the next release will cost the surface
+                // anything, which is the one thing about this tool a user
+                // cannot see by looking at the model.
+                button(
+                    column![
+                        icon::icon(icon::IconName::Gizmo, theme::ICON_TOOL, move_ink),
+                        text(match self.tool == Tool::Transform {
+                            true if smoothing => "free",
+                            true => "snap",
+                            false => "move",
+                        })
+                        .size(theme::TEXT_SIZE_SMALL),
+                    ]
+                    .width(Length::Fill)
+                    .spacing(0)
+                    .align_x(Alignment::Center)
+                )
+                .width(Length::Fill)
+                .style(move_style)
+                .on_press(Message::ToolChanged(Tool::Transform)),
             ]
             .spacing(theme::S3)
             .align_x(Alignment::Center),

--- a/crates/brokkr-app/src/articles.rs
+++ b/crates/brokkr-app/src/articles.rs
@@ -134,19 +134,20 @@ pub fn parse(xml: &str) -> Result<Vec<Article>, String> {
     Ok(parse_items(xml)?.into_iter().map(|(article, _)| article).collect())
 }
 
-/// The items, each with the URL of its picture if it has a usable one.
-///
-/// **Separate from [`parse`] so that parsing is pure.** Fetching thumbnails
-/// from inside the parser meant the unit tests only avoided the network by
-/// accident -- their fixtures happen to carry no `<enclosure>`, and the first
-/// one that did would have started making real requests from `cargo test`.
-/// Pull the items out of an RSS document.
+/// Pull the items out of an RSS document, each with the URL of its picture if
+/// it has a usable one.
 ///
 /// Deliberately tolerant: an item missing a title or a link is skipped rather
 /// than failing the whole feed, because one malformed entry on the site should
 /// not blank the panel. A document that is not XML at all IS an error -- that
 /// is a captive portal or an error page, and saying "no articles" for it would
 /// be a lie about what happened.
+///
+/// **It returns the picture URL rather than fetching it, so that parsing stays
+/// pure.** Fetching thumbnails from inside the parser meant the unit tests only
+/// avoided the network by accident -- their fixtures happen to carry no
+/// `<enclosure>`, and the first one that did would have started making real
+/// requests from `cargo test`.
 fn parse_items(xml: &str) -> Result<Vec<(Article, Option<String>)>, String> {
     let document =
         roxmltree::Document::parse(xml).map_err(|why| format!("the feed is not XML ({why})"))?;

--- a/crates/brokkr-app/src/articles.rs
+++ b/crates/brokkr-app/src/articles.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The TinkerAtlas articles shown on the welcome screen.
+//!
+//! SindriCAD embeds `tinkeratlas.com/sindricad/welcome` in an `<iframe>` and
+//! lets the page render itself. There is no webview here to put a frame in, so
+//! this fetches the same site's articles as DATA and draws them with the same
+//! widgets as everything else.
+//!
+//! # Why RSS and not the JSON API
+//!
+//! `GET /api/articles?limit=5` returns everything an article has, including its
+//! full rendered HTML body and its search vector: **105 KB for five titles**.
+//! The RSS feed is 43 KB for the whole list and carries exactly what a link
+//! needs -- title, link, description, date, author.
+//!
+//! The deciding argument is the dependency policy rather than the bytes.
+//! Parsing the JSON would mean `serde_json`; `roxmltree` is already a compiled
+//! dependency of this workspace for the 3MF importer, so RSS costs **zero new
+//! crates**. `ureq` is likewise already here for the bug reporter, and the line
+//! that workspace holds is that it stays the only network dependency -- this
+//! adds no second one.
+//!
+//! # When this runs, and when it does not
+//!
+//! **Only while the welcome screen is actually on screen.** Everything else
+//! this application does is local: the bug reporter talks to the network when a
+//! user asks it to, and `printer.rs` talks to a machine on the LAN. A fetch on
+//! every launch would be a new outbound connection nobody asked for, and this
+//! application has deliberately no account and no stored credential.
+//!
+//! Tying it to the screen makes the control honest: **turning the welcome
+//! screen off also turns this off**, with no second setting to find, and the
+//! tick that does it is on the screen itself.
+
+use std::time::Duration;
+
+/// Where the feed lives.
+const FEED_URL: &str = "https://tinkeratlas.com/api/rss/articles";
+
+/// How long to wait before deciding the site is unreachable.
+///
+/// Short on purpose. This is decoration on a screen the user is already
+/// looking at, so the cost of waiting is worse than the cost of missing it --
+/// and the offline state says what happened and offers a retry.
+const TIMEOUT: Duration = Duration::from_secs(6);
+
+/// How many to show. The column holds about this many before the card grows
+/// taller than a 768-high window, which is the size `tool_strip`'s own header
+/// records as the one that must keep working.
+pub const MAX_SHOWN: usize = 4;
+
+/// One article, reduced to what a link needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Article {
+    pub title: String,
+    pub link: String,
+    pub summary: String,
+    /// As the feed wrote it, trimmed to the date. Not parsed into a calendar
+    /// type: nothing here does arithmetic on it, and a date format that fails
+    /// to parse should still be shown rather than swallowed.
+    pub date: String,
+}
+
+/// What the welcome screen has to draw.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Feed {
+    /// Not asked for yet.
+    #[default]
+    Idle,
+    /// Asked, nothing back.
+    Loading,
+    Ready(Vec<Article>),
+    /// Unreachable, with what to say about it.
+    Failed(String),
+}
+
+/// Fetch and parse the feed. Blocking: call it off the interface thread.
+pub fn fetch() -> Result<Vec<Article>, String> {
+    // Same shape as `report.rs`'s send, which is the only other place this
+    // workspace touches the network.
+    let mut response =
+        ureq::get(FEED_URL).config().timeout_global(Some(TIMEOUT)).build().call().map_err(
+            |why| match why {
+                ureq::Error::StatusCode(code) => format!("tinkeratlas.com answered {code}"),
+                // Everything else is the network: no route, DNS, TLS, timeout.
+                // Worth saying differently from a rejection, because the answer is
+                // "try again" rather than "something is wrong with the request".
+                other => format!("could not reach tinkeratlas.com ({other})"),
+            },
+        )?;
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .map_err(|why| format!("the feed could not be read ({why})"))?;
+    parse(&body)
+}
+
+/// Pull the items out of an RSS document.
+///
+/// Deliberately tolerant: an item missing a title or a link is skipped rather
+/// than failing the whole feed, because one malformed entry on the site should
+/// not blank the panel. A document that is not XML at all IS an error -- that
+/// is a captive portal or an error page, and saying "no articles" for it would
+/// be a lie about what happened.
+pub fn parse(xml: &str) -> Result<Vec<Article>, String> {
+    let document =
+        roxmltree::Document::parse(xml).map_err(|why| format!("the feed is not XML ({why})"))?;
+
+    let mut articles = Vec::new();
+    for item in document.descendants().filter(|node| node.has_tag_name("item")) {
+        let child = |name: &str| {
+            item.children()
+                .find(|node| node.has_tag_name(name))
+                .and_then(|node| node.text())
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        };
+        let title = child("title");
+        let link = child("link");
+        if title.is_empty() || link.is_empty() {
+            continue;
+        }
+        // Only ever https, and only ever this site. The link is handed to the
+        // browser, so a feed that had been tampered with -- or a future entry
+        // pointing somewhere else entirely -- must not be able to send the user
+        // anywhere the welcome screen did not promise.
+        if !link.starts_with("https://tinkeratlas.com/") {
+            continue;
+        }
+        articles.push(Article {
+            title,
+            link,
+            summary: shorten(&child("description")),
+            date: date_only(&child("pubDate")),
+        });
+        if articles.len() == MAX_SHOWN {
+            break;
+        }
+    }
+    Ok(articles)
+}
+
+/// The day out of an RFC-822 date, without the time or the zone.
+///
+/// **Not a string split on `" 0"`, which is what this was first**, and the
+/// screenshot is what caught it: that cuts at the first space-then-zero, so
+/// `Tue, 18 Aug 2026 22:29:33 GMT` kept its whole time because the hour starts
+/// with a two, and `Sun, 03 Aug 2026 …` was cut down to `Sun,` because the DAY
+/// starts with a zero. Two different wrong answers from one clever line.
+///
+/// Taking the first four whitespace-separated words is what the format
+/// actually promises -- `Thu, 27 Aug 2026 00:38:32 GMT` -- and anything that
+/// is not that shape is passed through untouched rather than mangled, because
+/// a date we cannot read is still better shown than blanked.
+fn date_only(pub_date: &str) -> String {
+    let words: Vec<&str> = pub_date.split_whitespace().collect();
+    if words.len() < 4 {
+        return pub_date.trim().to_string();
+    }
+    words[..4].join(" ")
+}
+
+/// Cut a summary to something that fits beside the actions without growing the
+/// card. See `panel.rs`'s `shorten`, which does the same job for paths and
+/// records why a fixed-width column does not clip its own children.
+fn shorten(text: &str) -> String {
+    const MAX_CHARS: usize = 110;
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flat.chars().count() <= MAX_CHARS {
+        return flat;
+    }
+    let cut: String = flat.chars().take(MAX_CHARS - 1).collect();
+    // Back off to a word boundary so the ellipsis does not land mid-word.
+    let trimmed = cut.rsplit_once(' ').map(|(head, _)| head).unwrap_or(&cut);
+    format!("{trimmed}…")
+}
+
+/// Hand a link to whatever the desktop opens links with.
+///
+/// `xdg-open` rather than a crate: this is Linux-first, `slicer.rs` already
+/// spawns a process the same way, and a browser-opening dependency would be a
+/// second one to audit for the sake of one command.
+pub fn open_in_browser(link: &str) -> Result<(), String> {
+    if !link.starts_with("https://tinkeratlas.com/") {
+        return Err("that link does not lead to TinkerAtlas".to_string());
+    }
+    std::process::Command::new("xdg-open")
+        .arg(link)
+        .spawn()
+        .map(|_| ())
+        .map_err(|why| format!("nothing would open the link ({why})"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>TinkerAtlas Articles</title>
+    <item>
+      <title>Your Sketch Went Red</title>
+      <link>https://tinkeratlas.com/site-posts/your-sketch-went-red</link>
+      <description>A constraint that turns your sketch red and refuses to say which line caused it is the same bug as a save that quietly truncates your file, and it took ten days to fix properly.</description>
+      <pubDate>Thu, 27 Aug 2026 00:38:32 GMT</pubDate>
+    </item>
+    <item>
+      <title>Second</title>
+      <link>https://tinkeratlas.com/site-posts/second</link>
+      <description>Short one.</description>
+      <pubDate>Wed, 26 Aug 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>"#;
+
+    /// **The dates that broke the first version, kept as the test.**
+    ///
+    /// Both came off the real feed and both were wrong on screen: an hour that
+    /// does not start with zero kept the whole time, and a day that does was
+    /// cut down to the weekday alone.
+    #[test]
+    fn a_date_keeps_its_day_and_drops_its_time_whatever_the_digits_are() {
+        assert_eq!(date_only("Thu, 27 Aug 2026 00:38:32 GMT"), "Thu, 27 Aug 2026");
+        assert_eq!(
+            date_only("Tue, 18 Aug 2026 22:29:33 GMT"),
+            "Tue, 18 Aug 2026",
+            "an hour not starting with zero kept its time"
+        );
+        assert_eq!(
+            date_only("Sun, 03 Aug 2026 09:00:00 GMT"),
+            "Sun, 03 Aug 2026",
+            "a day starting with zero was cut down to the weekday"
+        );
+        // Anything not of that shape is shown rather than mangled.
+        assert_eq!(date_only("yesterday"), "yesterday");
+        assert_eq!(date_only(""), "");
+    }
+
+    #[test]
+    fn the_feed_yields_the_fields_a_link_needs() {
+        let articles = parse(FEED).expect("the fixture is valid RSS");
+        assert_eq!(articles.len(), 2);
+        assert_eq!(articles[0].title, "Your Sketch Went Red");
+        assert_eq!(articles[0].link, "https://tinkeratlas.com/site-posts/your-sketch-went-red");
+        assert_eq!(articles[0].date, "Thu, 27 Aug 2026", "the time of day is not worth the width");
+        assert!(articles[0].summary.ends_with('…'), "a long summary was not cut");
+        assert_eq!(articles[1].summary, "Short one.", "a short summary was cut anyway");
+    }
+
+    /// **A link is handed to the browser, so it may only ever go one place.**
+    ///
+    /// The feed is fetched over TLS from a site we control, which is most of
+    /// the answer -- but "most" is not the standard for a URL that a click
+    /// hands to the user's browser. An entry pointing anywhere else is dropped
+    /// rather than shown, and `open_in_browser` refuses it a second time in
+    /// case a link ever reaches it by another route.
+    #[test]
+    fn an_item_pointing_off_the_site_is_dropped_and_refused() {
+        let hostile =
+            FEED.replace("https://tinkeratlas.com/site-posts/second", "https://evil.example/phish");
+        let articles = parse(&hostile).expect("still valid RSS");
+        assert_eq!(articles.len(), 1, "an off-site item was shown: {articles:?}");
+
+        assert!(open_in_browser("https://evil.example/phish").is_err());
+        assert!(open_in_browser("http://tinkeratlas.com/site-posts/x").is_err(), "plain http");
+    }
+
+    /// One bad entry must not blank the panel.
+    #[test]
+    fn an_item_missing_a_title_or_link_is_skipped_rather_than_fatal() {
+        let broken = FEED.replace("<title>Second</title>", "");
+        let articles = parse(&broken).expect("still valid RSS");
+        assert_eq!(articles.len(), 1);
+        assert_eq!(articles[0].title, "Your Sketch Went Red");
+    }
+
+    /// **A page that is not the feed is an error, not an empty list.**
+    ///
+    /// A captive portal or a 502 page answers with HTML, and reporting "no
+    /// articles" for it would say the site had nothing to show when what
+    /// actually happened is that we never reached it.
+    #[test]
+    fn a_page_that_is_not_the_feed_is_an_error() {
+        assert!(parse("<html><body>not the feed</body>").is_err());
+        assert!(parse("").is_err());
+    }
+
+    /// The cap is the cap, however long the feed is.
+    #[test]
+    fn no_more_than_the_column_holds_is_returned() {
+        let mut many =
+            String::from(r#"<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel>"#);
+        for index in 0..20 {
+            many.push_str(&format!(
+                "<item><title>Article {index}</title>\
+                 <link>https://tinkeratlas.com/site-posts/{index}</link>\
+                 <description>d</description><pubDate>Thu, 27 Aug 2026 00:00:00 GMT</pubDate></item>"
+            ));
+        }
+        many.push_str("</channel></rss>");
+        assert_eq!(parse(&many).expect("valid").len(), MAX_SHOWN);
+    }
+}

--- a/crates/brokkr-app/src/articles.rs
+++ b/crates/brokkr-app/src/articles.rs
@@ -49,49 +49,37 @@ const TIMEOUT: Duration = Duration::from_secs(6);
 /// How many to show. The column holds about this many before the card grows
 /// taller than a 768-high window, which is the size `tool_strip`'s own header
 /// records as the one that must keep working.
-pub const MAX_SHOWN: usize = 4;
-
-/// A decoded thumbnail, ready to hand to iced.
-///
-/// Decoded once when the feed is fetched rather than per frame, which is the
-/// difference between a still panel and one that decodes four JPEGs sixty times
-/// a second.
-#[derive(Clone, PartialEq, Eq)]
-pub struct Thumbnail {
-    pub width: u32,
-    pub height: u32,
-    pub rgba: Vec<u8>,
-}
-
-/// Hand-written so a `Message` that carries one can still be printed. The
-/// derived form would dump 130 KB of pixels into a log line.
-impl std::fmt::Debug for Thumbnail {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Thumbnail({}x{}, {} bytes)", self.width, self.height, self.rgba.len())
-    }
-}
+const MAX_SHOWN: usize = 4;
 
 /// One article, reduced to what a link needs.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Article {
     pub title: String,
     pub link: String,
-    pub summary: String,
     /// As the feed wrote it, trimmed to the date. Not parsed into a calendar
     /// type: nothing here does arithmetic on it, and a date format that fails
     /// to parse should still be shown rather than swallowed.
     pub date: String,
     /// The picture beside it, when there was one and it decoded.
     ///
+    /// **An iced handle and not the pixels**, built once here rather than in
+    /// the view. `Handle::from_rgba` stamps a fresh `Id::unique()` on every
+    /// call, and the renderer's atlas is keyed on that id -- so building one
+    /// per frame is a cache miss per frame, which uploads every thumbnail to
+    /// the GPU again and drops last frame's. Four 240x135 images is 518 KB of
+    /// memcpy and 518 KB of upload, sixty times a second, for pictures that
+    /// never change. Cloning a handle is a refcount bump and keeps the id, so
+    /// the atlas entry survives.
+    ///
     /// `None` is an ordinary outcome and not an error: an article may have no
     /// image, the host may be slow, the bytes may be a format this does not
     /// decode. The row is drawn either way -- a missing picture must not cost
     /// the headline.
-    pub thumbnail: Option<Thumbnail>,
+    pub thumbnail: Option<iced::widget::image::Handle>,
 }
 
 /// What the welcome screen has to draw.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum Feed {
     /// Not asked for yet.
     #[default]
@@ -105,18 +93,21 @@ pub enum Feed {
 
 /// Fetch and parse the feed. Blocking: call it off the interface thread.
 pub fn fetch() -> Result<Vec<Article>, String> {
-    // Same shape as `report.rs`'s send, which is the only other place this
-    // workspace touches the network.
-    let mut response =
-        ureq::get(FEED_URL).config().timeout_global(Some(TIMEOUT)).build().call().map_err(
-            |why| match why {
-                ureq::Error::StatusCode(code) => format!("tinkeratlas.com answered {code}"),
-                // Everything else is the network: no route, DNS, TLS, timeout.
-                // Worth saying differently from a rejection, because the answer is
-                // "try again" rather than "something is wrong with the request".
-                other => format!("could not reach tinkeratlas.com ({other})"),
-            },
-        )?;
+    // **One agent for all five requests.** `ureq::get` is documented as running
+    // on a use-once agent, so a bare call per request builds a fresh rustls
+    // config, opens a fresh connection and pays a fresh TLS handshake -- and
+    // all four thumbnails come from one host, so four of those five handshakes
+    // would be pure waste.
+    let agent: ureq::Agent =
+        ureq::Agent::config_builder().timeout_global(Some(TIMEOUT)).build().into();
+
+    let mut response = agent.get(FEED_URL).call().map_err(|why| match why {
+        ureq::Error::StatusCode(code) => format!("tinkeratlas.com answered {code}"),
+        // Everything else is the network: no route, DNS, TLS, timeout.
+        // Worth saying differently from a rejection, because the answer is
+        // "try again" rather than "something is wrong with the request".
+        other => format!("could not reach tinkeratlas.com ({other})"),
+    })?;
     let body = response
         .body_mut()
         .read_to_string()
@@ -128,19 +119,12 @@ pub fn fetch() -> Result<Vec<Article>, String> {
     Ok(parse_items(&body)?
         .into_iter()
         .map(|(mut article, picture)| {
-            article.thumbnail = picture.as_deref().and_then(fetch_thumbnail);
+            article.thumbnail = picture.as_deref().and_then(|url| fetch_thumbnail(&agent, url));
             article
         })
         .collect())
 }
 
-/// Pull the items out of an RSS document.
-///
-/// Deliberately tolerant: an item missing a title or a link is skipped rather
-/// than failing the whole feed, because one malformed entry on the site should
-/// not blank the panel. A document that is not XML at all IS an error -- that
-/// is a captive portal or an error page, and saying "no articles" for it would
-/// be a lie about what happened.
 /// Test-only, and it wraps the real parser rather than duplicating it: what
 /// production runs is [`parse_items`], and a test that exercised anything else
 /// would be checking a second implementation nobody uses. CI builds with
@@ -156,6 +140,13 @@ pub fn parse(xml: &str) -> Result<Vec<Article>, String> {
 /// from inside the parser meant the unit tests only avoided the network by
 /// accident -- their fixtures happen to carry no `<enclosure>`, and the first
 /// one that did would have started making real requests from `cargo test`.
+/// Pull the items out of an RSS document.
+///
+/// Deliberately tolerant: an item missing a title or a link is skipped rather
+/// than failing the whole feed, because one malformed entry on the site should
+/// not blank the panel. A document that is not XML at all IS an error -- that
+/// is a captive portal or an error page, and saying "no articles" for it would
+/// be a lie about what happened.
 fn parse_items(xml: &str) -> Result<Vec<(Article, Option<String>)>, String> {
     let document =
         roxmltree::Document::parse(xml).map_err(|why| format!("the feed is not XML ({why})"))?;
@@ -188,13 +179,7 @@ fn parse_items(xml: &str) -> Result<Vec<(Article, Option<String>)>, String> {
             .and_then(|node| node.attribute("url"))
             .and_then(thumbnail_url);
         articles.push((
-            Article {
-                title,
-                link,
-                summary: shorten(&child("description")),
-                date: date_only(&child("pubDate")),
-                thumbnail: None,
-            },
+            Article { title, link, date: date_only(&child("pubDate")), thumbnail: None },
             picture,
         ));
         if articles.len() == MAX_SHOWN {
@@ -242,8 +227,8 @@ fn thumbnail_url(enclosure: &str) -> Option<String> {
 /// propagates. The one thing it will not do is decode something enormous: the
 /// server was asked for 240 pixels, and anything far larger than that is not
 /// the picture that was requested.
-fn fetch_thumbnail(url: &str) -> Option<Thumbnail> {
-    let mut response = ureq::get(url).config().timeout_global(Some(TIMEOUT)).build().call().ok()?;
+fn fetch_thumbnail(agent: &ureq::Agent, url: &str) -> Option<iced::widget::image::Handle> {
+    let mut response = agent.get(url).call().ok()?;
     let mut bytes = Vec::new();
     response.body_mut().as_reader().take(MAX_THUMB_BYTES).read_to_end(&mut bytes).ok()?;
 
@@ -252,7 +237,7 @@ fn fetch_thumbnail(url: &str) -> Option<Thumbnail> {
     if width == 0 || height == 0 || width > THUMB_WIDTH * 4 || height > THUMB_HEIGHT * 4 {
         return None;
     }
-    Some(Thumbnail { width, height, rgba: decoded.into_rgba8().into_raw() })
+    Some(iced::widget::image::Handle::from_rgba(width, height, decoded.into_rgba8().into_raw()))
 }
 
 /// A ceiling on what will be read for one thumbnail.
@@ -281,21 +266,6 @@ fn date_only(pub_date: &str) -> String {
         return pub_date.trim().to_string();
     }
     words[..4].join(" ")
-}
-
-/// Cut a summary to something that fits beside the actions without growing the
-/// card. See `panel.rs`'s `shorten`, which does the same job for paths and
-/// records why a fixed-width column does not clip its own children.
-fn shorten(text: &str) -> String {
-    const MAX_CHARS: usize = 110;
-    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if flat.chars().count() <= MAX_CHARS {
-        return flat;
-    }
-    let cut: String = flat.chars().take(MAX_CHARS - 1).collect();
-    // Back off to a word boundary so the ellipsis does not land mid-word.
-    let trimmed = cut.rsplit_once(' ').map(|(head, _)| head).unwrap_or(&cut);
-    format!("{trimmed}…")
 }
 
 /// Hand a link to whatever the desktop opens links with.
@@ -367,8 +337,6 @@ mod tests {
         assert_eq!(articles[0].title, "Your Sketch Went Red");
         assert_eq!(articles[0].link, "https://tinkeratlas.com/site-posts/your-sketch-went-red");
         assert_eq!(articles[0].date, "Thu, 27 Aug 2026", "the time of day is not worth the width");
-        assert!(articles[0].summary.ends_with('…'), "a long summary was not cut");
-        assert_eq!(articles[1].summary, "Short one.", "a short summary was cut anyway");
     }
 
     /// **A link is handed to the browser, so it may only ever go one place.**

--- a/crates/brokkr-app/src/articles.rs
+++ b/crates/brokkr-app/src/articles.rs
@@ -56,6 +56,14 @@ const MAX_SHOWN: usize = 4;
 pub struct Article {
     pub title: String,
     pub link: String,
+    /// The opening of the article, cut to fit the card. See [`shorten`].
+    ///
+    /// **Shown again, and the card is a grid because of it.** An earlier pass
+    /// dropped this on the grounds that four summaries stacked in a 340-pixel
+    /// column read as a wall of text. That was true of the column; the answer
+    /// was the layout rather than the words, and the page this mirrors has
+    /// carried a summary on every card all along.
+    pub summary: String,
     /// As the feed wrote it, trimmed to the date. Not parsed into a calendar
     /// type: nothing here does arithmetic on it, and a date format that fails
     /// to parse should still be shown rather than swallowed.
@@ -180,7 +188,13 @@ fn parse_items(xml: &str) -> Result<Vec<(Article, Option<String>)>, String> {
             .and_then(|node| node.attribute("url"))
             .and_then(thumbnail_url);
         articles.push((
-            Article { title, link, date: date_only(&child("pubDate")), thumbnail: None },
+            Article {
+                title,
+                link,
+                summary: shorten(&child("description")),
+                date: date_only(&child("pubDate")),
+                thumbnail: None,
+            },
             picture,
         ));
         if articles.len() == MAX_SHOWN {
@@ -192,10 +206,14 @@ fn parse_items(xml: &str) -> Result<Vec<(Article, Option<String>)>, String> {
 
 /// How wide a thumbnail is asked for, in pixels.
 ///
-/// The panel draws them at half this, so the extra is for a HiDPI output. See
-/// [`thumbnail_url`] for why the size is asked of the server at all.
-const THUMB_WIDTH: u32 = 240;
-const THUMB_HEIGHT: u32 = 135;
+/// Sized for the grid card, which draws the picture at the card's full width
+/// rather than beside the text -- roughly 320 logical pixels on the 960-wide
+/// welcome card. The panel draws them at that width, so on a HiDPI output the
+/// renderer is upscaling slightly; asking for double would quadruple the bytes
+/// for a picture that sits behind a headline. See [`thumbnail_url`] for why the
+/// size is asked of the server at all.
+const THUMB_WIDTH: u32 = 320;
+const THUMB_HEIGHT: u32 = 180;
 
 /// Turn a stored-object URL into a resized one, or refuse it.
 ///
@@ -269,13 +287,54 @@ fn date_only(pub_date: &str) -> String {
     words[..4].join(" ")
 }
 
+/// Cut a summary to two lines on a card, without breaking a word.
+///
+/// A character count and not a pixel measurement: the text is laid out by the
+/// renderer at a size and font this module knows nothing about, and a count
+/// that is roughly right everywhere beats a measurement that is exactly right
+/// on one machine. `MAX_CHARS` is two lines of the grid card at
+/// `TEXT_SIZE_SMALL`, with the ellipsis counted.
+///
+/// See `panel.rs`'s own `shorten`, which does the same job for paths and
+/// records why a fixed-width column does not clip its own children.
+fn shorten(text: &str) -> String {
+    const MAX_CHARS: usize = 110;
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flat.chars().count() <= MAX_CHARS {
+        return flat;
+    }
+    let cut: String = flat.chars().take(MAX_CHARS - 1).collect();
+    // Back off to a word boundary so the ellipsis does not land mid-word.
+    let trimmed = cut.rsplit_once(' ').map(|(head, _)| head).unwrap_or(&cut);
+    format!("{trimmed}…")
+}
+
+/// Where the two buttons on the welcome screen lead.
+///
+/// Here rather than in `panel.rs` so they sit beside the rule that admits them:
+/// a URL and the policy deciding whether it may be opened are one thing, and
+/// splitting them is how one quietly stops satisfying the other.
+pub const JOIN_URL: &str = "https://tinkeratlas.com/signup";
+pub const VISIT_URL: &str = "https://tinkeratlas.com/";
+
+/// Whether a link may be handed to the user's browser.
+///
+/// **Split out of [`open_in_browser`] so acceptance can be tested.** That one
+/// spawns a process the moment it approves, so a test proving a URL is allowed
+/// would open a browser on whoever ran the suite -- which is why the existing
+/// test only ever checks refusals. This is the same question with no side
+/// effect.
+pub(crate) fn leads_to_tinkeratlas(link: &str) -> bool {
+    link.starts_with("https://tinkeratlas.com/")
+}
+
 /// Hand a link to whatever the desktop opens links with.
 ///
 /// `xdg-open` rather than a crate: this is Linux-first, `slicer.rs` already
 /// spawns a process the same way, and a browser-opening dependency would be a
 /// second one to audit for the sake of one command.
 pub fn open_in_browser(link: &str) -> Result<(), String> {
-    if !link.starts_with("https://tinkeratlas.com/") {
+    if !leads_to_tinkeratlas(link) {
         return Err("that link does not lead to TinkerAtlas".to_string());
     }
     std::process::Command::new("xdg-open")
@@ -338,6 +397,8 @@ mod tests {
         assert_eq!(articles[0].title, "Your Sketch Went Red");
         assert_eq!(articles[0].link, "https://tinkeratlas.com/site-posts/your-sketch-went-red");
         assert_eq!(articles[0].date, "Thu, 27 Aug 2026", "the time of day is not worth the width");
+        assert!(articles[0].summary.ends_with('…'), "a long summary was not cut");
+        assert_eq!(articles[1].summary, "Short one.", "a short summary was cut anyway");
     }
 
     /// **A link is handed to the browser, so it may only ever go one place.**
@@ -356,6 +417,19 @@ mod tests {
 
         assert!(open_in_browser("https://evil.example/phish").is_err());
         assert!(open_in_browser("http://tinkeratlas.com/site-posts/x").is_err(), "plain http");
+    }
+
+    /// **The welcome screen's two buttons must survive their own guard.**
+    ///
+    /// They are constants, so a typo in one is not a compile error and not a
+    /// panic -- the button simply reports "that link does not lead to
+    /// TinkerAtlas" when pressed, which nobody would find until a user did.
+    /// A wrong scheme is the likely slip, and it is exactly what the guard
+    /// rejects.
+    #[test]
+    fn the_welcome_buttons_lead_somewhere_the_guard_allows() {
+        assert!(leads_to_tinkeratlas(JOIN_URL), "the Join button would be refused: {JOIN_URL}");
+        assert!(leads_to_tinkeratlas(VISIT_URL), "the Visit button would be refused: {VISIT_URL}");
     }
 
     /// One bad entry must not blank the panel.

--- a/crates/brokkr-app/src/articles.rs
+++ b/crates/brokkr-app/src/articles.rs
@@ -33,6 +33,7 @@
 //! screen off also turns this off**, with no second setting to find, and the
 //! tick that does it is on the screen itself.
 
+use std::io::Read;
 use std::time::Duration;
 
 /// Where the feed lives.
@@ -50,6 +51,26 @@ const TIMEOUT: Duration = Duration::from_secs(6);
 /// records as the one that must keep working.
 pub const MAX_SHOWN: usize = 4;
 
+/// A decoded thumbnail, ready to hand to iced.
+///
+/// Decoded once when the feed is fetched rather than per frame, which is the
+/// difference between a still panel and one that decodes four JPEGs sixty times
+/// a second.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Thumbnail {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Vec<u8>,
+}
+
+/// Hand-written so a `Message` that carries one can still be printed. The
+/// derived form would dump 130 KB of pixels into a log line.
+impl std::fmt::Debug for Thumbnail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Thumbnail({}x{}, {} bytes)", self.width, self.height, self.rgba.len())
+    }
+}
+
 /// One article, reduced to what a link needs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Article {
@@ -60,6 +81,13 @@ pub struct Article {
     /// type: nothing here does arithmetic on it, and a date format that fails
     /// to parse should still be shown rather than swallowed.
     pub date: String,
+    /// The picture beside it, when there was one and it decoded.
+    ///
+    /// `None` is an ordinary outcome and not an error: an article may have no
+    /// image, the host may be slow, the bytes may be a format this does not
+    /// decode. The row is drawn either way -- a missing picture must not cost
+    /// the headline.
+    pub thumbnail: Option<Thumbnail>,
 }
 
 /// What the welcome screen has to draw.
@@ -93,7 +121,17 @@ pub fn fetch() -> Result<Vec<Article>, String> {
         .body_mut()
         .read_to_string()
         .map_err(|why| format!("the feed could not be read ({why})"))?;
-    parse(&body)
+
+    // Pictures after the list, so a slow image host costs the panel time and
+    // never the headlines: a thumbnail that does not arrive leaves its article
+    // drawn without one.
+    Ok(parse_items(&body)?
+        .into_iter()
+        .map(|(mut article, picture)| {
+            article.thumbnail = picture.as_deref().and_then(fetch_thumbnail);
+            article
+        })
+        .collect())
 }
 
 /// Pull the items out of an RSS document.
@@ -103,7 +141,22 @@ pub fn fetch() -> Result<Vec<Article>, String> {
 /// not blank the panel. A document that is not XML at all IS an error -- that
 /// is a captive portal or an error page, and saying "no articles" for it would
 /// be a lie about what happened.
+/// Test-only, and it wraps the real parser rather than duplicating it: what
+/// production runs is [`parse_items`], and a test that exercised anything else
+/// would be checking a second implementation nobody uses. CI builds with
+/// `-D warnings`, so this cannot simply be left `pub` and unused.
+#[cfg(test)]
 pub fn parse(xml: &str) -> Result<Vec<Article>, String> {
+    Ok(parse_items(xml)?.into_iter().map(|(article, _)| article).collect())
+}
+
+/// The items, each with the URL of its picture if it has a usable one.
+///
+/// **Separate from [`parse`] so that parsing is pure.** Fetching thumbnails
+/// from inside the parser meant the unit tests only avoided the network by
+/// accident -- their fixtures happen to carry no `<enclosure>`, and the first
+/// one that did would have started making real requests from `cargo test`.
+fn parse_items(xml: &str) -> Result<Vec<(Article, Option<String>)>, String> {
     let document =
         roxmltree::Document::parse(xml).map_err(|why| format!("the feed is not XML ({why})"))?;
 
@@ -129,18 +182,86 @@ pub fn parse(xml: &str) -> Result<Vec<Article>, String> {
         if !link.starts_with("https://tinkeratlas.com/") {
             continue;
         }
-        articles.push(Article {
-            title,
-            link,
-            summary: shorten(&child("description")),
-            date: date_only(&child("pubDate")),
-        });
+        let picture = item
+            .children()
+            .find(|node| node.has_tag_name("enclosure"))
+            .and_then(|node| node.attribute("url"))
+            .and_then(thumbnail_url);
+        articles.push((
+            Article {
+                title,
+                link,
+                summary: shorten(&child("description")),
+                date: date_only(&child("pubDate")),
+                thumbnail: None,
+            },
+            picture,
+        ));
         if articles.len() == MAX_SHOWN {
             break;
         }
     }
     Ok(articles)
 }
+
+/// How wide a thumbnail is asked for, in pixels.
+///
+/// The panel draws them at half this, so the extra is for a HiDPI output. See
+/// [`thumbnail_url`] for why the size is asked of the server at all.
+const THUMB_WIDTH: u32 = 240;
+const THUMB_HEIGHT: u32 = 135;
+
+/// Turn a stored-object URL into a resized one, or refuse it.
+///
+/// **The size is asked of the server rather than taken locally**, and it is the
+/// difference between a panel that costs 17 KB and one that costs half a
+/// megabyte: the article images are full size, 113 KB each, and Supabase's
+/// render endpoint returns the same picture at 240 wide for 4 KB. Downloading
+/// the big one to shrink it here would be four times the bytes and all of the
+/// decode.
+///
+/// Only ever the storage host, over TLS. These bytes are fed to a decoder, so
+/// where they come from is a security question and not a tidiness one.
+fn thumbnail_url(enclosure: &str) -> Option<String> {
+    const PREFIX: &str = "https://api.tinkeratlas.com/storage/v1/object/public/";
+    const RENDER: &str = "https://api.tinkeratlas.com/storage/v1/render/image/public/";
+    let rest = enclosure.strip_prefix(PREFIX)?;
+    // A query of its own would be appended to ours and could override the size.
+    if rest.contains('?') {
+        return None;
+    }
+    Some(format!(
+        "{RENDER}{rest}?width={THUMB_WIDTH}&height={THUMB_HEIGHT}&resize=cover&quality=70"
+    ))
+}
+
+/// Fetch and decode one thumbnail. `None` on any failure, which is ordinary.
+///
+/// A picture that will not arrive or will not decode must not cost the article
+/// its headline, so every failure here is a `None` and never an error that
+/// propagates. The one thing it will not do is decode something enormous: the
+/// server was asked for 240 pixels, and anything far larger than that is not
+/// the picture that was requested.
+fn fetch_thumbnail(url: &str) -> Option<Thumbnail> {
+    let mut response = ureq::get(url).config().timeout_global(Some(TIMEOUT)).build().call().ok()?;
+    let mut bytes = Vec::new();
+    response.body_mut().as_reader().take(MAX_THUMB_BYTES).read_to_end(&mut bytes).ok()?;
+
+    let decoded = image::load_from_memory(&bytes).ok()?;
+    let (width, height) = (decoded.width(), decoded.height());
+    if width == 0 || height == 0 || width > THUMB_WIDTH * 4 || height > THUMB_HEIGHT * 4 {
+        return None;
+    }
+    Some(Thumbnail { width, height, rgba: decoded.into_rgba8().into_raw() })
+}
+
+/// A ceiling on what will be read for one thumbnail.
+///
+/// The request asks for a 240-pixel picture and the answer should be a few
+/// kilobytes. This is not a tuning constant, it is a refusal to let a
+/// misbehaving or hostile host stream unbounded bytes into memory while a modal
+/// waits on it.
+const MAX_THUMB_BYTES: u64 = 512 * 1024;
 
 /// The day out of an RFC-822 date, without the time or the zone.
 ///

--- a/crates/brokkr-app/src/camera.rs
+++ b/crates/brokkr-app/src/camera.rs
@@ -552,14 +552,54 @@ mod roll_tests {
     /// to about a part in a million, which is what a renderer and a picker
     /// need; they cannot agree to the last bit, because they are not the same
     /// arithmetic.
+    /// **Split into rotation and position, and run at the sizes the
+    /// application uses.**
+    ///
+    /// One absolute bound over all sixteen elements held only because the
+    /// fixture was 5 mm. The rotation columns are scale-free -- 4.2e-7 at every
+    /// radius tried -- while the whole of the growth is in the translation
+    /// column and is linear in the eye distance, so changing nothing but the
+    /// radius to `MODEL_RADIUS_MM` gives 1.144e-5 against the 1.0e-5 bound and
+    /// the test goes red with no defect behind it. A bound that fails on a
+    /// bigger model is not a bound, it is a fixture.
+    ///
+    /// So the rotation is compared element-wise and absolutely, and the
+    /// position is recovered from each matrix and compared RELATIVE to the
+    /// distance it was built from. Both carry about twenty times their margin
+    /// at every radius here.
     #[test]
     fn an_unrolled_camera_matches_the_matrix_look_at_would_have_built() {
-        let camera = OrbitCamera { yaw: 0.9, pitch: -0.4, ..OrbitCamera::framing(Vec3::ZERO, 5.0) };
-        assert_eq!(camera.roll, 0.0, "roll must default to zero");
+        for radius in [5.0_f32, crate::app::MODEL_RADIUS_MM, 230.0] {
+            let camera =
+                OrbitCamera { yaw: 0.9, pitch: -0.4, ..OrbitCamera::framing(Vec3::ZERO, radius) };
+            assert_eq!(camera.roll, 0.0, "roll must default to zero");
 
-        let expected = glam::camera::rh::view::look_at_mat4(camera.eye(), camera.target, Vec3::Y);
-        for (got, want) in camera.view().to_cols_array().iter().zip(expected.to_cols_array()) {
-            assert!((got - want).abs() < 1.0e-5, "{got} vs {want}");
+            let got = camera.view();
+            let want = glam::camera::rh::view::look_at_mat4(camera.eye(), camera.target, Vec3::Y);
+
+            // The rotation, which does not grow with the model.
+            for column in 0..3 {
+                for row in 0..3 {
+                    let (a, b) = (got.col(column)[row], want.col(column)[row]);
+                    assert!(
+                        (a - b).abs() < 1.0e-5,
+                        "at radius {radius}, rotation element ({column}, {row}) is {a} \
+                         against {b}"
+                    );
+                }
+            }
+
+            // The position, which does -- so it is bounded against the distance
+            // it was built from rather than against a constant.
+            let eye_of = |m: glam::Mat4| m.inverse().col(3).truncate();
+            let (got_eye, want_eye) = (eye_of(got), eye_of(want));
+            assert!(
+                got_eye.distance(want_eye) < camera.distance * 1.0e-5,
+                "at radius {radius}, the eye is {got_eye:?} against {want_eye:?}, \
+                 {} apart against a budget of {}",
+                got_eye.distance(want_eye),
+                camera.distance * 1.0e-5,
+            );
         }
     }
 

--- a/crates/brokkr-app/src/camera.rs
+++ b/crates/brokkr-app/src/camera.rs
@@ -7,11 +7,23 @@
 
 use glam::{Mat4, Quat, Vec2, Vec3};
 
-/// How close the pitch may come to straight up or down.
+/// How close the camera may come to what it is looking at, measured in voxels.
 ///
-/// Reaching the pole would make the up vector parallel to the view direction
-/// and the view matrix would collapse, so stop just short.
-const PITCH_LIMIT: f32 = std::f32::consts::FRAC_PI_2 - 0.01;
+/// **The unit is the whole point.** The floor this replaces was `near * 10.0`
+/// with `near` derived from the model's radius, so it said "a hundredth of the
+/// model" -- which is 1.33 mm on a 133 mm figure whatever the lattice under it
+/// was, and there is no detail work at 1.33 mm on a 0.0565 mm voxel. Two
+/// voxels is the same closeness on a 5 mm model and a 500 mm one, because two
+/// voxels is the same amount of *sculpting* on both.
+const FLOOR_VOXELS: f32 = 2.0;
+
+/// How far out the camera may go, as a multiple of the content radius.
+///
+/// [`OrbitCamera::framing`] sits at about three, so this is roughly thirty
+/// times framed: far enough that no gesture feels fenced in, close enough that
+/// the far plane stays a number a depth buffer can work with and the model is
+/// still a visible speck rather than nothing at all.
+const CEILING_RADII: f32 = 100.0;
 
 /// A camera that orbits a target point.
 #[derive(Debug, Clone, Copy)]
@@ -20,7 +32,12 @@ pub struct OrbitCamera {
     pub distance: f32,
     /// Rotation about the world Y axis, in radians.
     pub yaw: f32,
-    /// Elevation above the horizon, in radians, clamped short of the poles.
+    /// Elevation above the horizon, in radians.
+    ///
+    /// **Unclamped, and free to pass the poles**, which is what the composed
+    /// [`OrbitCamera::orientation`] buys. Wrapped into `-pi..pi` by
+    /// [`OrbitCamera::orbit_radians`] so a long drag does not accumulate an
+    /// angle in the thousands.
     pub pitch: f32,
     /// Twist about the camera's own view axis, in radians.
     ///
@@ -28,8 +45,15 @@ pub struct OrbitCamera {
     /// zero, so every other feature behaves as though it did not exist.
     pub roll: f32,
     pub fov_y: f32,
-    pub near: f32,
-    pub far: f32,
+    /// The lattice the model is stored on. Sets how close the camera may get.
+    ///
+    /// Kept on the camera rather than asked of the document per gesture
+    /// because [`OrbitCamera`] is deliberately free of any dependency on one;
+    /// [`OrbitCamera::set_lattice`] is how the application keeps it true.
+    pub voxel_size: f32,
+    /// Half the diagonal of the content's brick box. Sets the far plane, the
+    /// pick reach and how far out the camera may go.
+    pub content_radius: f32,
 }
 
 impl Default for OrbitCamera {
@@ -41,8 +65,8 @@ impl Default for OrbitCamera {
             pitch: 0.35,
             roll: 0.0,
             fov_y: 45f32.to_radians(),
-            near: 0.01,
-            far: 1000.0,
+            voxel_size: 0.25,
+            content_radius: 1.0,
         }
     }
 }
@@ -54,9 +78,73 @@ impl OrbitCamera {
         // Far enough that the sphere subtends most of the vertical field, with
         // a little air around it.
         camera.distance = radius / (camera.fov_y * 0.5).sin() * 1.15;
-        camera.near = (radius * 0.001).max(1.0e-4);
-        camera.far = camera.distance + radius * 20.0;
+        camera.content_radius = radius.max(1.0e-4);
         camera
+    }
+
+    /// Tell the camera what it is looking at, in the two figures it measures
+    /// itself against.
+    ///
+    /// Called wherever the document's lattice or extent can change -- an open,
+    /// an import, a resample, a body becoming active. Getting it wrong costs a
+    /// zoom floor in the wrong unit, which is the failure this replaces.
+    pub fn set_lattice(&mut self, voxel_size: f32, content_radius: f32) {
+        if voxel_size.is_finite() && voxel_size > 0.0 {
+            self.voxel_size = voxel_size;
+        }
+        if content_radius.is_finite() && content_radius > 0.0 {
+            self.content_radius = content_radius;
+        }
+    }
+
+    /// The closest the camera may come to its target.
+    pub fn min_distance(&self) -> f32 {
+        (self.voxel_size * FLOOR_VOXELS).max(1.0e-4)
+    }
+
+    /// The furthest out it may go.
+    pub fn max_distance(&self) -> f32 {
+        (self.content_radius * CEILING_RADII).max(self.min_distance() * 10.0)
+    }
+
+    /// The near plane, derived rather than stored.
+    ///
+    /// **A hundredth of the distance, so the target is a hundred near planes
+    /// away at every zoom level and cannot be clipped however close the camera
+    /// gets.** A stored near plane cannot promise that: it is a fixed number,
+    /// the distance is not, and the pair went wrong in both directions at once
+    /// -- too coarse to let the camera approach a detail, and, on a file
+    /// written by an older build, a floor computed from a body that was not
+    /// the one being restored.
+    ///
+    /// # The floor under it is a depth buffer's, not a geometry one
+    ///
+    /// A near plane that follows the distance all the way down drives the
+    /// far-to-near ratio through the roof exactly where the user is looking
+    /// hardest: two voxels from a 133 mm figure at a 0.0565 mm lattice is a
+    /// distance of 0.11 mm, and `distance * 0.01` would put the near plane at
+    /// a micrometre against a far plane of 920 -- a ratio near a million, on a
+    /// `Depth32Float` buffer, which quantises the far side of the model into
+    /// millimetres and z-fights it. The floor is a ten-thousandth of the
+    /// content radius, which is TEN TIMES SMALLER than the fixed
+    /// `radius * 0.001` this replaced, so nothing that used to be visible can
+    /// start being clipped -- and it caps the ratio at about forty thousand,
+    /// against the twenty thousand the old pair produced at a distance five
+    /// times further out. The normal case is far better than before rather
+    /// than merely no worse: at a framed distance the ratio is about 230,
+    /// because `far` is now `distance + 4r` where it used to be
+    /// `distance + 20r`.
+    pub fn near(&self) -> f32 {
+        (self.distance * 0.01).max(self.content_radius * 1.0e-4).max(1.0e-5)
+    }
+
+    /// The far plane, and also the length of every pick ray.
+    ///
+    /// Eye to target plus a generous allowance for the content around it. The
+    /// two uses must not be split apart: a pick ray shorter than the far plane
+    /// would fail to find surface the user can plainly see.
+    pub fn far(&self) -> f32 {
+        self.distance + self.content_radius * 4.0
     }
 
     pub fn eye(&self) -> Vec3 {
@@ -70,43 +158,47 @@ impl OrbitCamera {
         Vec3::new(cos_pitch * sin_yaw, sin_pitch, cos_pitch * cos_yaw)
     }
 
-    /// The camera's right axis in world space.
+    /// Camera local axes to world.
     ///
-    /// The rows of a view matrix are the camera basis vectors, which is why
-    /// this reads down a column of each axis rather than along one.
+    /// The three angle fields are this rotation's YXZ Euler form and stay the
+    /// stored representation, so nothing about the file format changes.
+    ///
+    /// **This is what retires the pitch clamp.** `look_at` builds its basis by
+    /// crossing the view direction with a hint, which degenerates when the two
+    /// are parallel -- so a camera looking straight down produced a non finite
+    /// matrix, and the only defence was to stop short of the pole and tell the
+    /// user the camera was "limited by angles". A product of three rotations
+    /// is orthonormal at every angle including exactly plus or minus a quarter
+    /// turn. Euler storage was never the problem; gimbal lock costs uniqueness
+    /// of the *numbers*, not fidelity of the orientation they name.
+    ///
+    /// The two negative signs are not decoration:
+    ///
+    /// - `Rx(-pitch)`, because pitch is measured as elevation ABOVE the
+    ///   horizon while a rotation about X by a positive angle takes the camera
+    ///   the other way. Pinned by `the_composed_forward_matches_the_spherical_one`.
+    /// - `Rz(-roll)`, because `Rz` turns about the camera's local +Z, which
+    ///   points BACKWARD along the view, where the `up_vector` this replaces
+    ///   turned about the view direction itself. Pinned by
+    ///   `a_rolled_camera_matches_the_up_vector_it_used_to_build`.
+    pub fn orientation(&self) -> Quat {
+        Quat::from_rotation_y(self.yaw)
+            * Quat::from_rotation_x(-self.pitch)
+            * Quat::from_rotation_z(-self.roll)
+    }
+
+    /// The camera's right axis in world space.
     pub fn right(&self) -> Vec3 {
-        let view = self.view();
-        Vec3::new(view.x_axis.x, view.y_axis.x, view.z_axis.x)
+        self.orientation() * Vec3::X
     }
 
     /// The camera's up axis in world space.
     pub fn up(&self) -> Vec3 {
-        let view = self.view();
-        Vec3::new(view.x_axis.y, view.y_axis.y, view.z_axis.y)
-    }
-
-    /// The up direction handed to `look_at`, twisted about the view axis by
-    /// [`Self::roll`].
-    ///
-    /// Returns world up unchanged when roll is zero, so a camera nobody has
-    /// twisted produces a bit identical view matrix to the one this had before
-    /// roll existed.
-    ///
-    /// An up vector parallel to the view axis collapses `look_at` into a non
-    /// finite matrix. `PITCH_LIMIT` is what keeps world up clear of the view
-    /// axis, and rotating a vector *about* that axis cannot change its angle
-    /// to it, so a rolled camera is exactly as safe as an upright one and
-    /// needs no clamp of its own.
-    fn up_vector(&self) -> Vec3 {
-        if self.roll == 0.0 {
-            return Vec3::Y;
-        }
-        let forward = (self.target - self.eye()).normalize();
-        Quat::from_axis_angle(forward, self.roll) * Vec3::Y
+        self.orientation() * Vec3::Y
     }
 
     pub fn view(&self) -> Mat4 {
-        glam::camera::rh::view::look_at_mat4(self.eye(), self.target, self.up_vector())
+        glam::Affine3A::from_rotation_translation(self.orientation(), self.eye()).inverse().into()
     }
 
     /// Projection for wgpu's clip space.
@@ -118,8 +210,8 @@ impl OrbitCamera {
         glam::camera::rh::proj::directx::perspective(
             self.fov_y,
             aspect.max(1.0e-3),
-            self.near,
-            self.far,
+            self.near(),
+            self.far(),
         )
     }
 
@@ -138,9 +230,35 @@ impl OrbitCamera {
     /// The SpaceMouse works in radians per millisecond, so it would otherwise
     /// have to convert into pixels only for [`Self::orbit`] to convert them
     /// straight back.
+    ///
+    /// Pitch is wrapped rather than clamped. With the pole open it accumulates
+    /// without bound otherwise, and an angle in the thousands of radians both
+    /// loses precision and reads as nonsense in a saved file.
     pub fn orbit_radians(&mut self, delta: Vec2) {
-        self.yaw -= delta.x;
-        self.pitch = (self.pitch + delta.y).clamp(-PITCH_LIMIT, PITCH_LIMIT);
+        self.yaw = wrap_angle(self.yaw - delta.x);
+        self.pitch = wrap_angle(self.pitch + delta.y);
+    }
+
+    /// Rotate the whole camera rigidly about a world point.
+    ///
+    /// The pivot keeps its exact position on screen, which is what makes
+    /// orbiting about the surface under the cursor feel like turning the model
+    /// in your hand rather than like the model running away from you.
+    ///
+    /// **The rotation is read out of the basis rather than solved for.** The
+    /// obvious route -- work out where the eye should end up and recover yaw
+    /// and pitch from it with `atan2` and `asin` -- disagrees with what
+    /// [`Self::orbit`] actually did by a little at every step and by a lot near
+    /// the poles, and the pivot slides out from under the cursor over a long
+    /// drag. Taking `new * old.inverse()` asks the basis what it did and
+    /// cannot disagree with it.
+    pub fn orbit_about(&mut self, delta: Vec2, pivot: Vec3) {
+        let eye_before = self.eye();
+        let before = self.orientation();
+        self.orbit(delta);
+        let turned = self.orientation() * before.inverse();
+        let eye = pivot + turned * (eye_before - pivot);
+        self.target = eye - self.forward_from_target() * self.distance;
     }
 
     /// Drag to slide the target across the view plane. Deltas are in pixels.
@@ -155,13 +273,15 @@ impl OrbitCamera {
         self.target += (-self.right() * delta.x + self.up() * delta.y) * world_per_pixel;
     }
 
-    /// Wheel to zoom. Positive `amount` moves closer.
+    /// The multiplier one wheel amount corresponds to.
     ///
-    /// Multiplicative so each notch covers the same visual fraction whether the
-    /// camera is near or far.
-    pub fn zoom(&mut self, amount: f32) {
+    /// Split out of the `zoom` it replaces because a wheel notch now needs an
+    /// anchor as well as an amount, and there must be exactly one place that
+    /// knows how many millimetres a notch is worth. Multiplicative, so each
+    /// notch covers the same visual fraction whether the camera is near or far.
+    pub fn zoom_factor(amount: f32) -> f32 {
         const RATE: f32 = 0.12;
-        self.zoom_by((-amount * RATE).exp());
+        (-amount * RATE).exp()
     }
 
     /// Scale the orbit distance directly. Below 1 moves closer.
@@ -170,7 +290,37 @@ impl OrbitCamera {
     /// already and would otherwise have to take its logarithm and divide by
     /// `RATE` purely for [`Self::zoom`] to undo both.
     pub fn zoom_by(&mut self, factor: f32) {
-        self.distance = (self.distance * factor).clamp(self.near * 10.0, self.far);
+        self.zoom_by_about(factor, self.target);
+    }
+
+    /// Zoom toward a world point, which keeps its position on screen.
+    ///
+    /// **This, and not the distance floor, is what "I cannot zoom in to work
+    /// on a detail" was really about.** The eye travels toward the TARGET, and
+    /// after a file is opened the target is the centre of the model -- so
+    /// zooming in on an eyelid walks the camera into the skull, and by the time
+    /// the eyelid fills the view the eye is inside the head. Lowering the floor
+    /// only lets you get further in. Moving what is zoomed toward onto the
+    /// surface under the cursor is the fix; the floor is then free to be as low
+    /// as the lattice deserves, because the thing it is a floor above is the
+    /// surface rather than the centre.
+    ///
+    /// **The clamp is applied to the distance first and the factor derived back
+    /// out of it.** Scaling the target by the requested factor and clamping the
+    /// distance separately un-pins the anchor exactly at the floor, which is
+    /// where the user is pushing hardest and watching most closely.
+    pub fn zoom_by_about(&mut self, factor: f32, anchor: Vec3) {
+        if self.distance <= 0.0
+            || !self.distance.is_finite()
+            || !factor.is_finite()
+            || !anchor.is_finite()
+        {
+            return;
+        }
+        let clamped = (self.distance * factor).clamp(self.min_distance(), self.max_distance());
+        let effective = clamped / self.distance;
+        self.target = anchor + (self.target - anchor) * effective;
+        self.distance = clamped;
     }
 
     /// The shortest way round from one angle to another, in radians.
@@ -180,15 +330,7 @@ impl OrbitCamera {
     /// long way — several times round, in the worst case — for a click that
     /// should have moved it a few degrees.
     pub fn shortest_angle_delta(from: f32, to: f32) -> f32 {
-        use std::f32::consts::{PI, TAU};
-        let delta = (to - from) % TAU;
-        if delta > PI {
-            delta - TAU
-        } else if delta < -PI {
-            delta + TAU
-        } else {
-            delta
-        }
+        wrap_angle(to - from)
     }
 
     /// The world space ray through a point given in normalised device
@@ -214,6 +356,24 @@ impl OrbitCamera {
     }
 }
 
+/// Bring an angle back into -pi..pi.
+///
+/// Moved here from the SpaceMouse, which wanted it for roll, because with the
+/// pitch clamp gone pitch accumulates for as long as the user keeps dragging
+/// and needs exactly the same treatment. Wrapping does not change the
+/// orientation an angle names: a full turn of pitch is the same camera.
+pub fn wrap_angle(angle: f32) -> f32 {
+    use std::f32::consts::{PI, TAU};
+    let wrapped = angle % TAU;
+    if wrapped > PI {
+        wrapped - TAU
+    } else if wrapped < -PI {
+        wrapped + TAU
+    } else {
+        wrapped
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,15 +385,77 @@ mod tests {
         assert!((camera.eye().distance(camera.target) - 7.0).abs() < 1.0e-4);
     }
 
+    /// **This replaces `pitch_never_reaches_the_pole`, and the behaviour it
+    /// pinned is the thing being fixed.** Stopping 0.01 rad short of straight
+    /// down was a workaround for `look_at` collapsing there, and the user felt
+    /// it as a camera "limited by angles". The property that mattered -- a
+    /// finite, orthonormal view matrix -- is now asserted AT the pole and past
+    /// it rather than being bought by never going there.
     #[test]
-    fn pitch_never_reaches_the_pole() {
+    fn pitch_may_pass_the_pole_and_the_view_matrix_survives_it() {
+        use std::f32::consts::{FRAC_PI_2, PI};
+
         let mut camera = OrbitCamera::default();
+        let mut reached_the_far_side = false;
         for _ in 0..1000 {
             camera.orbit(Vec2::new(0.0, 100.0));
+            assert!(
+                camera.view().to_cols_array().iter().all(|v| v.is_finite()),
+                "the view matrix collapsed at pitch {}",
+                camera.pitch
+            );
+            // Upside down: only reachable by having gone over the top.
+            reached_the_far_side |= camera.up().y < -0.5;
         }
-        assert!(camera.pitch < std::f32::consts::FRAC_PI_2);
-        // A collapsed view matrix shows up as a non finite entry.
-        assert!(camera.view().to_cols_array().iter().all(|v| v.is_finite()));
+        assert!(reached_the_far_side, "the camera never got past the pole");
+        assert!(camera.pitch.abs() <= PI + 1.0e-4, "pitch was not wrapped: {}", camera.pitch);
+
+        // And exactly at the pole, which the clamp existed to avoid.
+        for pitch in [FRAC_PI_2, -FRAC_PI_2] {
+            let camera = OrbitCamera { pitch, ..OrbitCamera::framing(Vec3::ZERO, 5.0) };
+            let (right, up) = (camera.right(), camera.up());
+            assert!(camera.view().to_cols_array().iter().all(|v| v.is_finite()));
+            assert!((right.length() - 1.0).abs() < 1.0e-5, "right was not unit at pitch {pitch}");
+            assert!((up.length() - 1.0).abs() < 1.0e-5, "up was not unit at pitch {pitch}");
+            assert!(right.dot(up).abs() < 1.0e-5, "axes not perpendicular at pitch {pitch}");
+        }
+    }
+
+    /// The sign of the `-pitch` in [`OrbitCamera::orientation`], which is the
+    /// one thing in the composed basis that cannot be derived by reading it.
+    #[test]
+    fn the_composed_forward_matches_the_spherical_one() {
+        for yaw in [-3.0_f32, -1.1, 0.0, 0.7, 2.5, 3.1] {
+            for pitch in [-3.0_f32, -1.6, -0.4, 0.0, 0.4, std::f32::consts::FRAC_PI_2, 2.9] {
+                let camera = OrbitCamera { yaw, pitch, ..OrbitCamera::framing(Vec3::ZERO, 5.0) };
+                let composed = camera.orientation() * Vec3::Z;
+                let spherical = camera.forward_from_target();
+                assert!(
+                    composed.distance(spherical) < 1.0e-5,
+                    "at yaw {yaw} pitch {pitch}: composed {composed:?} vs spherical {spherical:?}"
+                );
+            }
+        }
+    }
+
+    /// The composed up has to be the one `look_at` would have built, or every
+    /// gesture that reads `up()` -- pan above all -- changes direction.
+    #[test]
+    fn the_composed_up_matches_look_at_at_zero_roll() {
+        for yaw in [-2.0_f32, 0.0, 0.9, 2.7] {
+            for pitch in [-1.4_f32, -0.3, 0.0, 0.6, 1.4] {
+                let camera = OrbitCamera { yaw, pitch, ..OrbitCamera::framing(Vec3::ZERO, 5.0) };
+                let expected =
+                    glam::camera::rh::view::look_at_mat4(camera.eye(), camera.target, Vec3::Y);
+                let expected_up =
+                    Vec3::new(expected.x_axis.y, expected.y_axis.y, expected.z_axis.y);
+                assert!(
+                    camera.up().distance(expected_up) < 1.0e-5,
+                    "at yaw {yaw} pitch {pitch}: {:?} vs {expected_up:?}",
+                    camera.up()
+                );
+            }
+        }
     }
 
     #[test]
@@ -244,7 +466,7 @@ mod tests {
         let expected = (camera.target - camera.eye()).normalize();
         assert!(direction.dot(expected) > 0.9999, "direction was {direction:?}");
         // The ray starts on the near plane, just in front of the eye.
-        assert!((origin.distance(camera.eye()) - camera.near).abs() < 1.0e-3);
+        assert!((origin.distance(camera.eye()) - camera.near()).abs() < 1.0e-3);
     }
 
     #[test]
@@ -273,9 +495,9 @@ mod tests {
     fn zooming_in_and_back_out_returns_to_the_same_distance() {
         let mut camera = OrbitCamera::framing(Vec3::ZERO, 1.0);
         let before = camera.distance;
-        camera.zoom(3.0);
+        camera.zoom_by(OrbitCamera::zoom_factor(3.0));
         assert!(camera.distance < before, "positive zoom should move closer");
-        camera.zoom(-3.0);
+        camera.zoom_by(OrbitCamera::zoom_factor(-3.0));
         assert!((camera.distance - before).abs() < 1.0e-4);
     }
 
@@ -320,17 +542,52 @@ mod basis_tests {
 mod roll_tests {
     use super::*;
 
-    /// Roll is only worth having if it costs nothing when unused: every other
-    /// feature reads `view()`, so an upright camera has to produce exactly the
-    /// matrix it produced before roll existed, not one that merely rounds to
-    /// it.
+    /// Roll used to be free when unused because `view()` handed `look_at` a
+    /// literal `Vec3::Y` and got back the same matrix it always had.
+    ///
+    /// **That bit identity is deliberately given up, and this test says so
+    /// rather than quietly loosening.** `view()` is no longer built by
+    /// `look_at` at all -- it is the inverse of a rotation composed from three
+    /// quaternions, which is what lets the camera pass the pole. The two agree
+    /// to about a part in a million, which is what a renderer and a picker
+    /// need; they cannot agree to the last bit, because they are not the same
+    /// arithmetic.
     #[test]
-    fn an_unrolled_camera_produces_a_bit_identical_view_matrix() {
+    fn an_unrolled_camera_matches_the_matrix_look_at_would_have_built() {
         let camera = OrbitCamera { yaw: 0.9, pitch: -0.4, ..OrbitCamera::framing(Vec3::ZERO, 5.0) };
         assert_eq!(camera.roll, 0.0, "roll must default to zero");
 
         let expected = glam::camera::rh::view::look_at_mat4(camera.eye(), camera.target, Vec3::Y);
-        assert_eq!(camera.view().to_cols_array(), expected.to_cols_array());
+        for (got, want) in camera.view().to_cols_array().iter().zip(expected.to_cols_array()) {
+            assert!((got - want).abs() < 1.0e-5, "{got} vs {want}");
+        }
+    }
+
+    /// The sign of the `-roll` in [`OrbitCamera::orientation`].
+    ///
+    /// `Rz` turns about the camera's local +Z, which points backward along the
+    /// view; the `up_vector` this replaced turned about the view direction
+    /// itself. Get the sign wrong and the SpaceMouse's twist axis reverses.
+    #[test]
+    fn a_rolled_camera_matches_the_up_vector_it_used_to_build() {
+        for roll in [-1.3_f32, -0.4, 0.4, 1.3, 2.9] {
+            let camera = OrbitCamera {
+                yaw: 0.9,
+                pitch: -0.4,
+                roll,
+                ..OrbitCamera::framing(Vec3::ZERO, 5.0)
+            };
+            // Exactly what `up_vector` computed, before it was deleted.
+            let forward = (camera.target - camera.eye()).normalize();
+            let hint = Quat::from_axis_angle(forward, roll) * Vec3::Y;
+            let expected = glam::camera::rh::view::look_at_mat4(camera.eye(), camera.target, hint);
+            let expected_up = Vec3::new(expected.x_axis.y, expected.y_axis.y, expected.z_axis.y);
+            assert!(
+                camera.up().distance(expected_up) < 1.0e-5,
+                "at roll {roll}: {:?} vs {expected_up:?}",
+                camera.up()
+            );
+        }
     }
 
     #[test]
@@ -360,28 +617,26 @@ mod roll_tests {
         );
     }
 
-    /// The one way roll could break the camera is by putting the up vector
-    /// along the view axis, which collapses `look_at`. Rotating about that
-    /// axis cannot change the angle to it, so this must hold even at the
-    /// pitch limit, where world up is as close to the view axis as it ever
-    /// gets.
+    /// Roll's one hazard used to be putting the up vector along the view axis,
+    /// which collapsed `look_at`. The composed basis has no such case, so this
+    /// now sweeps the pole rather than stopping short of it.
     #[test]
-    fn roll_stays_finite_and_orthonormal_even_at_the_pitch_limit() {
-        for steps in [0.0, 0.5, 1.0, 2.0, -2.0, std::f32::consts::TAU] {
-            let camera = OrbitCamera {
-                pitch: PITCH_LIMIT,
-                roll: steps,
-                ..OrbitCamera::framing(Vec3::ZERO, 5.0)
-            };
+    fn roll_stays_finite_and_orthonormal_at_and_past_the_pole() {
+        use std::f32::consts::FRAC_PI_2;
+        for pitch in [FRAC_PI_2 - 0.01, FRAC_PI_2, FRAC_PI_2 + 0.3, -FRAC_PI_2, 3.0] {
+            for steps in [0.0, 0.5, 1.0, 2.0, -2.0, std::f32::consts::TAU] {
+                let camera =
+                    OrbitCamera { pitch, roll: steps, ..OrbitCamera::framing(Vec3::ZERO, 5.0) };
 
-            assert!(
-                camera.view().to_cols_array().iter().all(|v| v.is_finite()),
-                "the view matrix collapsed at roll {steps}"
-            );
-            let (right, up) = (camera.right(), camera.up());
-            assert!((right.length() - 1.0).abs() < 1.0e-4, "right was not unit at roll {steps}");
-            assert!((up.length() - 1.0).abs() < 1.0e-4, "up was not unit at roll {steps}");
-            assert!(right.dot(up).abs() < 1.0e-4, "axes not perpendicular at roll {steps}");
+                assert!(
+                    camera.view().to_cols_array().iter().all(|v| v.is_finite()),
+                    "the view matrix collapsed at pitch {pitch} roll {steps}"
+                );
+                let (right, up) = (camera.right(), camera.up());
+                assert!((right.length() - 1.0).abs() < 1.0e-4, "right was not unit at {steps}");
+                assert!((up.length() - 1.0).abs() < 1.0e-4, "up was not unit at {steps}");
+                assert!(right.dot(up).abs() < 1.0e-4, "axes not perpendicular at {steps}");
+            }
         }
     }
 
@@ -414,7 +669,7 @@ mod roll_tests {
         let mut by_amount = OrbitCamera::framing(Vec3::ZERO, 1.0);
         let mut by_factor = by_amount;
 
-        by_amount.zoom(1.0);
+        by_amount.zoom_by(OrbitCamera::zoom_factor(1.0));
         by_factor.zoom_by((-0.12f32).exp());
         assert!((by_amount.distance - by_factor.distance).abs() < 1.0e-6);
     }
@@ -423,9 +678,9 @@ mod roll_tests {
     fn zooming_by_a_factor_honours_the_same_clamp() {
         let mut camera = OrbitCamera::framing(Vec3::ZERO, 1.0);
         camera.zoom_by(1.0e-9);
-        assert!(camera.distance >= camera.near * 10.0, "zoom_by went inside the near clamp");
+        assert!(camera.distance >= camera.min_distance(), "zoom_by went under the floor");
         camera.zoom_by(1.0e9);
-        assert!(camera.distance <= camera.far, "zoom_by went past the far clamp");
+        assert!(camera.distance <= camera.max_distance(), "zoom_by went past the ceiling");
     }
 
     #[test]
@@ -439,11 +694,243 @@ mod roll_tests {
         assert!((by_pixels.pitch - by_radians.pitch).abs() < 1.0e-6);
     }
 
+    /// Pitch is wrapped now rather than clamped, and it has to be: an
+    /// unbounded angle loses precision and reads as nonsense in a saved file.
     #[test]
-    fn orbiting_by_radians_is_clamped_short_of_the_pole_too() {
+    fn orbiting_by_radians_wraps_rather_than_accumulating() {
         let mut camera = OrbitCamera::framing(Vec3::ZERO, 1.0);
-        camera.orbit_radians(Vec2::new(0.0, 100.0));
-        assert!(camera.pitch <= PITCH_LIMIT);
+        camera.orbit_radians(Vec2::new(100.0, 100.0));
+        assert!(camera.pitch.abs() <= std::f32::consts::PI + 1.0e-4, "pitch {}", camera.pitch);
+        assert!(camera.yaw.abs() <= std::f32::consts::PI + 1.0e-4, "yaw {}", camera.yaw);
         assert!(camera.view().to_cols_array().iter().all(|v| v.is_finite()));
+    }
+}
+
+#[cfg(test)]
+mod anchor_tests {
+    use super::*;
+
+    const ASPECT: f32 = 16.0 / 9.0;
+
+    /// Where a world point lands on screen, in normalised device coordinates.
+    fn on_screen(camera: &OrbitCamera, point: Vec3) -> Vec2 {
+        let clip = camera.view_projection(ASPECT) * point.extend(1.0);
+        Vec2::new(clip.x / clip.w, clip.y / clip.w)
+    }
+
+    fn model() -> OrbitCamera {
+        let mut camera = OrbitCamera::framing(Vec3::new(3.0, -1.0, 2.0), 40.0);
+        camera.set_lattice(0.25, 40.0);
+        camera
+    }
+
+    /// A world point off the view axis, standing in for the surface an
+    /// off-centre cursor is hovering.
+    ///
+    /// Built from the camera's own axes rather than from a screen coordinate,
+    /// because the wheel's anchor is now always a picked surface point or the
+    /// target -- there is no longer any code that turns a pixel into an anchor,
+    /// and a test helper that pretended otherwise would be testing a route
+    /// nothing takes. What these tests are about is unchanged: an arbitrary
+    /// world point holds its position on screen across a zoom.
+    fn off_axis(camera: &OrbitCamera, right: f32, up: f32) -> Vec3 {
+        camera.target + camera.right() * right + camera.up() * up
+    }
+
+    /// Anchored zoom has to be a strict generalisation of the zoom it
+    /// replaces, or every existing gesture changes underneath the user.
+    /// Anchoring at the target is the case that must not move at all.
+    #[test]
+    fn zooming_about_the_target_is_the_old_zoom_exactly() {
+        let mut anchored = model();
+        let mut plain = model();
+
+        for amount in [1.0_f32, 1.0, -0.5, 3.0, -2.0] {
+            let factor = OrbitCamera::zoom_factor(amount);
+            anchored.zoom_by_about(factor, anchored.target);
+            plain.distance =
+                (plain.distance * factor).clamp(plain.min_distance(), plain.max_distance());
+            assert_eq!(anchored.distance, plain.distance);
+            assert_eq!(anchored.target, plain.target);
+        }
+    }
+
+    /// The property the whole feature is: the thing under the cursor stays
+    /// under the cursor.
+    #[test]
+    fn the_anchor_stays_under_the_cursor_across_a_zoom() {
+        for (right, up) in [(11.0, 7.0), (-18.0, -13.0), (0.0, 0.0)] {
+            let mut camera = model();
+            let anchor = off_axis(&camera, right, up);
+            let before = on_screen(&camera, anchor);
+
+            for _ in 0..20 {
+                camera.zoom_by_about(OrbitCamera::zoom_factor(1.0), anchor);
+            }
+            let after = on_screen(&camera, anchor);
+            assert!(
+                before.distance(after) < 1.0e-3,
+                "the anchor slid from {before:?} to {after:?} over twenty notches"
+            );
+        }
+    }
+
+    /// **The case that catches the obvious wrong implementation.** Scaling the
+    /// target by the requested factor and clamping the distance separately
+    /// looks right and is right everywhere except at the floor -- which is
+    /// where the user is pushing hardest and watching most closely.
+    #[test]
+    fn the_anchor_stays_pinned_even_against_the_distance_floor() {
+        let mut camera = model();
+        let anchor = off_axis(&camera, 9.0, -5.0);
+        let before = on_screen(&camera, anchor);
+
+        // Far past the floor, so most of these notches are fully clamped.
+        for _ in 0..200 {
+            camera.zoom_by_about(OrbitCamera::zoom_factor(5.0), anchor);
+        }
+        assert!(
+            (camera.distance - camera.min_distance()).abs() < 1.0e-4,
+            "the test did not actually reach the floor: {}",
+            camera.distance
+        );
+        let after = on_screen(&camera, anchor);
+        assert!(
+            before.distance(after) < 1.0e-3,
+            "the anchor un-pinned at the floor: {before:?} to {after:?}"
+        );
+    }
+
+    /// The floor has to mean the same amount of sculpting whatever the model
+    /// is, which is what expressing it in voxels buys and what expressing it
+    /// as a fraction of the radius cost.
+    #[test]
+    fn the_zoom_floor_is_the_same_number_of_voxels_on_a_small_model_and_a_large_one() {
+        let mut small = OrbitCamera::framing(Vec3::ZERO, 5.0);
+        small.set_lattice(0.01, 5.0);
+        let mut large = OrbitCamera::framing(Vec3::ZERO, 500.0);
+        large.set_lattice(0.01, 500.0);
+
+        assert!((small.min_distance() - large.min_distance()).abs() < 1.0e-9);
+        assert!((small.min_distance() - 0.02).abs() < 1.0e-6, "{}", small.min_distance());
+
+        // And it tracks the lattice, which is the thing detail is measured in.
+        let mut fine = large;
+        fine.set_lattice(0.0565, 500.0);
+        assert!(fine.min_distance() > large.min_distance());
+    }
+
+    /// A near plane that does not follow the distance clips the very thing the
+    /// camera was moved close to look at.
+    #[test]
+    fn the_target_is_never_clipped_by_the_near_plane_at_any_distance() {
+        let mut camera = model();
+        for _ in 0..400 {
+            assert!(
+                camera.near() < camera.distance * 0.5,
+                "near {} against distance {}",
+                camera.near(),
+                camera.distance
+            );
+            assert!(camera.far() > camera.distance, "the target is behind the far plane");
+            camera.zoom_by_about(OrbitCamera::zoom_factor(1.0), camera.target);
+        }
+    }
+
+    /// The depth buffer is `Depth32Float` and the projection is not reversed,
+    /// so the far-to-near ratio is what decides whether the far side of the
+    /// model z-fights. This pins the floor under `near` that keeps it bounded,
+    /// including at the closest the camera can get on the finest lattice a
+    /// large model is ever imported at.
+    #[test]
+    fn the_depth_ratio_stays_within_a_float_buffers_reach_at_every_zoom() {
+        // The dragon: 133 mm of model at 0.0565 mm, which is 230 mm of loose
+        // content radius.
+        let mut camera = OrbitCamera::framing(Vec3::ZERO, 230.0);
+        camera.set_lattice(0.0565, 230.0);
+
+        let framed = camera.far() / camera.near();
+        assert!(framed < 1_000.0, "the ratio at a framed distance is {framed}");
+
+        for _ in 0..400 {
+            camera.zoom_by_about(OrbitCamera::zoom_factor(3.0), camera.target);
+        }
+        assert!((camera.distance - camera.min_distance()).abs() < 1.0e-6);
+        let closest = camera.far() / camera.near();
+        assert!(closest < 50_000.0, "the ratio at the floor is {closest}");
+        // And still nowhere near clipping what the camera came to look at.
+        assert!(
+            camera.near() * 4.0 < camera.distance,
+            "near {} of {}",
+            camera.near(),
+            camera.distance
+        );
+    }
+
+    /// `far` is the length of every pick ray as well as the far plane, so a
+    /// value that does not cover the content silently stops the cursor working
+    /// on the far side of the model.
+    #[test]
+    fn the_pick_ray_reaches_the_far_corner_from_any_distance() {
+        let mut camera = model();
+        for _ in 0..60 {
+            let furthest = camera.eye().distance(camera.target) + camera.content_radius;
+            assert!(camera.far() >= furthest, "far {} against {furthest}", camera.far());
+            camera.zoom_by_about(OrbitCamera::zoom_factor(-1.0), camera.target);
+        }
+    }
+
+    /// Orbiting about the target is what orbiting has always been, so it has
+    /// to survive being routed through the pivoted version.
+    #[test]
+    fn orbiting_about_the_target_is_exactly_what_it_was_before() {
+        let mut pivoted = model();
+        let mut plain = model();
+
+        for delta in [Vec2::new(30.0, -10.0), Vec2::new(-5.0, 40.0), Vec2::new(0.0, 300.0)] {
+            pivoted.orbit_about(delta, pivoted.target);
+            plain.orbit(delta);
+            assert!((pivoted.yaw - plain.yaw).abs() < 1.0e-6);
+            assert!((pivoted.pitch - plain.pitch).abs() < 1.0e-6);
+            assert!(
+                pivoted.target.distance(plain.target) < 1.0e-3,
+                "the target moved: {:?} vs {:?}",
+                pivoted.target,
+                plain.target
+            );
+        }
+    }
+
+    #[test]
+    fn the_pivot_stays_at_the_same_screen_position_through_a_whole_gesture() {
+        let mut camera = model();
+        let pivot = off_axis(&camera, 8.0, 11.0);
+        let before = on_screen(&camera, pivot);
+
+        for step in 0..60 {
+            camera.orbit_about(Vec2::new(7.0, if step % 3 == 0 { -5.0 } else { 4.0 }), pivot);
+        }
+        let after = on_screen(&camera, pivot);
+        assert!(
+            before.distance(after) < 1.0e-3,
+            "the pivot drifted from {before:?} to {after:?} over sixty steps"
+        );
+    }
+
+    /// A pivot on the view axis is the degenerate case for anything that
+    /// recovers angles from a desired eye position; the basis-difference
+    /// route has no such case.
+    #[test]
+    fn orbiting_about_a_pivot_on_the_view_axis_does_not_jump() {
+        let mut camera = model();
+        let pivot = camera.eye();
+        let before = camera.eye();
+        camera.orbit_about(Vec2::new(20.0, 15.0), pivot);
+        assert!(
+            camera.eye().distance(before) < 1.0e-3,
+            "the eye left the pivot it was standing on: {:?}",
+            camera.eye()
+        );
+        assert!(camera.target.is_finite());
     }
 }

--- a/crates/brokkr-app/src/crash.rs
+++ b/crates/brokkr-app/src/crash.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What happens when the application panics, and how the next launch says so.
+//!
+//! Before this, a panic was invisible. The window vanished, the sculpt went
+//! with it, and the only trace was a backtrace on a terminal nobody launched
+//! the application from -- so on a machine that is not this one, the report
+//! that reached the maintainer was "it closed". That is a fine state of affairs
+//! while the only user builds from source; it is not one to open a beta with.
+//!
+//! # What this deliberately does NOT do
+//!
+//! **It does not save the document.** The obvious next thought is to write an
+//! emergency copy of the field from the hook, and it is a trap: the panic may
+//! be *because* the document is inconsistent, the hook has no access to it
+//! anyway -- iced owns the state -- and a corrupt emergency file written over a
+//! good autosave turns a recoverable crash into a lost afternoon. The sculpt is
+//! already covered by the two-minute autosave and `File > Recover`; this covers
+//! the thing that had nothing at all.
+//!
+//! # Rules a panic hook has to keep
+//!
+//! **It must not panic.** A panic inside a panic hook aborts the process
+//! immediately, losing the very report it was writing, so every fallible step
+//! here is `let _ =` or `if let Ok`. There is no `unwrap` in this file and
+//! there must not be one.
+//!
+//! **It must chain to the hook it replaced.** Otherwise the terminal output
+//! disappears for the developer who *is* running from a terminal, and the fix
+//! for "I cannot see crashes" would have removed the one place they were
+//! visible.
+//!
+//! **Everything written goes through [`crate::report::redact_user_paths`]**, by
+//! the same argument the bug reporter makes: a backtrace is full of build paths
+//! and a panic message can quote a filename. The file lands in the state
+//! directory beside the autosave, where a user can read it before it goes
+//! anywhere -- nothing here sends anything.
+
+use std::fmt::Write;
+
+/// Where the last crash is left for the next launch to find.
+///
+/// A state file rather than a config one: it is something the application
+/// recovers from, not something the user set. See [`crate::paths::state_file`].
+const CRASH_FILE: &str = "last-crash.txt";
+
+/// How much of a report is kept.
+///
+/// A deep recursion produces a backtrace measured in megabytes, and the point
+/// of this file is to be read -- by a person first and the bug reporter second,
+/// where it has to fit in a payload the dialog shows in full.
+const MAX_BYTES: usize = 64 * 1024;
+
+/// Install the panic hook. Call once, before the window opens.
+pub fn install() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        write_report(info);
+        // Chained last, so the report exists even if the default hook decides
+        // to abort.
+        previous(info);
+    }));
+}
+
+/// Compose the report and put it beside the autosave. Never fails loudly.
+fn write_report(info: &std::panic::PanicHookInfo<'_>) {
+    // `payload_as_str` is not stable, so this is the two-cast dance every panic
+    // hook does. A payload that is neither is not worth guessing at.
+    let payload = info
+        .payload()
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| info.payload().downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("(a panic payload that was neither &str nor String)");
+    let where_ = info.location().map(|at| (at.file().to_string(), at.line()));
+    let text = compose(payload, where_.as_ref().map(|(f, l)| (f.as_str(), *l)));
+    if let Some(path) = crate::paths::state_file(CRASH_FILE) {
+        let _ = put(&path, &text);
+    }
+}
+
+/// The report's text, from the two things a panic actually carries.
+///
+/// **Split out from the hook so it can be tested without installing one.** A
+/// test that sets the global panic hook and then panics inside `catch_unwind`
+/// is not a local act: the suite runs tests in parallel, so any OTHER test's
+/// failing assertion during that window would be swallowed by this hook instead
+/// of printing. Testing the composition directly costs nothing and cannot mask
+/// a real failure.
+fn compose(payload: &str, at: Option<(&str, u32)>) -> String {
+    let mut text = String::with_capacity(4096);
+    text.push_str("BrokkrSculpt crashed.\n\n");
+    let _ = writeln!(text, "version: {}", env!("CARGO_PKG_VERSION"));
+    let _ = writeln!(text, "target:  {}", std::env::consts::ARCH);
+    let _ = writeln!(text, "os:      {}", std::env::consts::OS);
+    if let Some((file, line)) = at {
+        let _ = writeln!(text, "at:      {file}:{line}");
+    }
+    let _ = writeln!(text, "\nmessage:\n{payload}\n");
+    let _ = writeln!(text, "backtrace:\n{}", std::backtrace::Backtrace::force_capture());
+
+    let mut redacted = crate::report::redact_user_paths(&text);
+    if redacted.len() > MAX_BYTES {
+        // On a char boundary, because the result is written as UTF-8 and read
+        // back as a String.
+        let mut cut = MAX_BYTES;
+        while cut > 0 && !redacted.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        redacted.truncate(cut);
+        redacted.push_str("\n\n[truncated]\n");
+    }
+    redacted
+}
+
+/// Write a report to a given path, creating the directory. Errors are dropped.
+fn put(path: &std::path::Path, text: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, text)
+}
+
+/// Take a report from a given path. The path is a parameter so a test never
+/// touches the real one -- the suite runs in parallel, and two tests sharing
+/// one file race, while clobbering the real file would swallow a crash report
+/// the developer had not read yet.
+fn take_from(path: &std::path::Path) -> Option<String> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let _ = std::fs::remove_file(path);
+    let trimmed = text.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// The report a previous run left, if there is one, removing it as it goes.
+///
+/// **Taken and not merely read**, so a crash is announced once. Left in place
+/// it would greet the user on every launch for ever, and a notice that is
+/// always there is one nobody reads -- which is the state the autosave notice
+/// was deliberately designed out of.
+pub fn take_pending() -> Option<String> {
+    take_from(&crate::paths::state_file(CRASH_FILE)?)
+}
+
+/// Where a crash report would be written, for the message that mentions it.
+pub fn report_path() -> Option<std::path::PathBuf> {
+    crate::paths::state_file(CRASH_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("brokkr-crash-test-{name}-{}", std::process::id()))
+    }
+
+    /// **A crash is announced once, not for ever.**
+    ///
+    /// The autosave notice is shown whenever an autosave exists, which is right
+    /// for a file that stays useful. A crash report is not that: left in place
+    /// it would greet every launch until the file were deleted by hand, and a
+    /// notice that is always there is one nobody reads.
+    #[test]
+    fn a_pending_report_is_taken_rather_than_read() {
+        let path = scratch("taken");
+        put(&path, "a crash from a previous run").expect("the temp dir is writable");
+
+        assert_eq!(take_from(&path).as_deref(), Some("a crash from a previous run"));
+        assert_eq!(take_from(&path), None, "the report was announced a second time");
+        assert!(!path.exists(), "the report file outlived being taken");
+    }
+
+    /// **A report carries the panic and not the user's home directory.**
+    ///
+    /// A backtrace is full of build paths and a panic message can quote a
+    /// filename, which is the whole reason this goes through
+    /// `redact_user_paths` -- the same argument the bug reporter makes about
+    /// everything it collects.
+    #[test]
+    fn a_report_carries_the_panic_and_no_home_directory() {
+        let text = compose(
+            "the field went missing at /home/somebody/Models/secret.brokkr",
+            Some(("crates/brokkr-app/src/volume.rs", 42)),
+        );
+
+        assert!(text.contains("the field went missing"), "the message is missing: {text}");
+        assert!(text.contains("volume.rs:42"), "the panic location is missing: {text}");
+        assert!(text.contains("backtrace:"), "no backtrace was captured");
+        assert!(
+            !text.contains("somebody"),
+            "the report carries an unredacted home directory: {text}"
+        );
+    }
+
+    /// An empty or whitespace-only file is not a crash.
+    ///
+    /// A zero-byte file is what a run killed mid-write leaves, and announcing
+    /// "the last session crashed" over nothing would train the user to ignore
+    /// the message that matters.
+    #[test]
+    fn an_empty_report_file_is_not_announced() {
+        let path = scratch("empty");
+        put(&path, "   \n\t\n ").expect("the temp dir is writable");
+        assert_eq!(take_from(&path), None);
+    }
+}

--- a/crates/brokkr-app/src/cursor.rs
+++ b/crates/brokkr-app/src/cursor.rs
@@ -29,7 +29,7 @@ use brokkr_core::{Brush, BrushDirection, FalloffCurve, MaskOp, MirrorAxis, Symme
 use brokkr_gpu::OverlayBatch;
 use glam::Vec3;
 
-use crate::theme;
+use crate::theme::{self, linear};
 
 /// Segments in a ring. Sixty four is smooth at any size the interface offers
 /// and is still only 128 line vertices.
@@ -89,16 +89,6 @@ pub enum CursorMood {
     /// because they really are two things; these two are one thing and its
     /// inverse.
     Unmasking,
-}
-
-/// Convert a theme colour to the linear space the overlay shader expects.
-///
-/// The tokens in [`crate::theme`] are sRGB, because they came from SindriCAD's
-/// CSS. Handing those straight to the shader would draw every overlay too
-/// bright, and inconsistently with the model beside it.
-fn linear(colour: iced::Color, alpha: f32) -> [f32; 4] {
-    let to_linear = |c: f32| c.powf(2.2);
-    [to_linear(colour.r), to_linear(colour.g), to_linear(colour.b), alpha]
 }
 
 /// The distance, as a fraction of the radius, at which a falloff curve has

--- a/crates/brokkr-app/src/gizmo.rs
+++ b/crates/brokkr-app/src/gizmo.rs
@@ -66,12 +66,20 @@ const HEAD_PX: f32 = 18.0;
 const HEAD_RADIUS_PX: f32 = 6.0;
 /// Half-width of the shaft ribbon.
 const SHAFT_HALF_PX: f32 = 1.6;
-/// Radius of the rotation rings. Clear of the arrowheads, which end at
 /// Where the per-axis scale box sits along its axis, in pixels.
 ///
-/// Between the move arrow's head and the rotation ring, so the three handles on
-/// one axis never compete for a pixel: the arrow ends at `SHAFT_PX + HEAD_PX`
-/// (80), this box is centred at 92, and the ring is at 104.
+/// Between the move arrow's head and the rotation ring: the arrow ends at
+/// `SHAFT_PX + HEAD_PX` (80), this box is centred at 92, and [`RING_PX`] is
+/// 128.
+///
+/// **Do not read that spacing as "these three never compete for a pixel",
+/// which is what this comment used to say.** They are clear in WORLD units
+/// along the axis and that is not the question -- a ring is a circle seen at
+/// an angle, so its projection sweeps every radius from 0 to `RING_PX` as the
+/// camera turns and crosses this box at a large fraction of camera angles.
+/// Moving the ring from 104 to 128 reduced that; it did not remove it. Any
+/// change to the spacing has to be judged by sweeping cameras and picking,
+/// never by comparing these constants.
 const SCALE_BOX_PX: f32 = 92.0;
 
 /// Half the scale box's side, in pixels. Its grab region is this plus GRAB_PX.
@@ -142,7 +150,7 @@ const SCALE_SNAP: f32 = 0.05;
 /// is the half that was missing and the half that mattered: `Similarity::then`
 /// multiplies scales, so two drags each saturating this ceiling compose to 400
 /// and ten drags at the floor compose to 1e-13. See the clamp in [`drag`].
-const MIN_SCALE: f32 = 0.05;
+pub(crate) const MIN_SCALE: f32 = 0.05;
 pub(crate) const MAX_SCALE: f32 = 20.0;
 
 /// One thing on the gizmo that can be grabbed.
@@ -275,6 +283,39 @@ fn to_pixels(camera: &OrbitCamera, viewport: Vec2, point: Vec3) -> Option<Vec2> 
 
 fn axis_of(index: u8) -> Vec3 {
     [Vec3::X, Vec3::Y, Vec3::Z][index as usize % 3]
+}
+
+/// The world direction a per-axis scale box sits on: the BODY's axis.
+///
+/// **The one place the gizmo is not square to the world, and it has to be.**
+/// The module header is right that a move and a quarter turn stay on world axes
+/// because that is where the exact route lives -- but a scale is never
+/// `Bake::Exact`, so nothing is given up here.
+///
+/// What forced it: `Similarity::then` stores `rotation = next.rotation *
+/// self.rotation` and `scale = next.scale * self.scale`, and `transform_point`
+/// applies `R * (S * p)`. Composed onto a rotation already in `pinned`, that is
+/// `R2 R1 S2 S1 p` where the stepwise truth is `R2 S2 R1 S1 p`. Those are not
+/// the same map -- but the composition is not broken, because
+/// `R1 S2 = (R1 S2 R1inv) R1`, so what it computes is a squash along the body's
+/// OWN axes. Perfectly representable, which is why the composed placement stays
+/// a valid `R S p + t` and why nothing in `similarity.rs` needs changing.
+///
+/// The lie was told here: the box was drawn and dragged on the world axis while
+/// the squash went along the body's. After an ordinary snapped quarter turn --
+/// `ROTATION_SNAP` is a quarter turn, so the DEFAULT unshifted ring drag leaves
+/// a rotation in `pinned` -- a squash to 0.6 landed 8.49 mm from where the
+/// handle said it would.
+///
+/// Taken from `placement` and NOT from `pinned`, which was the first version
+/// and did nothing at all: `pinned` is only latched when a button goes down, so
+/// after a completed turn it still holds the identity and the box stayed on the
+/// world axis exactly as before. The two agree during a scale drag anyway -- a
+/// scale gesture carries an identity rotation, so `pinned.then(gesture)` leaves
+/// the rotation untouched -- so there is nothing to be gained by the staler of
+/// the two and a whole fix to be lost.
+fn scale_axis_of(gizmo: &Gizmo, index: u8) -> Vec3 {
+    gizmo.placement.rotation * axis_of(index)
 }
 
 /// The two axes a plane handle spans, or a ring lies in.
@@ -421,7 +462,7 @@ pub fn pick(camera: &OrbitCamera, viewport: Vec2, gizmo: &Gizmo, at: Vec2) -> Op
     // Giving the ring first refusal costs the box nothing, because a press that
     // the ring wanted was never meant for the box.
     for index in 0..3u8 {
-        let box_centre = origin + axis_of(index) * (SCALE_BOX_PX * scale);
+        let box_centre = origin + scale_axis_of(gizmo, index) * (SCALE_BOX_PX * scale);
         if let Some(pixel) = to_pixels(camera, viewport, box_centre)
             && at.distance(pixel) <= SCALE_BOX_HALF_PX + GRAB_PX
         {
@@ -459,7 +500,23 @@ fn inside_polygon(corners: &[Vec2], at: Vec2) -> bool {
         positive |= cross > 0.0;
         negative |= cross < 0.0;
     }
-    !(positive && negative)
+    // **A polygon with no area contains nothing, and saying so takes the second
+    // clause.** Seen exactly edge-on, a plane handle's four corners project
+    // onto one line; every cross product is then exactly zero, neither flag is
+    // set, and `!(positive && negative)` alone answers TRUE for every point
+    // tested against it. Since `Plane` outranks `Axis` in the precedence, the
+    // handle swallowed the arrow drawn straight through it.
+    //
+    // Reachable in one click rather than by contrivance: at yaw 0 the corners
+    // of `plane_quad(0)` project to the same column to the last bit, and at
+    // pitch 0 plane 1 is collinear along the centre row at ANY yaw -- and the
+    // navigation cube's Front face flies the camera to exactly 0.0 on both.
+    //
+    // The damage is one pixel wide, not a dead handle: a point OFF the line
+    // still sees the doubled-back edges disagree and is correctly refused. But
+    // the pixel it takes is the arrow's own centreline, which is where a user
+    // aiming at an arrow puts the stylus.
+    !(positive && negative) && (positive || negative)
 }
 
 /// The gesture a drag from `from` to `to` describes, about the gizmo's pinned
@@ -568,9 +625,21 @@ pub fn drag(
             // drag that comes back to the pixel it started on must be exactly
             // the identity, and a clamp that could exclude it would make a
             // gesture uncancellable by hand.
-            let pinned = gizmo.pinned.scale.max_element().max(f32::MIN_POSITIVE);
-            let highest = (gizmo.max_scale / pinned).clamp(1.0, MAX_SCALE);
-            let lowest = MIN_SCALE.max(MIN_SCALE / pinned).min(1.0);
+            //
+            // **The floor comes off the SMALLEST axis and the ceiling off the
+            // largest**, because `Similarity::then` multiplies scales component
+            // by component, so it is the smallest axis that reaches `MIN_SCALE`
+            // first and the largest that reaches the ceiling first. Taking both
+            // from `max_element` -- which is what this did -- meant that after
+            // a per-axis squash to (1, 1, 0.05) the floor was computed from 1.0
+            // again, and the next uniform shrink composed to (0.05, 0.05,
+            // 0.0025): twenty times under `MIN_SCALE`, which is precisely the
+            // state that constant exists to prevent. `Handle::Scale` never had
+            // the bug because it bounds against its own axis.
+            let smallest = gizmo.pinned.scale.min_element().max(f32::MIN_POSITIVE);
+            let largest = gizmo.pinned.scale.max_element().max(f32::MIN_POSITIVE);
+            let highest = (gizmo.max_scale / largest).clamp(1.0, MAX_SCALE);
+            let lowest = MIN_SCALE.max(MIN_SCALE / smallest).min(1.0);
             let mut scale = (centre.distance(to) / started).clamp(lowest, highest);
             if snap.is_some() {
                 scale = ((scale / SCALE_SNAP).round() * SCALE_SNAP).clamp(lowest, highest);
@@ -585,7 +654,11 @@ pub fn drag(
             // to ONE component.** Measured along the projected axis rather than
             // radially, because a squash reads as "pull this end" and a radial
             // measure would grow it when the pointer moved sideways.
-            let axis = axis_of(index);
+            //
+            // The BODY's axis, matching where the box is drawn and picked. See
+            // [`scale_axis_of`] for why that is not the world axis and why this
+            // is the one part of the gizmo that turns with the body.
+            let axis = scale_axis_of(gizmo, index);
             let Some(centre) = to_pixels(camera, viewport, origin) else {
                 return Similarity::IDENTITY;
             };
@@ -718,22 +791,44 @@ pub fn build(batch: &mut OverlayBatch, camera: &OrbitCamera, viewport: Vec2, giz
         // another cone, because a second cone on the same axis reads as a
         // longer arrow and the two handles do different things -- this is the
         // one that squashes.
+        //
+        // **Drawn only if pressing its own centre would actually select it.**
+        // The box is 5 px square at 92 px and the ring's PROJECTION sweeps
+        // every radius out to `RING_PX` as the camera turns, so at a large
+        // fraction of angles the box's own centre pixel belongs to an arrow or
+        // a ring -- measured, before the boxes moved onto the body's axes, at
+        // roughly half of them, split across `Axis`, `Ring` and `Uniform`. A
+        // handle that is drawn where it cannot be pressed is worse than one
+        // that is absent: the user aims at it, gets a move or a turn, and sees
+        // the wrong thing light up.
+        //
+        // Asked of `pick` rather than re-derived from the constants, so the
+        // draw and the hit test cannot drift apart -- which is exactly the
+        // failure that put the ring at 104 through the box at 92, and which
+        // reasoning about world-space gaps got wrong. It is three extra `pick`
+        // calls a frame against a handful of handles, and it is the same
+        // honesty `MIN_SHAFT_PX` already gives the arrow.
         let box_colour = colour(Handle::Scale(index));
-        let box_centre = origin + axis * (SCALE_BOX_PX * scale);
+        let box_centre = origin + scale_axis_of(gizmo, index) * (SCALE_BOX_PX * scale);
+        let box_is_reachable = to_pixels(camera, viewport, box_centre).is_some_and(|pixel| {
+            pick(camera, viewport, gizmo, pixel) == Some(Handle::Scale(index))
+        });
         let half = SCALE_BOX_HALF_PX * scale;
         let (u, v) = other_axes(index);
-        for face in 0..3usize {
-            let normal = [axis, u, v][face];
-            let (a, b) = ([u, v, axis][face], [v, axis, u][face]);
-            for sign in [-1.0f32, 1.0] {
-                let middle = box_centre + normal * (half * sign);
-                batch.push_quad(
-                    middle - a * half - b * half,
-                    middle + a * half - b * half,
-                    middle + a * half + b * half,
-                    middle - a * half + b * half,
-                    box_colour,
-                );
+        if box_is_reachable {
+            for face in 0..3usize {
+                let normal = [axis, u, v][face];
+                let (a, b) = ([u, v, axis][face], [v, axis, u][face]);
+                for sign in [-1.0f32, 1.0] {
+                    let middle = box_centre + normal * (half * sign);
+                    batch.push_quad(
+                        middle - a * half - b * half,
+                        middle + a * half - b * half,
+                        middle + a * half + b * half,
+                        middle - a * half + b * half,
+                        box_colour,
+                    );
+                }
             }
         }
 
@@ -802,6 +897,115 @@ pub fn build(batch: &mut OverlayBatch, camera: &OrbitCamera, viewport: Vec2, giz
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// **Every scale box that is drawn can be pressed.**
+    ///
+    /// A 5 px square at 92 px, with a ring whose PROJECTION sweeps every radius
+    /// out to `RING_PX` as the camera turns: at a large fraction of angles the
+    /// box's own centre pixel belongs to an arrow or a ring instead. Measured
+    /// before this gate, the box's centre was stolen at roughly half of camera
+    /// angles, split across `Axis`, `Ring` and `Uniform`. Aiming at a handle
+    /// and watching a different one light up is worse than the handle not
+    /// being there.
+    ///
+    /// Swept over cameras rather than argued from the constants, because
+    /// arguing from the constants is precisely what put a ring at 104 through a
+    /// box at 92 and called them twelve pixels clear.
+    #[test]
+    fn every_scale_box_that_is_drawn_can_be_pressed() {
+        let mut drawn = 0;
+        let mut checked = 0;
+        for yaw_step in 0..12 {
+            for pitch_step in 0..5 {
+                let mut camera = camera();
+                camera.yaw = yaw_step as f32 * std::f32::consts::TAU / 12.0;
+                camera.pitch = -0.8 + pitch_step as f32 * 0.4;
+                let gizmo = gizmo();
+                let origin = gizmo.origin();
+                let scale = world_per_pixel(&camera, origin, VIEWPORT.y);
+
+                for index in 0..3u8 {
+                    let centre = origin + scale_axis_of(&gizmo, index) * (SCALE_BOX_PX * scale);
+                    let Some(pixel) = to_pixels(&camera, VIEWPORT, centre) else {
+                        continue;
+                    };
+                    checked += 1;
+                    // `build` draws the box exactly when this holds, so the two
+                    // cannot disagree; what this asserts is that the rule is
+                    // the reachability one and not something weaker.
+                    if pick(&camera, VIEWPORT, &gizmo, pixel) == Some(Handle::Scale(index)) {
+                        drawn += 1;
+                    }
+                }
+            }
+        }
+        assert!(checked > 0, "the sweep projected no boxes at all");
+        assert!(
+            drawn > 0,
+            "not one scale box was reachable at any of {checked} camera-and-axis pairs, so the \
+             gate has switched the handle off entirely rather than hidden the unreachable ones"
+        );
+        assert!(
+            drawn < checked,
+            "every one of {checked} pairs was reachable, so this sweep never exercises the \
+             case the gate exists for and would pass with the gate removed"
+        );
+    }
+
+    /// **A polygon with no area contains nothing.**
+    ///
+    /// `inside_polygon` was `!(positive && negative)`. A plane handle seen
+    /// exactly edge-on projects its four corners onto one line, every cross
+    /// product is then exactly zero, neither flag is set, and the test answered
+    /// TRUE for every point put to it -- and `Plane` outranks `Axis`, so the
+    /// handle swallowed the arrow drawn straight through it.
+    ///
+    /// **Tested here rather than through a camera, and the reason is worth
+    /// recording.** The end-to-end path could not be made to reproduce it:
+    /// when a plane is close enough to edge-on for its corners to be collinear
+    /// to the last bit, some of them are also behind the near plane, so
+    /// `to_pixels` returns `None`, `all_on_screen` is false and `pick` skips
+    /// the handle before this function is ever called. That is a SECOND reason
+    /// the press is refused, not a reason the first one is sound -- it depends
+    /// on the near plane, which `apply_view` derives from the body and which
+    /// this branch has already had to fix once. The predicate is wrong on its
+    /// own terms and is fixed on its own terms.
+    #[test]
+    fn a_polygon_with_no_area_contains_nothing() {
+        // Four corners on one horizontal line, in the order `plane_quad`
+        // produces: near-near, far-near, far-far, near-far. Collapsed onto a
+        // line, that doubles back on itself exactly as an edge-on quad does.
+        let flat = [
+            Vec2::new(20.0, 50.0),
+            Vec2::new(40.0, 50.0),
+            Vec2::new(40.0, 50.0),
+            Vec2::new(20.0, 50.0),
+        ];
+
+        assert!(
+            !inside_polygon(&flat, Vec2::new(30.0, 50.0)),
+            "a zero-area quad claimed a point lying on its own line"
+        );
+        assert!(
+            !inside_polygon(&flat, Vec2::new(30.0, 51.0)),
+            "a zero-area quad claimed a point off its line"
+        );
+
+        // And a real quad still contains what it should, so the second clause
+        // has not simply switched the handle off.
+        let real = [
+            Vec2::new(20.0, 20.0),
+            Vec2::new(40.0, 20.0),
+            Vec2::new(40.0, 40.0),
+            Vec2::new(20.0, 40.0),
+        ];
+        assert!(inside_polygon(&real, Vec2::new(30.0, 30.0)), "a real quad lost its middle");
+        assert!(inside_polygon(&real, Vec2::new(20.0, 30.0)), "a real quad lost its own edge");
+        assert!(
+            !inside_polygon(&real, Vec2::new(10.0, 30.0)),
+            "a real quad claimed a point outside it"
+        );
+    }
 
     const VIEWPORT: Vec2 = Vec2::new(1280.0, 720.0);
     const VOXEL: f32 = 0.5;

--- a/crates/brokkr-app/src/gizmo.rs
+++ b/crates/brokkr-app/src/gizmo.rs
@@ -67,8 +67,26 @@ const HEAD_RADIUS_PX: f32 = 6.0;
 /// Half-width of the shaft ribbon.
 const SHAFT_HALF_PX: f32 = 1.6;
 /// Radius of the rotation rings. Clear of the arrowheads, which end at
-/// `SHAFT_PX + HEAD_PX`, so the two never compete for the same pixel.
-const RING_PX: f32 = 104.0;
+/// Where the per-axis scale box sits along its axis, in pixels.
+///
+/// Between the move arrow's head and the rotation ring, so the three handles on
+/// one axis never compete for a pixel: the arrow ends at `SHAFT_PX + HEAD_PX`
+/// (80), this box is centred at 92, and the ring is at 104.
+const SCALE_BOX_PX: f32 = 92.0;
+
+/// Half the scale box's side, in pixels. Its grab region is this plus GRAB_PX.
+const SCALE_BOX_HALF_PX: f32 = 5.0;
+
+/// The rotation ring's radius, in pixels.
+///
+/// **Moved out from 104 to make room for the per-axis scale box**, and the
+/// reason is worth keeping: at 104 the ring's PROJECTION passed over the box at
+/// 92 even though the two are twelve pixels apart in world terms. A ring is a
+/// circle seen at an angle, so its screen distance from a point on the axis is
+/// not its world distance, and reasoning about the gap in world pixels said
+/// they were clear when they were not. A test caught it -- a press aimed at the
+/// box came back `Ring(1)`.
+pub const RING_PX: f32 = 128.0;
 /// Half-width of a ring's band.
 const RING_HALF_PX: f32 = 2.0;
 /// How many segments a ring is drawn and picked with.
@@ -138,6 +156,8 @@ pub enum Handle {
     Plane(u8),
     Ring(u8),
     Uniform,
+    /// Squash or stretch along ONE axis. What `Uniform` is not.
+    Scale(u8),
 }
 
 impl Handle {
@@ -147,6 +167,7 @@ impl Handle {
             Handle::Axis(_) | Handle::Plane(_) => "move",
             Handle::Ring(_) => "turn",
             Handle::Uniform => "scale",
+            Handle::Scale(_) => "resize",
         }
     }
 }
@@ -391,6 +412,23 @@ pub fn pick(camera: &OrbitCamera, viewport: Vec2, gizmo: &Gizmo, at: Vec2) -> Op
         }
     }
 
+    // **After the rings and before the shafts, and the order is arithmetic
+    // rather than taste.** The box is centred at SCALE_BOX_PX (92) and grabs
+    // within SCALE_BOX_HALF_PX + GRAB_PX (13), so it reaches 79..105 -- which
+    // overlaps the ring at RING_PX (104) at one end and the arrow head ending
+    // at SHAFT_PX + HEAD_PX (80) at the other. Testing it first swallowed every
+    // ring press, and a test caught it: a free turn reported an exact move.
+    // Giving the ring first refusal costs the box nothing, because a press that
+    // the ring wanted was never meant for the box.
+    for index in 0..3u8 {
+        let box_centre = origin + axis_of(index) * (SCALE_BOX_PX * scale);
+        if let Some(pixel) = to_pixels(camera, viewport, box_centre)
+            && at.distance(pixel) <= SCALE_BOX_HALF_PX + GRAB_PX
+        {
+            return Some(Handle::Scale(index));
+        }
+    }
+
     None
 }
 
@@ -504,7 +542,7 @@ pub fn drag(
             if angle == 0.0 {
                 return Similarity::IDENTITY;
             }
-            Similarity::about(origin, Quat::from_axis_angle(normal, angle), 1.0, Vec3::ZERO)
+            Similarity::about(origin, Quat::from_axis_angle(normal, angle), Vec3::ONE, Vec3::ZERO)
         }
         Handle::Uniform => {
             let Some(centre) = to_pixels(camera, viewport, origin) else {
@@ -530,7 +568,7 @@ pub fn drag(
             // drag that comes back to the pixel it started on must be exactly
             // the identity, and a clamp that could exclude it would make a
             // gesture uncancellable by hand.
-            let pinned = gizmo.pinned.scale.max(f32::MIN_POSITIVE);
+            let pinned = gizmo.pinned.scale.max_element().max(f32::MIN_POSITIVE);
             let highest = (gizmo.max_scale / pinned).clamp(1.0, MAX_SCALE);
             let lowest = MIN_SCALE.max(MIN_SCALE / pinned).min(1.0);
             let mut scale = (centre.distance(to) / started).clamp(lowest, highest);
@@ -540,6 +578,50 @@ pub fn drag(
             if scale == 1.0 {
                 return Similarity::IDENTITY;
             }
+            Similarity::about(origin, Quat::IDENTITY, Vec3::splat(scale), Vec3::ZERO)
+        }
+        Handle::Scale(index) => {
+            // **Per-axis scale: the same screen measure as `Uniform`, applied
+            // to ONE component.** Measured along the projected axis rather than
+            // radially, because a squash reads as "pull this end" and a radial
+            // measure would grow it when the pointer moved sideways.
+            let axis = axis_of(index);
+            let Some(centre) = to_pixels(camera, viewport, origin) else {
+                return Similarity::IDENTITY;
+            };
+            // A screen direction for this axis, from the body's own extent so
+            // it is long enough to project stably. Only the DIRECTION is used
+            // -- the length cancels in the ratio below -- so any positive
+            // world length would do, and a large one keeps the projection out
+            // of the noise.
+            let span = (gizmo.base_high - gizmo.base_low).length().max(1.0);
+            let Some(tip) = to_pixels(camera, viewport, origin + axis * span) else {
+                return Similarity::IDENTITY;
+            };
+            let along = tip - centre;
+            let length = along.length();
+            if length < 1.0 {
+                // The axis points at the eye, so there is no screen direction
+                // to measure along and any answer would be noise.
+                return Similarity::IDENTITY;
+            }
+            let direction = along / length;
+            let started = (from - centre).dot(direction);
+            if started.abs() < 1.0 {
+                return Similarity::IDENTITY;
+            }
+            let pinned = gizmo.pinned.scale[index as usize].max(f32::MIN_POSITIVE);
+            let highest = (gizmo.max_scale / pinned).clamp(1.0, MAX_SCALE);
+            let lowest = MIN_SCALE.max(MIN_SCALE / pinned).min(1.0);
+            let mut factor = ((to - centre).dot(direction) / started).clamp(lowest, highest);
+            if snap.is_some() {
+                factor = ((factor / SCALE_SNAP).round() * SCALE_SNAP).clamp(lowest, highest);
+            }
+            if factor == 1.0 {
+                return Similarity::IDENTITY;
+            }
+            let mut scale = Vec3::ONE;
+            scale[index as usize] = factor;
             Similarity::about(origin, Quat::IDENTITY, scale, Vec3::ZERO)
         }
     }
@@ -630,6 +712,29 @@ pub fn build(batch: &mut OverlayBatch, camera: &OrbitCamera, viewport: Vec2, giz
             let b = ring_point(tip, scale, index, HEAD_RADIUS_PX, step + 1);
             batch.push_triangle(apex, a, b, shaft_colour);
             batch.push_triangle(tip, b, a, shaft_colour);
+        }
+
+        // The per-axis scale box, past the arrow head. A cube rather than
+        // another cone, because a second cone on the same axis reads as a
+        // longer arrow and the two handles do different things -- this is the
+        // one that squashes.
+        let box_colour = colour(Handle::Scale(index));
+        let box_centre = origin + axis * (SCALE_BOX_PX * scale);
+        let half = SCALE_BOX_HALF_PX * scale;
+        let (u, v) = other_axes(index);
+        for face in 0..3usize {
+            let normal = [axis, u, v][face];
+            let (a, b) = ([u, v, axis][face], [v, axis, u][face]);
+            for sign in [-1.0f32, 1.0] {
+                let middle = box_centre + normal * (half * sign);
+                batch.push_quad(
+                    middle - a * half - b * half,
+                    middle + a * half - b * half,
+                    middle + a * half + b * half,
+                    middle - a * half + b * half,
+                    box_colour,
+                );
+            }
         }
 
         // The plane handle.
@@ -1065,9 +1170,9 @@ mod tests {
             middle + Vec2::new(80.0, 0.0),
             Some(VOXEL),
         );
-        assert!(out.scale > 1.5, "the fixture did not grow: {}", out.scale);
+        assert!(out.scale.max_element() > 1.5, "the fixture did not grow: {:?}", out.scale);
         let back = drag(&camera, VIEWPORT, &gizmo, Handle::Uniform, from, from, Some(VOXEL));
-        assert_eq!(back.scale, 1.0);
+        assert_eq!(back.scale, Vec3::ONE);
     }
 
     /// **The bound is on the total, and one gesture cannot see the total.**
@@ -1102,13 +1207,13 @@ mod tests {
             gizmo.placement = gizmo.pinned.then(gesture);
             gizmo.pinned = gizmo.placement;
             assert!(
-                gizmo.placement.scale <= 6.0 + 1.0e-4,
+                gizmo.placement.scale.max_element() <= 6.0 + 1.0e-4,
                 "round {round} composed to {}, past a ceiling of 6",
                 gizmo.placement.scale
             );
         }
         assert!(
-            gizmo.placement.scale > 1.0,
+            gizmo.placement.scale.max_element() > 1.0,
             "the fixture never grew the body at all, so it proves nothing"
         );
     }
@@ -1128,13 +1233,13 @@ mod tests {
             gizmo.placement = gizmo.pinned.then(gesture);
             gizmo.pinned = gizmo.placement;
             assert!(
-                gizmo.placement.scale >= MIN_SCALE - 1.0e-6,
+                gizmo.placement.scale.min_element() >= MIN_SCALE - 1.0e-6,
                 "round {round} composed down to {}, under a floor of {MIN_SCALE}",
                 gizmo.placement.scale
             );
         }
         assert!(
-            gizmo.placement.scale < 1.0,
+            gizmo.placement.scale.min_element() < 1.0,
             "the fixture never shrank the body at all, so it proves nothing"
         );
     }
@@ -1147,7 +1252,7 @@ mod tests {
         let camera = camera();
         let mut gizmo = gizmo();
         gizmo.max_scale = 1.0;
-        gizmo.pinned = Similarity::about(gizmo.origin(), Quat::IDENTITY, 1.0, Vec3::ZERO);
+        gizmo.pinned = Similarity::about(gizmo.origin(), Quat::IDENTITY, Vec3::ONE, Vec3::ZERO);
         let from = centre(&camera, &gizmo) + Vec2::new(30.0, 0.0);
 
         for snap in [Some(VOXEL), None] {

--- a/crates/brokkr-app/src/gizmo.rs
+++ b/crates/brokkr-app/src/gizmo.rs
@@ -516,7 +516,9 @@ fn inside_polygon(corners: &[Vec2], at: Vec2) -> bool {
     // still sees the doubled-back edges disagree and is correctly refused. But
     // the pixel it takes is the arrow's own centreline, which is where a user
     // aiming at an arrow puts the stylus.
-    !(positive && negative) && (positive || negative)
+    // "the signs disagree, and at least one sign exists", which is exactly
+    // what a point inside a polygon of non-zero area looks like.
+    positive != negative
 }
 
 /// The gesture a drag from `from` to `to` describes, about the gizmo's pinned

--- a/crates/brokkr-app/src/gizmo.rs
+++ b/crates/brokkr-app/src/gizmo.rs
@@ -1,0 +1,1211 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The transform gizmo: move, turn and scale one body.
+//!
+//! Three arrows to move along an axis, three squares to move in a plane, three
+//! rings to turn about an axis, and a box in the middle to scale. It rides the
+//! overlay pass the brush ring, the mirror planes and the navigation cube
+//! already share -- see `brokkr_gpu::overlay`, whose header asks that the next
+//! overlay use the third mechanism rather than inventing a fourth, and
+//! `SculptRenderer::overlay_pass`, which the cube's own pass was generalised
+//! into for it.
+//!
+//! # The gizmo is aligned to the WORLD, always, and that is not a preference
+//!
+//! Blender offers global and local orientations and calls it a setting. Here it
+//! cannot be one. A whole-voxel translation is a translation along the world
+//! axes and a lossless quarter turn is a turn about a world axis, so a gizmo
+//! that rotated with the body would put its second gesture on axes the lattice
+//! does not have -- and every subsequent move and turn would fall through to a
+//! resample. The gizmo stays square to the world because that is where the
+//! exact route lives.
+//!
+//! # What the drag produces, and what it does NOT do
+//!
+//! [`drag`] returns the gesture as an ABSOLUTE [`Similarity`] measured from the
+//! pixel the button went down on, never an increment from the last pointer
+//! event. Accumulating increments makes a gesture's result depend on how many
+//! motion events the operating system happened to deliver, so an identical
+//! sweep of the hand gives a different answer on a busy frame; and it makes
+//! "drag out and come back" merely approximately the identity, where the point
+//! of the whole design is that it is exactly the identity.
+//!
+//! Nothing here touches a [`brokkr_core::Volume`]. The gesture is arithmetic on
+//! a camera and two pixels; the field is rebuilt once, on release, by
+//! `Brokkr::rebake_gizmo`.
+//!
+//! # One scale factor for the draw and the hit test
+//!
+//! [`world_per_pixel`] is called once per frame and its result is threaded
+//! through both [`build`] and [`pick`]. Keeping two of them -- a constant
+//! screen size for the draw and a world-space tolerance for the picking -- is
+//! the bug Unreal and tinygizmo have both shipped: they agree at one distance
+//! and drift apart everywhere else, and the camera work this sits on top of has
+//! just made a much wider range of distances reachable.
+//!
+//! # Shafts are quads, not lines
+//!
+//! wgpu's `PrimitiveState` has no line-width field and the overlay pipelines
+//! are built with `multisample: Default::default()`, so a `push_line` shaft is
+//! one physical pixel wide -- unaimable with a stylus, which is the input this
+//! application is built around. Every part of the gizmo except the drag
+//! preview box is therefore triangles.
+
+use brokkr_core::{NodeId, Similarity};
+use brokkr_gpu::OverlayBatch;
+use glam::{Quat, Vec2, Vec3};
+
+use crate::camera::OrbitCamera;
+use crate::theme;
+
+/// Length of an arrow's shaft, in logical pixels.
+const SHAFT_PX: f32 = 62.0;
+/// Length of the cone on the end of it.
+const HEAD_PX: f32 = 18.0;
+/// Radius of that cone's base.
+const HEAD_RADIUS_PX: f32 = 6.0;
+/// Half-width of the shaft ribbon.
+const SHAFT_HALF_PX: f32 = 1.6;
+/// Radius of the rotation rings. Clear of the arrowheads, which end at
+/// `SHAFT_PX + HEAD_PX`, so the two never compete for the same pixel.
+const RING_PX: f32 = 104.0;
+/// Half-width of a ring's band.
+const RING_HALF_PX: f32 = 2.0;
+/// How many segments a ring is drawn and picked with.
+const RING_SEGMENTS: usize = 48;
+/// Near and far edges of a plane handle, along each of its two axes.
+const PLANE_NEAR_PX: f32 = 20.0;
+const PLANE_FAR_PX: f32 = 40.0;
+/// Half-extent of the box in the middle, which scales.
+const CENTRE_PX: f32 = 8.0;
+
+/// How near a handle the pointer has to be, in logical pixels.
+///
+/// Blender settled at "a few pixels" and then reopened it (T68525) because a
+/// few pixels is not enough with a tablet, where there is no cursor resting
+/// against the target to nudge. Eight is chosen for the stylus.
+const GRAB_PX: f32 = 8.0;
+
+/// How long an axis has to be ON SCREEN before it may be grabbed.
+///
+/// An axis pointing nearly at the camera projects to almost nothing, and the
+/// drag maths for it is anomalous rather than merely imprecise: the ray and the
+/// axis are close to parallel, so the closest-point solve divides by something
+/// near zero and a one-pixel move sends the body a hundred millimetres. Refuse
+/// it instead. The plane handles cover the same motion, and their maths is
+/// well conditioned at exactly the angle this is not.
+const MIN_SHAFT_PX: f32 = 12.0;
+
+/// The coarsest snap a rotation is offered, and the only one worth having.
+///
+/// **A quarter turn, and deliberately not five or fifteen degrees.** The whole
+/// value of snapping here is that a snapped gesture takes
+/// [`brokkr_core::Bake::Exact`] and costs the surface nothing; a fifteen degree
+/// snap is exactly as lossy as thirty-seven degrees and would only make the
+/// loss feel deliberate. Free angles are available on the modifier, and the
+/// status line says what they cost.
+const ROTATION_SNAP: f32 = std::f32::consts::FRAC_PI_2;
+
+/// The step a snapped uniform scale moves in.
+///
+/// No scale is lossless, so this buys predictability rather than exactness:
+/// what it does guarantee is that coming back to the pixel the drag started on
+/// gives exactly 1.0, which is what makes a scale gesture cancellable by hand
+/// as well as by Escape.
+const SCALE_SNAP: f32 = 0.05;
+
+/// The narrowest and widest a single gesture may scale.
+///
+/// Not a taste limit. Below the floor the body shrinks under its own voxel and
+/// the bake returns almost nothing; above the ceiling the destination footprint
+/// -- and so the memory the bake allocates -- grows with the cube of it.
+///
+/// **Both are applied to the COMPOSED scale as well as to the gesture**, which
+/// is the half that was missing and the half that mattered: `Similarity::then`
+/// multiplies scales, so two drags each saturating this ceiling compose to 400
+/// and ten drags at the floor compose to 1e-13. See the clamp in [`drag`].
+const MIN_SCALE: f32 = 0.05;
+pub(crate) const MAX_SCALE: f32 = 20.0;
+
+/// One thing on the gizmo that can be grabbed.
+///
+/// The axis index is 0, 1, 2 for X, Y, Z. `Plane(i)` is the plane
+/// PERPENDICULAR to axis `i`, which is how every other tool numbers them and
+/// which makes the axis the one thing the handle does not move along.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Handle {
+    Axis(u8),
+    Plane(u8),
+    Ring(u8),
+    Uniform,
+}
+
+impl Handle {
+    /// What a grab on this handle is about to do, for the status line.
+    pub fn verb(self) -> &'static str {
+        match self {
+            Handle::Axis(_) | Handle::Plane(_) => "move",
+            Handle::Ring(_) => "turn",
+            Handle::Uniform => "scale",
+        }
+    }
+}
+
+/// The transform gizmo, armed on one body.
+///
+/// # `placement` is absolute, and that is what bounds the damage
+///
+/// It is the total map from the field as it was when the gizmo ARMED, not a
+/// composition of what each gesture did to the last result. Every bake goes
+/// `base.warped(placement)`, so the number of lossy passes a body has suffered
+/// is bounded by how many times the user left the gizmo rather than by how many
+/// times they nudged it. Thirty adjustments cost one pass. See
+/// `Brokkr::rebake_gizmo`, which is where that promise is kept, and
+/// `thirty_adjustments_cost_exactly_one_resample_pass`, which is what holds it.
+#[derive(Debug, Clone, Copy)]
+pub struct Gizmo {
+    /// The body being placed.
+    pub body: NodeId,
+    /// The pivot, in the BASE field's world space. Everything turns about it.
+    pub base_pivot: Vec3,
+    /// The total placement since arming.
+    pub placement: Similarity,
+    /// The placement as it stood when the live drag's button went down.
+    ///
+    /// A drag is absolute from its press pixel, so it needs the state it is
+    /// absolute FROM. This is also what Escape restores.
+    pub pinned: Similarity,
+    pub hovered: Option<Handle>,
+    pub grabbed: Option<Handle>,
+    /// The base field's world box, drawn as a wireframe while dragging so the
+    /// user can see where the body is going before it is rebuilt there.
+    pub base_low: Vec3,
+    pub base_high: Vec3,
+    /// The largest TOTAL scale a bake of this body can be built at, from
+    /// `Brokkr::largest_scale_that_fits`.
+    ///
+    /// **On the gizmo rather than checked at the release, because a refusal
+    /// after the drag is an answer that arrives too late to act on.** The
+    /// gesture is the question; folding the ceiling into it means the preview
+    /// box stops growing exactly where the bake would stop fitting, and what
+    /// the user is looking at is always a placement that can be built.
+    ///
+    /// Always finite and in `1.0..=MAX_SCALE`, which [`drag`] relies on: it
+    /// derives a `clamp` BOUND from this, and `f32::clamp` panics when its
+    /// bounds are NaN.
+    pub max_scale: f32,
+}
+
+impl Gizmo {
+    pub fn new(body: NodeId, low: Vec3, high: Vec3, max_scale: f32) -> Self {
+        Self {
+            body,
+            base_pivot: (low + high) * 0.5,
+            placement: Similarity::IDENTITY,
+            pinned: Similarity::IDENTITY,
+            hovered: None,
+            grabbed: None,
+            base_low: low,
+            base_high: high,
+            // Filtered rather than clamped: `clamp` passes NaN straight
+            // through, and a NaN here becomes a `clamp` bound in `drag`, which
+            // panics. One is the largest scale that is always affordable.
+            max_scale: if max_scale.is_finite() { max_scale.clamp(1.0, MAX_SCALE) } else { 1.0 },
+        }
+    }
+
+    /// Where the gizmo is drawn: the pivot carried by everything done so far.
+    pub fn origin(&self) -> Vec3 {
+        self.placement.transform_point(self.base_pivot)
+    }
+
+    /// Where the live drag is measured about.
+    fn pinned_origin(&self) -> Vec3 {
+        self.pinned.transform_point(self.base_pivot)
+    }
+}
+
+/// How many world units one logical pixel covers at `origin`.
+///
+/// The perspective divide, at the DEPTH of the point rather than at the
+/// camera's orbit distance: a gizmo on a body away from the target would
+/// otherwise be drawn the wrong size, and the picking would be wrong by the
+/// same factor in the same direction, which is the failure that hides itself.
+pub fn world_per_pixel(camera: &OrbitCamera, origin: Vec3, viewport_height: f32) -> f32 {
+    // `orientation() * Z` points from the target toward the eye, so the view
+    // direction is its negation.
+    let forward = -(camera.orientation() * Vec3::Z);
+    let depth = (origin - camera.eye()).dot(forward).max(camera.near());
+    2.0 * depth * (camera.fov_y * 0.5).tan() / viewport_height.max(1.0)
+}
+
+/// Where a world point lands, in widget pixels. `None` when it is behind the
+/// eye, where the perspective divide would fold it back onto the screen at a
+/// plausible-looking and completely wrong position.
+fn to_pixels(camera: &OrbitCamera, viewport: Vec2, point: Vec3) -> Option<Vec2> {
+    let aspect = viewport.x / viewport.y.max(1.0);
+    let clip = camera.view_projection(aspect) * point.extend(1.0);
+    if clip.w <= 1.0e-6 {
+        return None;
+    }
+    let ndc = Vec2::new(clip.x / clip.w, clip.y / clip.w);
+    Some(Vec2::new((ndc.x + 1.0) * 0.5 * viewport.x, (1.0 - ndc.y) * 0.5 * viewport.y))
+}
+
+fn axis_of(index: u8) -> Vec3 {
+    [Vec3::X, Vec3::Y, Vec3::Z][index as usize % 3]
+}
+
+/// The two axes a plane handle spans, or a ring lies in.
+fn other_axes(index: u8) -> (Vec3, Vec3) {
+    let u = axis_of((index + 1) % 3);
+    let v = axis_of((index + 2) % 3);
+    (u, v)
+}
+
+/// The four corners of a plane handle, wound around its rim.
+fn plane_quad(origin: Vec3, scale: f32, index: u8) -> [Vec3; 4] {
+    let (u, v) = other_axes(index);
+    let (near, far) = (PLANE_NEAR_PX * scale, PLANE_FAR_PX * scale);
+    [
+        origin + u * near + v * near,
+        origin + u * far + v * near,
+        origin + u * far + v * far,
+        origin + u * near + v * far,
+    ]
+}
+
+/// One point on a ring, by segment index.
+///
+/// **A function of the index rather than a `Vec` of the whole loop**, and that
+/// is the no-allocation rule rather than a style preference: [`build`] runs
+/// from `publish_camera`, which is every frame of an orbit, and it needs nine
+/// of these loops -- three ring inners, three ring outers, three arrowhead
+/// bases. Nine heap allocations per frame is exactly what the per-frame path is
+/// not allowed to do. Indices wrap, so `step` may run past the end.
+fn ring_point(origin: Vec3, scale: f32, index: u8, radius_px: f32, step: usize) -> Vec3 {
+    let (u, v) = other_axes(index);
+    let radius = radius_px * scale;
+    let angle = (step % RING_SEGMENTS) as f32 / RING_SEGMENTS as f32 * std::f32::consts::TAU;
+    origin + (u * angle.cos() + v * angle.sin()) * radius
+}
+
+/// Whether a widget-local point is anywhere near the gizmo at all.
+///
+/// **The bounds check that lets a press be claimed.** ONLY BOUNDS-CHECKED
+/// EVENTS MAY CAPTURE: a widget that claims an unbounded event kills every
+/// press after it, and this application has shipped that once already. [`pick`]
+/// gates on this exactly the way `navcube::pick` gates on `navcube::contains`,
+/// and `a_press_away_from_the_gizmo_is_not_claimed` is what holds it.
+///
+/// The disc is the outermost thing drawn -- the rings -- plus the grab
+/// tolerance, so it is a superset of everything [`pick`] can return and can
+/// never refuse a press that a handle would have wanted.
+pub fn contains(camera: &OrbitCamera, viewport: Vec2, gizmo: &Gizmo, at: Vec2) -> bool {
+    let origin = gizmo.origin();
+    let Some(centre) = to_pixels(camera, viewport, origin) else {
+        return false;
+    };
+    // The disc is measured on screen rather than in world units, because that
+    // is the space the pointer is in. The radius is the ring's, converted
+    // through the SAME factor the draw uses -- but a ring seen from an angle
+    // projects to an ellipse inside that circle, never outside it, so the
+    // circle bounds every part of the gizmo whatever the camera is doing.
+    let scale = world_per_pixel(camera, origin, viewport.y);
+    let Some(edge) = to_pixels(camera, viewport, origin + camera.right() * (RING_PX * scale))
+    else {
+        return false;
+    };
+    at.distance(centre) <= centre.distance(edge) + GRAB_PX
+}
+
+/// Which handle a widget-local point is over, if any.
+///
+/// Precedence is fixed rather than nearest-wins: `Uniform`, then `Plane`, then
+/// `Axis`, then `Ring`. It is an ordering by how small the target is, so the
+/// hardest thing to hit is never stolen by something larger sitting under the
+/// same pixel -- and a ring seen edge-on projects to a line straight through
+/// the middle of everything, which is exactly the case a nearest-wins rule gets
+/// wrong.
+pub fn pick(camera: &OrbitCamera, viewport: Vec2, gizmo: &Gizmo, at: Vec2) -> Option<Handle> {
+    if !contains(camera, viewport, gizmo, at) {
+        return None;
+    }
+    let origin = gizmo.origin();
+    let scale = world_per_pixel(camera, origin, viewport.y);
+    let centre = to_pixels(camera, viewport, origin)?;
+
+    if at.distance(centre) <= CENTRE_PX + GRAB_PX {
+        return Some(Handle::Uniform);
+    }
+
+    for index in 0..3u8 {
+        let corners = plane_quad(origin, scale, index);
+        let mut projected = [Vec2::ZERO; 4];
+        let mut all_on_screen = true;
+        for (slot, point) in projected.iter_mut().zip(corners) {
+            match to_pixels(camera, viewport, point) {
+                Some(pixel) => *slot = pixel,
+                None => all_on_screen = false,
+            }
+        }
+        if all_on_screen && inside_polygon(&projected, at) {
+            return Some(Handle::Plane(index));
+        }
+    }
+
+    for index in 0..3u8 {
+        let axis = axis_of(index);
+        let tip = origin + axis * ((SHAFT_PX + HEAD_PX) * scale);
+        let (Some(from), Some(to)) =
+            (to_pixels(camera, viewport, origin), to_pixels(camera, viewport, tip))
+        else {
+            continue;
+        };
+        // An axis pointing nearly at the camera is refused rather than picked
+        // imprecisely. See MIN_SHAFT_PX.
+        if from.distance(to) < MIN_SHAFT_PX {
+            continue;
+        }
+        if distance_to_segment(at, from, to) <= GRAB_PX {
+            return Some(Handle::Axis(index));
+        }
+    }
+
+    for index in 0..3u8 {
+        // Walked segment by segment rather than collected, for the reason
+        // `ring_point` gives: this runs on every pointer move.
+        let mut nearest = f32::INFINITY;
+        let mut previous =
+            to_pixels(camera, viewport, ring_point(origin, scale, index, RING_PX, 0));
+        for step in 1..=RING_SEGMENTS {
+            let point = ring_point(origin, scale, index, RING_PX, step);
+            let current = to_pixels(camera, viewport, point);
+            if let (Some(a), Some(b)) = (previous, current) {
+                nearest = nearest.min(distance_to_segment(at, a, b));
+            }
+            previous = current;
+        }
+        if nearest <= GRAB_PX {
+            return Some(Handle::Ring(index));
+        }
+    }
+
+    None
+}
+
+/// Distance from a point to a line segment, in whatever units it was given.
+fn distance_to_segment(point: Vec2, from: Vec2, to: Vec2) -> f32 {
+    let span = to - from;
+    let length_squared = span.length_squared();
+    if length_squared < 1.0e-9 {
+        return point.distance(from);
+    }
+    let t = ((point - from).dot(span) / length_squared).clamp(0.0, 1.0);
+    point.distance(from + span * t)
+}
+
+/// Whether a point is inside a convex quad given in order around its rim.
+///
+/// By the sign of the cross product at each edge, which needs no winding
+/// convention: a projected quad's winding depends on which side of it the
+/// camera is, and requiring one would make a plane handle unpickable from
+/// behind.
+fn inside_polygon(corners: &[Vec2], at: Vec2) -> bool {
+    let mut positive = false;
+    let mut negative = false;
+    for index in 0..corners.len() {
+        let a = corners[index];
+        let b = corners[(index + 1) % corners.len()];
+        let cross = (b - a).perp_dot(at - a);
+        positive |= cross > 0.0;
+        negative |= cross < 0.0;
+    }
+    !(positive && negative)
+}
+
+/// The gesture a drag from `from` to `to` describes, about the gizmo's pinned
+/// origin.
+///
+/// Absolute from the press pixel, never an increment; see the module header.
+/// The result is the GESTURE alone -- the caller composes it onto
+/// [`Gizmo::pinned`] -- so that a cancelled drag is undone by throwing this
+/// away rather than by computing an inverse.
+///
+/// Returns [`Similarity::IDENTITY`] whenever the maths is ill conditioned: a
+/// ray parallel to the axis it is dragging, a ray that misses the plane it is
+/// dragging in. Doing nothing is the right answer there, and it is also the
+/// only one that keeps the gesture continuous as the camera swings through the
+/// degenerate angle.
+///
+/// `snap` carries the lattice to snap translations to rather than sitting
+/// beside it as a `bool`, because the two are never independently meaningful:
+/// snapping without a voxel size is not a thing this can do, and a voxel size
+/// with snapping off is ignored. One argument cannot be half set.
+pub fn drag(
+    camera: &OrbitCamera,
+    viewport: Vec2,
+    gizmo: &Gizmo,
+    handle: Handle,
+    from: Vec2,
+    to: Vec2,
+    snap: Option<f32>,
+) -> Similarity {
+    let origin = gizmo.pinned_origin();
+    let aspect = viewport.x / viewport.y.max(1.0);
+    let ray = |pixel: Vec2| {
+        let ndc = OrbitCamera::ndc_from_pixels(pixel, viewport);
+        camera.ray(ndc, aspect)
+    };
+
+    match handle {
+        Handle::Axis(index) => {
+            let axis = axis_of(index);
+            let (Some(start), Some(now)) =
+                (along_axis(ray(from), origin, axis), along_axis(ray(to), origin, axis))
+            else {
+                return Similarity::IDENTITY;
+            };
+            let mut offset = axis * (now - start);
+            if let Some(voxel_size) = snap {
+                offset = snap_to_voxels(offset, voxel_size);
+            }
+            Similarity::moving(offset)
+        }
+        Handle::Plane(index) => {
+            let normal = axis_of(index);
+            let (Some(start), Some(now)) =
+                (on_plane(ray(from), origin, normal), on_plane(ray(to), origin, normal))
+            else {
+                return Similarity::IDENTITY;
+            };
+            let mut offset = now - start;
+            if let Some(voxel_size) = snap {
+                offset = snap_to_voxels(offset, voxel_size);
+            }
+            Similarity::moving(offset)
+        }
+        Handle::Ring(index) => {
+            let normal = axis_of(index);
+            let (Some(start), Some(now)) =
+                (on_plane(ray(from), origin, normal), on_plane(ray(to), origin, normal))
+            else {
+                return Similarity::IDENTITY;
+            };
+            let (u, v) = other_axes(index);
+            let angle_of = |point: Vec3| {
+                let spoke = point - origin;
+                (spoke.dot(v)).atan2(spoke.dot(u))
+            };
+            let mut angle = crate::camera::wrap_angle(angle_of(now) - angle_of(start));
+            if snap.is_some() {
+                angle = (angle / ROTATION_SNAP).round() * ROTATION_SNAP;
+            }
+            if angle == 0.0 {
+                return Similarity::IDENTITY;
+            }
+            Similarity::about(origin, Quat::from_axis_angle(normal, angle), 1.0, Vec3::ZERO)
+        }
+        Handle::Uniform => {
+            let Some(centre) = to_pixels(camera, viewport, origin) else {
+                return Similarity::IDENTITY;
+            };
+            // Radial on screen, in pixels. A world-space measure would need a
+            // plane to measure in, and the only honest one is the view plane,
+            // which is what this already is.
+            let started = centre.distance(from);
+            if started < 1.0 {
+                return Similarity::IDENTITY;
+            }
+            // **Bounded on the TOTAL, not on this gesture.** The press that
+            // selects `Uniform` has to land within `CENTRE_PX + GRAB_PX` of the
+            // middle, so a 320 pixel drag already saturates `MAX_SCALE`; and
+            // `Similarity::then` multiplies scales, so a second such drag would
+            // compose to 400 and a third to 8000 with nothing in the way. What
+            // is actually being bounded is the allocation `Volume::warped`
+            // makes for the composed placement, so the composed placement is
+            // where the bound has to bite.
+            //
+            // Both ends are widened to admit 1.0 whatever `pinned` holds: a
+            // drag that comes back to the pixel it started on must be exactly
+            // the identity, and a clamp that could exclude it would make a
+            // gesture uncancellable by hand.
+            let pinned = gizmo.pinned.scale.max(f32::MIN_POSITIVE);
+            let highest = (gizmo.max_scale / pinned).clamp(1.0, MAX_SCALE);
+            let lowest = MIN_SCALE.max(MIN_SCALE / pinned).min(1.0);
+            let mut scale = (centre.distance(to) / started).clamp(lowest, highest);
+            if snap.is_some() {
+                scale = ((scale / SCALE_SNAP).round() * SCALE_SNAP).clamp(lowest, highest);
+            }
+            if scale == 1.0 {
+                return Similarity::IDENTITY;
+            }
+            Similarity::about(origin, Quat::IDENTITY, scale, Vec3::ZERO)
+        }
+    }
+}
+
+/// Round a world offset to a whole number of voxels on each axis.
+///
+/// This is what makes the ordinary move gesture take
+/// [`brokkr_core::Bake::Exact`] and cost the surface nothing at all. Component
+/// by component in WORLD axes, which is the lattice's own frame -- see the
+/// module header on why the gizmo does not turn with the body.
+fn snap_to_voxels(offset: Vec3, voxel_size: f32) -> Vec3 {
+    if !voxel_size.is_finite() || voxel_size <= 0.0 {
+        return offset;
+    }
+    (offset / voxel_size).round() * voxel_size
+}
+
+/// Where a ray comes closest to a line through `origin` along `axis`, as a
+/// distance along that axis. `None` when the two are near enough parallel that
+/// the answer is meaningless.
+fn along_axis((ray_origin, ray_direction): (Vec3, Vec3), origin: Vec3, axis: Vec3) -> Option<f32> {
+    let w = ray_origin - origin;
+    let b = ray_direction.dot(axis);
+    let denominator = 1.0 - b * b;
+    if denominator.abs() < 1.0e-4 {
+        return None;
+    }
+    let d = ray_direction.dot(w);
+    let e = axis.dot(w);
+    Some((e - b * d) / denominator)
+}
+
+/// Where a ray meets the plane through `origin` with `normal`. `None` when it
+/// is parallel to the plane, or meets it behind the eye.
+fn on_plane((ray_origin, ray_direction): (Vec3, Vec3), origin: Vec3, normal: Vec3) -> Option<Vec3> {
+    let denominator = ray_direction.dot(normal);
+    if denominator.abs() < 1.0e-4 {
+        return None;
+    }
+    let t = (origin - ray_origin).dot(normal) / denominator;
+    (t > 0.0).then(|| ray_origin + ray_direction * t)
+}
+
+/// Build the gizmo for one frame.
+///
+/// Every dimension goes through the one `scale` from [`world_per_pixel`], which
+/// is the same number [`pick`] uses, so the thing drawn and the thing grabbed
+/// cannot be different sizes.
+pub fn build(batch: &mut OverlayBatch, camera: &OrbitCamera, viewport: Vec2, gizmo: &Gizmo) {
+    batch.clear();
+
+    let origin = gizmo.origin();
+    let scale = world_per_pixel(camera, origin, viewport.y);
+    if !scale.is_finite() || scale <= 0.0 {
+        return;
+    }
+    let towards_viewer = (camera.eye() - origin).normalize_or(Vec3::Z);
+
+    // The live handle beats the hovered one: while a drag is running the
+    // pointer wanders off the handle it grabbed, and dimming it then would say
+    // the grab had been let go.
+    let lit = gizmo.grabbed.or(gizmo.hovered);
+
+    for index in 0..3u8 {
+        let axis = axis_of(index);
+        let colour = |handle: Handle| {
+            let table = if lit == Some(handle) { theme::AXIS_HOVER } else { theme::AXIS };
+            theme::linear(table[index as usize], 1.0)
+        };
+
+        // The shaft, as a ribbon turned to face the camera. A `push_line` here
+        // would be one physical pixel; see the module header.
+        let shaft_colour = colour(Handle::Axis(index));
+        let tip = origin + axis * (SHAFT_PX * scale);
+        let side = axis.cross(towards_viewer).try_normalize().unwrap_or_else(|| {
+            // Looking straight down the axis. Any perpendicular will do, and
+            // the ribbon is a dot on screen either way.
+            axis.cross(camera.up()).try_normalize().unwrap_or(camera.right())
+        }) * (SHAFT_HALF_PX * scale);
+        batch.push_quad(origin - side, tip - side, tip + side, origin + side, shaft_colour);
+
+        // The arrowhead, as a cone: a fan from the apex plus a fan closing the
+        // base, so it occludes itself correctly in the cleared-depth pass.
+        let apex = origin + axis * ((SHAFT_PX + HEAD_PX) * scale);
+        for step in 0..RING_SEGMENTS {
+            let a = ring_point(tip, scale, index, HEAD_RADIUS_PX, step);
+            let b = ring_point(tip, scale, index, HEAD_RADIUS_PX, step + 1);
+            batch.push_triangle(apex, a, b, shaft_colour);
+            batch.push_triangle(tip, b, a, shaft_colour);
+        }
+
+        // The plane handle.
+        let quad = plane_quad(origin, scale, index);
+        batch.push_quad(quad[0], quad[1], quad[2], quad[3], colour(Handle::Plane(index)));
+
+        // The ring, as a flat annulus in its own plane.
+        let ring_colour = colour(Handle::Ring(index));
+        let (inner_px, outer_px) = (RING_PX - RING_HALF_PX, RING_PX + RING_HALF_PX);
+        for step in 0..RING_SEGMENTS {
+            let ring = |radius, at| ring_point(origin, scale, index, radius, at);
+            batch.push_quad(
+                ring(inner_px, step),
+                ring(outer_px, step),
+                ring(outer_px, step + 1),
+                ring(inner_px, step + 1),
+                ring_colour,
+            );
+        }
+    }
+
+    // The box in the middle. A camera-facing square rather than a cube: a cube
+    // would need its own occlusion reasoning against three shafts leaving it,
+    // and a square reads as a grab target at eight pixels where a cube reads as
+    // a smudge.
+    let centre_colour = theme::linear(
+        if lit == Some(Handle::Uniform) { theme::TEXT } else { theme::TEXT_DIM },
+        1.0,
+    );
+    let right = camera.right() * (CENTRE_PX * scale);
+    let up = camera.up() * (CENTRE_PX * scale);
+    batch.push_quad(
+        origin - right - up,
+        origin + right - up,
+        origin + right + up,
+        origin - right + up,
+        centre_colour,
+    );
+
+    // While a drag is live, where the body is GOING, as the transformed corners
+    // of its box. Twelve lines rather than a transformed mesh: a live mesh
+    // needs a per-body model matrix in the renderer's uniforms, which is the
+    // one thing the bodies design refused to introduce anywhere. Deferred with
+    // a trigger -- build it if the box turns out not to be enough to place a
+    // rotation by.
+    if gizmo.grabbed.is_some() {
+        let preview = theme::linear(theme::ACCENT, 1.0);
+        let corner = |mask: usize| {
+            gizmo.placement.transform_point(Vec3::new(
+                if mask & 1 == 0 { gizmo.base_low.x } else { gizmo.base_high.x },
+                if mask & 2 == 0 { gizmo.base_low.y } else { gizmo.base_high.y },
+                if mask & 4 == 0 { gizmo.base_low.z } else { gizmo.base_high.z },
+            ))
+        };
+        for mask in 0..8usize {
+            for bit in [1usize, 2, 4] {
+                if mask & bit == 0 {
+                    batch.push_line(corner(mask), corner(mask | bit), preview);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VIEWPORT: Vec2 = Vec2::new(1280.0, 720.0);
+    const VOXEL: f32 = 0.5;
+
+    fn camera() -> OrbitCamera {
+        let mut camera = OrbitCamera::framing(Vec3::ZERO, 30.0);
+        camera.set_lattice(VOXEL, 30.0);
+        camera
+    }
+
+    fn gizmo() -> Gizmo {
+        Gizmo::new(NodeId(1), Vec3::splat(-20.0), Vec3::splat(20.0), MAX_SCALE)
+    }
+
+    fn centre(camera: &OrbitCamera, gizmo: &Gizmo) -> Vec2 {
+        to_pixels(camera, VIEWPORT, gizmo.origin()).expect("the gizmo is in front of the camera")
+    }
+
+    /// The property that makes a gizmo usable at any distance, and the one that
+    /// silently fails when the draw and the hit test keep separate scales.
+    ///
+    /// Measured two ways, because they check different halves and the first one
+    /// alone passes for a factor that is merely CONSISTENTLY wrong:
+    ///
+    /// * A world axis holds the same number of pixels at every zoom. It does
+    ///   not hold `SHAFT_PX` of them -- a world axis leaning away from the
+    ///   camera is foreshortened, which is correct 3D and not a scaling bug.
+    /// * A length laid out ACROSS the view is exactly `SHAFT_PX` pixels, which
+    ///   is what `world_per_pixel` actually promises.
+    #[test]
+    fn the_gizmo_is_the_same_size_on_screen_at_every_distance() {
+        let gizmo = gizmo();
+        let mut sizes = Vec::new();
+        for notches in [-8.0_f32, -3.0, 0.0, 4.0, 9.0] {
+            let mut camera = camera();
+            camera.zoom_by(OrbitCamera::zoom_factor(notches));
+            let scale = world_per_pixel(&camera, gizmo.origin(), VIEWPORT.y);
+            let middle = centre(&camera, &gizmo);
+
+            let tip = to_pixels(&camera, VIEWPORT, gizmo.origin() + Vec3::X * (SHAFT_PX * scale))
+                .expect("the tip is on screen");
+            sizes.push(middle.distance(tip));
+
+            let across =
+                to_pixels(&camera, VIEWPORT, gizmo.origin() + camera.right() * (SHAFT_PX * scale))
+                    .expect("on screen");
+            let measured = middle.distance(across);
+            assert!(
+                (measured - SHAFT_PX).abs() < 0.5,
+                "across the view the shaft is {measured} px at {notches} notches, \
+                 expected {SHAFT_PX}"
+            );
+        }
+        let first = sizes[0];
+        for size in &sizes {
+            assert!(
+                (size - first).abs() < 1.0,
+                "the shaft measured {sizes:?} pixels across a range of zooms"
+            );
+        }
+    }
+
+    /// ONLY BOUNDS-CHECKED EVENTS MAY CAPTURE. A gizmo that claimed presses
+    /// across the viewport would kill sculpting everywhere but on itself, which
+    /// is a failure this project has shipped once.
+    #[test]
+    fn a_press_away_from_the_gizmo_is_not_claimed() {
+        let camera = camera();
+        let gizmo = gizmo();
+        let middle = centre(&camera, &gizmo);
+        for at in [
+            Vec2::new(4.0, 4.0),
+            Vec2::new(VIEWPORT.x - 4.0, 4.0),
+            Vec2::new(4.0, VIEWPORT.y - 4.0),
+            Vec2::new(VIEWPORT.x - 4.0, VIEWPORT.y - 4.0),
+            middle + Vec2::new(400.0, 0.0),
+        ] {
+            assert!(!contains(&camera, VIEWPORT, &gizmo, at), "{at:?} was inside the disc");
+            assert!(pick(&camera, VIEWPORT, &gizmo, at).is_none(), "{at:?} was claimed");
+        }
+    }
+
+    /// The bounds check has to be a SUPERSET of everything drawn, or a handle
+    /// the user can see is refused before `pick` is ever consulted.
+    ///
+    /// **Asserting "everything picked is inside the disc" would be a
+    /// tautology** -- `pick` gates on `contains` in its first two lines, so that
+    /// direction is true by construction and holds equally for a disc of radius
+    /// zero. The direction with content is this one: every point the gizmo
+    /// actually DRAWS is admitted.
+    #[test]
+    fn the_bounds_check_admits_every_point_the_gizmo_draws() {
+        for (yaw, pitch) in [(0.0_f32, 0.0_f32), (0.9, 0.6), (2.4, -1.2), (0.0, 1.5)] {
+            let camera = OrbitCamera { yaw, pitch, ..camera() };
+            let gizmo = gizmo();
+            let origin = gizmo.origin();
+            let scale = world_per_pixel(&camera, origin, VIEWPORT.y);
+
+            let mut checked = 0;
+            for index in 0..3u8 {
+                // The far end of each arrow.
+                let tip = origin + axis_of(index) * ((SHAFT_PX + HEAD_PX) * scale);
+                // The far corner of each plane handle.
+                let corner = plane_quad(origin, scale, index)[2];
+                // And the whole of each ring, which is the outermost thing.
+                for step in 0..RING_SEGMENTS {
+                    let on_ring = ring_point(origin, scale, index, RING_PX + RING_HALF_PX, step);
+                    for point in [tip, corner, on_ring] {
+                        let Some(at) = to_pixels(&camera, VIEWPORT, point) else {
+                            continue;
+                        };
+                        assert!(
+                            contains(&camera, VIEWPORT, &gizmo, at),
+                            "at yaw {yaw} pitch {pitch} the disc refused {at:?}, \
+                             which the gizmo draws"
+                        );
+                        checked += 1;
+                    }
+                }
+            }
+            assert!(checked > 100, "only {checked} points were on screen to check");
+        }
+    }
+
+    #[test]
+    fn the_middle_of_the_gizmo_is_the_scale_handle() {
+        let camera = camera();
+        let gizmo = gizmo();
+        assert_eq!(pick(&camera, VIEWPORT, &gizmo, centre(&camera, &gizmo)), Some(Handle::Uniform));
+    }
+
+    /// Each shaft has to be grabbable along its length, and grabbing it must
+    /// name the axis it is actually drawn along.
+    #[test]
+    fn a_point_on_a_shaft_picks_that_axis() {
+        // Away from the poles and off every axis, so no shaft is edge on.
+        let camera = OrbitCamera { yaw: 0.9, pitch: 0.6, ..camera() };
+        let gizmo = gizmo();
+        let scale = world_per_pixel(&camera, gizmo.origin(), VIEWPORT.y);
+        for index in 0..3u8 {
+            // Halfway along the shaft, clear of the centre box and the head.
+            let at = to_pixels(
+                &camera,
+                VIEWPORT,
+                gizmo.origin() + axis_of(index) * (SHAFT_PX * 0.55 * scale),
+            )
+            .expect("the shaft is on screen");
+            assert_eq!(
+                pick(&camera, VIEWPORT, &gizmo, at),
+                Some(Handle::Axis(index)),
+                "axis {index}"
+            );
+        }
+    }
+
+    /// **Sampled between the axes, and that is not incidental.** The three
+    /// rings genuinely meet at the six points where an axis crosses them, so a
+    /// sample taken on an axis is on two rings at once and whichever one the
+    /// precedence order reaches first is the correct answer. Forty-five degrees
+    /// round is on exactly one ring.
+    #[test]
+    fn a_point_on_a_ring_picks_that_ring() {
+        let camera = OrbitCamera { yaw: 0.9, pitch: 0.6, ..camera() };
+        let gizmo = gizmo();
+        let scale = world_per_pixel(&camera, gizmo.origin(), VIEWPORT.y);
+        for index in 0..3u8 {
+            let (u, v) = other_axes(index);
+            let diagonal = (u + v).normalize() * (RING_PX * scale);
+            let at = to_pixels(&camera, VIEWPORT, gizmo.origin() + diagonal).expect("on");
+            assert_eq!(
+                pick(&camera, VIEWPORT, &gizmo, at),
+                Some(Handle::Ring(index)),
+                "ring {index}"
+            );
+        }
+    }
+
+    /// A one-pixel move must not send the body across the room. An axis pointing
+    /// at the camera is the case where the closest-point solve divides by
+    /// nothing, and it is refused rather than answered badly.
+    #[test]
+    fn an_axis_pointing_at_the_camera_is_not_grabbable() {
+        // Looking straight down Z: the Z shaft projects onto the middle of the
+        // gizmo and is a couple of pixels long.
+        let camera = OrbitCamera { yaw: 0.0, pitch: 0.0, ..camera() };
+        let gizmo = gizmo();
+        let scale = world_per_pixel(&camera, gizmo.origin(), VIEWPORT.y);
+        let middle = centre(&camera, &gizmo);
+        let tip = to_pixels(&camera, VIEWPORT, gizmo.origin() + Vec3::Z * (SHAFT_PX * scale))
+            .expect("on screen");
+        assert!(middle.distance(tip) < MIN_SHAFT_PX, "the fixture's Z axis is not edge on");
+
+        // A few pixels out along where that shaft would be: not the Z axis.
+        for step in 1..6 {
+            let at = middle + Vec2::new(0.0, -(CENTRE_PX + GRAB_PX + step as f32 * 2.0));
+            assert_ne!(
+                pick(&camera, VIEWPORT, &gizmo, at),
+                Some(Handle::Axis(2)),
+                "a shaft {} px long was grabbed",
+                middle.distance(tip)
+            );
+        }
+    }
+
+    /// Exactly one handle lights, or the interface is telling the user two
+    /// different things about what a press would do.
+    #[test]
+    fn hovering_lights_exactly_one_handle() {
+        let camera = OrbitCamera { yaw: 0.9, pitch: 0.6, ..camera() };
+        let mut gizmo = gizmo();
+        gizmo.hovered = Some(Handle::Axis(0));
+
+        let mut lit = OverlayBatch::default();
+        build(&mut lit, &camera, VIEWPORT, &gizmo);
+        let mut plain = OverlayBatch::default();
+        gizmo.hovered = None;
+        build(&mut plain, &camera, VIEWPORT, &gizmo);
+
+        assert_eq!(lit.surfaces.len(), plain.surfaces.len(), "the hover changed the geometry");
+        let changed: std::collections::HashSet<[u32; 4]> = lit
+            .surfaces
+            .iter()
+            .zip(&plain.surfaces)
+            .filter(|(a, b)| a.colour != b.colour)
+            .map(|(a, _)| a.colour.map(f32::to_bits))
+            .collect();
+        assert_eq!(changed.len(), 1, "hovering one handle changed {} colours", changed.len());
+    }
+
+    /// A move along an axis is exactly a move along that axis: nothing may leak
+    /// into the other two, or a nudge sideways would drift the body off the
+    /// lattice it was snapped to.
+    #[test]
+    fn dragging_an_axis_moves_only_along_that_axis() {
+        let camera = OrbitCamera { yaw: 0.9, pitch: 0.6, ..camera() };
+        let gizmo = gizmo();
+        let middle = centre(&camera, &gizmo);
+        for index in 0..3u8 {
+            let gesture = drag(
+                &camera,
+                VIEWPORT,
+                &gizmo,
+                Handle::Axis(index),
+                middle,
+                middle + Vec2::new(37.0, -21.0),
+                None,
+            );
+            let moved = gesture.translation;
+            assert!(moved.length() > 1.0e-3, "axis {index} did not move at all");
+            for other in 0..3usize {
+                if other != index as usize {
+                    assert!(
+                        moved[other].abs() < 1.0e-4,
+                        "axis {index} leaked {} onto axis {other}",
+                        moved[other]
+                    );
+                }
+            }
+        }
+    }
+
+    /// **The gesture that has to be lossless, and the one users make most.**
+    #[test]
+    fn a_snapped_move_takes_the_exact_route() {
+        let camera = OrbitCamera { yaw: 0.9, pitch: 0.6, ..camera() };
+        let gizmo = gizmo();
+        let middle = centre(&camera, &gizmo);
+        for pixels in [7.0_f32, 23.0, 61.0, -44.0] {
+            let gesture = drag(
+                &camera,
+                VIEWPORT,
+                &gizmo,
+                Handle::Axis(0),
+                middle,
+                middle + Vec2::new(pixels, 0.0),
+                Some(VOXEL),
+            );
+            assert!(
+                !gesture.route(VOXEL).is_lossy(),
+                "a snapped move of {pixels} px routed to {:?}",
+                gesture.route(VOXEL)
+            );
+        }
+    }
+
+    #[test]
+    fn a_snapped_turn_takes_the_exact_route_and_an_unsnapped_one_says_it_does_not() {
+        let camera = OrbitCamera { yaw: 0.9, pitch: 0.6, ..camera() };
+        // A pivot on the lattice, which is what makes a quarter turn exact.
+        let gizmo = Gizmo::new(NodeId(1), Vec3::splat(-20.0), Vec3::splat(20.0), MAX_SCALE);
+        let scale = world_per_pixel(&camera, gizmo.origin(), VIEWPORT.y);
+
+        for index in 0..3u8 {
+            let (u, v) = other_axes(index);
+            let radius = RING_PX * scale;
+            let from = to_pixels(&camera, VIEWPORT, gizmo.origin() + u * radius).expect("on");
+            // A right angle round the ring.
+            let to = to_pixels(&camera, VIEWPORT, gizmo.origin() + v * radius).expect("on");
+
+            let snapped =
+                drag(&camera, VIEWPORT, &gizmo, Handle::Ring(index), from, to, Some(VOXEL));
+            assert!(
+                !snapped.route(VOXEL).is_lossy(),
+                "a snapped quarter turn about axis {index} routed to {:?}",
+                snapped.route(VOXEL)
+            );
+
+            // A third of the way round is not a quarter turn under any
+            // tolerance, and the routing has to say so rather than rounding.
+            let third = to_pixels(
+                &camera,
+                VIEWPORT,
+                gizmo.origin() + (u * (0.5f32).cos() + v * (0.5f32).sin()) * radius,
+            )
+            .expect("on");
+            let free = drag(&camera, VIEWPORT, &gizmo, Handle::Ring(index), from, third, None);
+            assert!(free.route(VOXEL).is_lossy(), "a 0.5 rad turn was called exact");
+        }
+    }
+
+    /// Coming back to the pixel the drag started on has to be EXACTLY the
+    /// identity, not approximately it. It is the cheapest cancel there is, and
+    /// an approximate one would bake a resample for a gesture that did nothing.
+    #[test]
+    fn a_drag_that_returns_to_its_press_pixel_is_exactly_the_identity() {
+        let camera = OrbitCamera { yaw: 0.9, pitch: 0.6, ..camera() };
+        let gizmo = gizmo();
+        let scale = world_per_pixel(&camera, gizmo.origin(), VIEWPORT.y);
+        let middle = centre(&camera, &gizmo);
+        let on_ring =
+            to_pixels(&camera, VIEWPORT, gizmo.origin() + Vec3::Y * (RING_PX * scale)).expect("on");
+
+        for (handle, from) in [
+            (Handle::Axis(0), middle),
+            (Handle::Axis(1), middle),
+            (Handle::Plane(2), middle),
+            (Handle::Ring(0), on_ring),
+            (Handle::Uniform, middle + Vec2::new(30.0, 0.0)),
+        ] {
+            for snap in [Some(VOXEL), None] {
+                let gesture = drag(&camera, VIEWPORT, &gizmo, handle, from, from, snap);
+                assert_eq!(
+                    gesture.route(VOXEL),
+                    brokkr_core::Bake::Identity,
+                    "{handle:?} snap {snap:?} routed to {:?}",
+                    gesture.route(VOXEL)
+                );
+            }
+        }
+    }
+
+    /// Scaling has to be reversible within the gesture: drag out, drag back,
+    /// and the factor is one again rather than one and a bit.
+    #[test]
+    fn a_snapped_scale_comes_back_to_exactly_one() {
+        let camera = camera();
+        let gizmo = gizmo();
+        let middle = centre(&camera, &gizmo);
+        let from = middle + Vec2::new(40.0, 0.0);
+        let out = drag(
+            &camera,
+            VIEWPORT,
+            &gizmo,
+            Handle::Uniform,
+            from,
+            middle + Vec2::new(80.0, 0.0),
+            Some(VOXEL),
+        );
+        assert!(out.scale > 1.5, "the fixture did not grow: {}", out.scale);
+        let back = drag(&camera, VIEWPORT, &gizmo, Handle::Uniform, from, from, Some(VOXEL));
+        assert_eq!(back.scale, 1.0);
+    }
+
+    /// **The bound is on the total, and one gesture cannot see the total.**
+    ///
+    /// `Handle::Uniform` is only selected by a press within `CENTRE_PX +
+    /// GRAB_PX` of the middle, so every scale drag starts near the centre and a
+    /// long one saturates [`MAX_SCALE`] on its own. Clamping each gesture
+    /// therefore bounds nothing: [`Similarity::then`] MULTIPLIES scales, so a
+    /// second saturating drag composes to 400 and a third to 8000, and
+    /// `Volume::warped` allocates a dense destination grid for whatever it is
+    /// handed.
+    #[test]
+    fn scale_drags_compose_without_ever_passing_the_gizmo_s_ceiling() {
+        let camera = camera();
+        let mut gizmo = gizmo();
+        gizmo.max_scale = 6.0;
+        let middle = centre(&camera, &gizmo);
+
+        for round in 0..8 {
+            // From as near the middle as a press can land, out to the far edge
+            // of the viewport: the most one gesture can possibly ask for.
+            let from = middle + Vec2::new(2.0, 0.0);
+            let gesture = drag(
+                &camera,
+                VIEWPORT,
+                &gizmo,
+                Handle::Uniform,
+                from,
+                from + Vec2::splat(320.0),
+                None,
+            );
+            gizmo.placement = gizmo.pinned.then(gesture);
+            gizmo.pinned = gizmo.placement;
+            assert!(
+                gizmo.placement.scale <= 6.0 + 1.0e-4,
+                "round {round} composed to {}, past a ceiling of 6",
+                gizmo.placement.scale
+            );
+        }
+        assert!(
+            gizmo.placement.scale > 1.0,
+            "the fixture never grew the body at all, so it proves nothing"
+        );
+    }
+
+    /// The floor composes the same way, and its failure is quieter: a body
+    /// scaled to 1e-13 is rebuilt as a handful of nonsense voxels, which reads
+    /// as the body having vanished with nothing said.
+    #[test]
+    fn shrinking_drags_compose_without_ever_passing_the_floor() {
+        let camera = camera();
+        let mut gizmo = gizmo();
+        let middle = centre(&camera, &gizmo);
+
+        for round in 0..10 {
+            let from = middle + Vec2::new(14.0, 0.0);
+            let gesture = drag(&camera, VIEWPORT, &gizmo, Handle::Uniform, from, middle, None);
+            gizmo.placement = gizmo.pinned.then(gesture);
+            gizmo.pinned = gizmo.placement;
+            assert!(
+                gizmo.placement.scale >= MIN_SCALE - 1.0e-6,
+                "round {round} composed down to {}, under a floor of {MIN_SCALE}",
+                gizmo.placement.scale
+            );
+        }
+        assert!(
+            gizmo.placement.scale < 1.0,
+            "the fixture never shrank the body at all, so it proves nothing"
+        );
+    }
+
+    /// Whatever the clamps do, coming back to the press pixel has to be exactly
+    /// one -- including at the ceiling, where a naive clamp would pin the
+    /// gesture above 1.0 and make the drag uncancellable by hand.
+    #[test]
+    fn a_scale_drag_returns_to_exactly_one_even_with_no_room_left_to_grow() {
+        let camera = camera();
+        let mut gizmo = gizmo();
+        gizmo.max_scale = 1.0;
+        gizmo.pinned = Similarity::about(gizmo.origin(), Quat::IDENTITY, 1.0, Vec3::ZERO);
+        let from = centre(&camera, &gizmo) + Vec2::new(30.0, 0.0);
+
+        for snap in [Some(VOXEL), None] {
+            let gesture = drag(&camera, VIEWPORT, &gizmo, Handle::Uniform, from, from, snap);
+            assert_eq!(gesture, Similarity::IDENTITY, "snap {snap:?} could not come back to one");
+        }
+    }
+
+    /// A degenerate drag must do nothing rather than something arbitrary: a ray
+    /// parallel to the plane it is dragging in has no intersection to take.
+    #[test]
+    fn a_drag_whose_maths_is_degenerate_does_nothing() {
+        // Looking along Z, so the ray is parallel to the XY plane's own axes
+        // only at the extreme -- what is actually degenerate here is dragging
+        // in the planes that contain the view direction.
+        let camera = OrbitCamera { yaw: 0.0, pitch: 0.0, ..camera() };
+        let gizmo = gizmo();
+        let middle = centre(&camera, &gizmo);
+        for handle in [Handle::Plane(0), Handle::Plane(1), Handle::Axis(2), Handle::Ring(0)] {
+            let gesture =
+                drag(&camera, VIEWPORT, &gizmo, handle, middle, middle + Vec2::new(9.0, 3.0), None);
+            assert!(
+                gesture.transform_point(Vec3::ZERO).is_finite() && gesture.scale.is_finite(),
+                "{handle:?} produced {gesture:?}"
+            );
+        }
+    }
+
+    /// The preview box only exists while a drag is live, and it has to follow
+    /// the placement rather than sitting on the body's old position.
+    #[test]
+    fn the_preview_box_appears_only_while_dragging_and_follows_the_placement() {
+        let camera = camera();
+        let mut gizmo = gizmo();
+
+        let mut idle = OverlayBatch::default();
+        build(&mut idle, &camera, VIEWPORT, &gizmo);
+        assert!(idle.lines.is_empty(), "an idle gizmo drew a preview box");
+
+        gizmo.grabbed = Some(Handle::Axis(0));
+        gizmo.placement = Similarity::moving(Vec3::new(100.0, 0.0, 0.0));
+        let mut dragging = OverlayBatch::default();
+        build(&mut dragging, &camera, VIEWPORT, &gizmo);
+        // Twelve edges, two vertices each.
+        assert_eq!(dragging.lines.len(), 24);
+        assert!(
+            dragging.lines.iter().all(|vertex| vertex.position[0] > 70.0),
+            "the preview box did not travel with the placement"
+        );
+    }
+
+    /// The gizmo sits on the body it is moving, so its origin has to travel
+    /// with the placement rather than staying where the body used to be.
+    #[test]
+    fn the_gizmo_travels_with_what_it_has_already_moved() {
+        let mut gizmo = gizmo();
+        assert_eq!(gizmo.origin(), Vec3::ZERO);
+        gizmo.placement = Similarity::moving(Vec3::new(0.0, 15.0, 0.0));
+        assert_eq!(gizmo.origin(), Vec3::new(0.0, 15.0, 0.0));
+    }
+}

--- a/crates/brokkr-app/src/icon.rs
+++ b/crates/brokkr-app/src/icon.rs
@@ -564,6 +564,33 @@ const EYE_OFF: Glyph = Glyph {
 /// The pair is the one place in this set where orientation carries the entire
 /// meaning, which is why both are centred on the same axes and drawn at the same
 /// length.
+/// The four-way arrow every modelling tool uses for Move, plus a corner arc
+/// for the turn: one gizmo with move, turn and scale handles needs one glyph
+/// that says all three rather than three buttons.
+const GIZMO: Glyph = Glyph {
+    subs: &[
+        Sub { segs: &[Seg::Move(12.0, 4.5), Seg::Line(12.0, 19.5)], ink: Ink::Stroke },
+        Sub { segs: &[Seg::Move(4.5, 12.0), Seg::Line(19.5, 12.0)], ink: Ink::Stroke },
+        // Four arrowheads, one per arm.
+        Sub {
+            segs: &[Seg::Move(9.4, 7.1), Seg::Line(12.0, 4.5), Seg::Line(14.6, 7.1)],
+            ink: Ink::Stroke,
+        },
+        Sub {
+            segs: &[Seg::Move(9.4, 16.9), Seg::Line(12.0, 19.5), Seg::Line(14.6, 16.9)],
+            ink: Ink::Stroke,
+        },
+        Sub {
+            segs: &[Seg::Move(7.1, 9.4), Seg::Line(4.5, 12.0), Seg::Line(7.1, 14.6)],
+            ink: Ink::Stroke,
+        },
+        Sub {
+            segs: &[Seg::Move(16.9, 9.4), Seg::Line(19.5, 12.0), Seg::Line(16.9, 14.6)],
+            ink: Ink::Stroke,
+        },
+    ],
+};
+
 const PLUS: Glyph = Glyph {
     subs: &[
         Sub { segs: &[Seg::Move(12.0, 6.0), Seg::Line(12.0, 18.0)], ink: Ink::Stroke },
@@ -746,6 +773,7 @@ pub enum IconName {
     BrushMove,
     CutPlane,
     Mask,
+    Gizmo,
     Eye,
     EyeOff,
     Plus,
@@ -857,6 +885,7 @@ impl IconName {
             IconName::BrushMove => &BRUSH_MOVE,
             IconName::CutPlane => &CUT_PLANE,
             IconName::Mask => &MASK,
+            IconName::Gizmo => &GIZMO,
             IconName::Eye => &EYE,
             IconName::EyeOff => &EYE_OFF,
             IconName::Plus => &PLUS,

--- a/crates/brokkr-app/src/main.rs
+++ b/crates/brokkr-app/src/main.rs
@@ -5,6 +5,7 @@
 mod app;
 mod breadcrumbs;
 mod camera;
+mod crash;
 mod cursor;
 mod gizmo;
 #[cfg(target_os = "linux")]
@@ -55,6 +56,11 @@ fn main() -> iced::Result {
     // crate had been invisible since the day it was written -- which is why an
     // import or a resample left no trace in a log people were being told to
     // read. `brokkr_gpu` IS correct: that one is a library.
+    // Before anything can panic, and before the window opens. A panic used to
+    // take the window and leave nothing behind but a backtrace on a terminal
+    // the user had not launched from.
+    crash::install();
+
     env_logger::Builder::from_env(
         env_logger::Env::default().default_filter_or("warn,brokkrsculpt=info,brokkr_gpu=info"),
     )

--- a/crates/brokkr-app/src/main.rs
+++ b/crates/brokkr-app/src/main.rs
@@ -51,6 +51,11 @@ fn main() -> iced::Result {
         return Ok(());
     }
 
+    // Before anything can panic, and before the window opens. A panic used to
+    // take the window and leave nothing behind but a backtrace on a terminal
+    // the user had not launched from.
+    crash::install();
+
     // `brokkrsculpt`, not `brokkr_app`: env_logger filters on the MODULE PATH,
     // and the module path is the crate root name, which for a binary target is
     // the `[[bin]] name` rather than the package name. It read `brokkr_app`
@@ -58,11 +63,6 @@ fn main() -> iced::Result {
     // crate had been invisible since the day it was written -- which is why an
     // import or a resample left no trace in a log people were being told to
     // read. `brokkr_gpu` IS correct: that one is a library.
-    // Before anything can panic, and before the window opens. A panic used to
-    // take the window and leave nothing behind but a backtrace on a terminal
-    // the user had not launched from.
-    crash::install();
-
     env_logger::Builder::from_env(
         env_logger::Env::default().default_filter_or("warn,brokkrsculpt=info,brokkr_gpu=info"),
     )

--- a/crates/brokkr-app/src/main.rs
+++ b/crates/brokkr-app/src/main.rs
@@ -25,6 +25,7 @@ mod theme;
 mod thumbnails;
 mod timeline;
 mod viewport;
+mod welcome;
 
 use app::Brokkr;
 

--- a/crates/brokkr-app/src/main.rs
+++ b/crates/brokkr-app/src/main.rs
@@ -3,6 +3,7 @@
 //! BrokkrSculpt: a voxel and SDF based 3D sculpting application.
 
 mod app;
+mod articles;
 mod breadcrumbs;
 mod camera;
 mod crash;

--- a/crates/brokkr-app/src/main.rs
+++ b/crates/brokkr-app/src/main.rs
@@ -6,6 +6,7 @@ mod app;
 mod breadcrumbs;
 mod camera;
 mod cursor;
+mod gizmo;
 #[cfg(target_os = "linux")]
 mod icon;
 mod input_watch;

--- a/crates/brokkr-app/src/message.rs
+++ b/crates/brokkr-app/src/message.rs
@@ -387,6 +387,12 @@ pub enum Message {
     WelcomeOpened,
     /// Dismiss it. Escape does this too.
     WelcomeClosed,
+    /// The TinkerAtlas feed came back, or did not.
+    ArticlesLoaded(Result<Vec<crate::articles::Article>, String>),
+    /// Ask again after a failure.
+    ArticlesRetried,
+    /// Read one in the browser.
+    ArticleOpened(String),
     /// The "show this on startup" tick, which is written through immediately:
     /// a preference that only lands when the dialog is dismissed the right way
     /// is one that silently forgets.

--- a/crates/brokkr-app/src/message.rs
+++ b/crates/brokkr-app/src/message.rs
@@ -64,8 +64,16 @@ pub enum PointerEvent {
         button: PointerButton,
     },
     /// Positive is a scroll toward the model.
+    ///
+    /// Carries where the pointer was, because the zoom is anchored on what is
+    /// under it rather than on the camera's target. Legal to add without
+    /// weakening the capture rule: the scroll arm already gates on
+    /// `cursor.position_in(bounds)`, so there is no case where a scroll is
+    /// routed here without a position to go with it.
     Scrolled {
         amount: f32,
+        position: Vector,
+        size: Vector,
     },
     Modifiers {
         shift: bool,
@@ -580,6 +588,12 @@ pub enum Message {
     /// key repeats while it is held, and a toggle would strobe.
     MaskPeekStarted,
     MaskPeekEnded,
+    /// Put the camera back on the active body, keeping the angles.
+    ///
+    /// The recovery half of a free camera. A camera that can go anywhere can
+    /// end up anywhere, and the answer is one keystroke back rather than a
+    /// fence around where it may go.
+    CameraFramedOnActive,
     /// Throw the active body's mask away. The map is MOVED into the history
     /// entry, so this allocates nothing however large the mask was.
     MaskCleared,

--- a/crates/brokkr-app/src/message.rs
+++ b/crates/brokkr-app/src/message.rs
@@ -383,6 +383,14 @@ pub enum Message {
     OpenRecent(std::path::PathBuf),
     /// Load the crash net left behind by a session that did not save.
     RecoverAutosave,
+    /// Show the welcome screen, from the Help menu.
+    WelcomeOpened,
+    /// Dismiss it. Escape does this too.
+    WelcomeClosed,
+    /// The "show this on startup" tick, which is written through immediately:
+    /// a preference that only lands when the dialog is dismissed the right way
+    /// is one that silently forgets.
+    WelcomeOnStartupSet(bool),
     /// Import a mesh: ask for a file, then read and voxelise whatever came back.
     ImportRequested,
     ImportChosen(Option<std::path::PathBuf>),

--- a/crates/brokkr-app/src/message.rs
+++ b/crates/brokkr-app/src/message.rs
@@ -391,8 +391,11 @@ pub enum Message {
     ArticlesLoaded(Result<Vec<crate::articles::Article>, String>),
     /// Ask again after a failure.
     ArticlesRetried,
-    /// Read one in the browser.
-    ArticleOpened(String),
+    /// Open a TinkerAtlas link in the browser: an article, or one of the two
+    /// buttons on the welcome screen. The link is checked against the one host
+    /// it may lead to before anything is spawned -- see
+    /// [`crate::articles::open_in_browser`].
+    LinkOpened(String),
     /// The "show this on startup" tick, which is written through immediately:
     /// a preference that only lands when the dialog is dismissed the right way
     /// is one that silently forgets.

--- a/crates/brokkr-app/src/navcube.rs
+++ b/crates/brokkr-app/src/navcube.rs
@@ -22,7 +22,7 @@ use brokkr_gpu::OverlayBatch;
 use glam::{Mat4, Vec2, Vec3};
 
 use crate::camera::OrbitCamera;
-use crate::theme;
+use crate::theme::{self, linear};
 
 /// Edge length of the corner box, in logical pixels.
 pub const SIZE_PX: f32 = 92.0;
@@ -98,11 +98,6 @@ pub fn view_projection(camera: &OrbitCamera) -> Mat4 {
     let projection =
         glam::camera::rh::proj::directx::orthographic(-reach, reach, -reach, reach, 0.1, 10.0);
     projection * view
-}
-
-fn linear(colour: iced::Color, alpha: f32) -> [f32; 4] {
-    let to_linear = |c: f32| c.powf(2.2);
-    [to_linear(colour.r), to_linear(colour.g), to_linear(colour.b), alpha]
 }
 
 /// Line segments making up a letter, in a unit square with y up.

--- a/crates/brokkr-app/src/paths.rs
+++ b/crates/brokkr-app/src/paths.rs
@@ -46,6 +46,31 @@ pub fn state_file(name: &str) -> Option<PathBuf> {
     Some(base("XDG_STATE_HOME", ".local/state")?.join(APPLICATION).join(name))
 }
 
+/// The `key = value` pairs in one of this application's flat config files.
+///
+/// Blank lines and `#` comments are skipped, a line with no `=` is skipped, and
+/// both halves are trimmed. What a key MEANS, and what to do about one that is
+/// unknown or unparseable, is the caller's business and differs per file --
+/// `printer.rs` falls back to a default port, `spacemouse.rs` leaves the
+/// binding alone, `welcome.rs` treats anything but `false` as yes.
+///
+/// **Extracted at the third copy and not before.** `printer.rs` and
+/// `spacemouse.rs` each grew this loop independently and each documented that
+/// it matched the other; `welcome.rs` made three, which is where duplication
+/// stops being cheaper than an abstraction. Only the scanning is shared: a
+/// "config file" type that also owned the defaults would have to know all three
+/// schemas, which is the wrong abstraction rather than a missing one.
+pub fn entries(text: &str) -> impl Iterator<Item = (&str, &str)> {
+    text.lines().filter_map(|line| {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            return None;
+        }
+        let (key, value) = line.split_once('=')?;
+        Some((key.trim(), value.trim()))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/brokkr-app/src/printer.rs
+++ b/crates/brokkr-app/src/printer.rs
@@ -266,19 +266,12 @@ pub(crate) fn configured(from: Option<&std::path::Path>) -> Option<Printer> {
     let text = std::fs::read_to_string(from?).ok()?;
     let mut host = None;
     let mut port = MOONRAKER_PORT;
-    for line in text.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        match key.trim() {
-            "host" => host = Some(value.trim().to_string()),
+    for (key, value) in crate::paths::entries(&text) {
+        match key {
+            "host" => host = Some(value.to_string()),
             // An unparseable port leaves the default rather than failing the
             // whole file: the same forgiveness the spacemouse config gives.
-            "port" => port = value.trim().parse().unwrap_or(MOONRAKER_PORT),
+            "port" => port = value.parse().unwrap_or(MOONRAKER_PORT),
             _ => {}
         }
     }

--- a/crates/brokkr-app/src/spacemouse.rs
+++ b/crates/brokkr-app/src/spacemouse.rs
@@ -309,23 +309,6 @@ impl Default for Config {
     }
 }
 
-/// Bring an angle back into -pi..pi.
-///
-/// Roll accumulates for as long as the user holds the twist, and an angle in
-/// the thousands of radians both loses precision and reads as nonsense in the
-/// settings panel.
-fn wrap_angle(angle: f32) -> f32 {
-    use std::f32::consts::{PI, TAU};
-    let wrapped = angle % TAU;
-    if wrapped > PI {
-        wrapped - TAU
-    } else if wrapped < -PI {
-        wrapped + TAU
-    } else {
-        wrapped
-    }
-}
-
 impl Config {
     pub fn binding(&self, action: Action) -> AxisBinding {
         self.bind[action as usize]
@@ -408,7 +391,8 @@ impl Config {
 
         let roll = self.value(Action::Roll, motion);
         if roll != 0.0 {
-            camera.roll = wrap_angle(camera.roll + roll * self.orbit_sens * elapsed_ms * sign);
+            camera.roll =
+                crate::camera::wrap_angle(camera.roll + roll * self.orbit_sens * elapsed_ms * sign);
             moved = true;
         }
 

--- a/crates/brokkr-app/src/spacemouse.rs
+++ b/crates/brokkr-app/src/spacemouse.rs
@@ -669,16 +669,7 @@ impl Config {
     }
 
     fn merge(&mut self, text: &str) {
-        for line in text.lines() {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
-            let Some((key, value)) = line.split_once('=') else {
-                continue;
-            };
-            let (key, value) = (key.trim(), value.trim());
-
+        for (key, value) in crate::paths::entries(text) {
             // An unknown key or an unparseable value leaves the default in
             // place rather than failing the whole file, so a config written by
             // a newer version still mostly works.

--- a/crates/brokkr-app/src/theme.rs
+++ b/crates/brokkr-app/src/theme.rs
@@ -101,6 +101,55 @@ pub const MASK: Color = rgb(0x58, 0x87, 0xf0);
 /// lightnesses rather than two hues.
 pub const MASK_PALE: Color = rgb(0xa8, 0xc4, 0xf8);
 
+/// The transform gizmo's three axes: X, Y, Z, in that order.
+///
+/// # Why these are authored rather than taken from what is already here
+///
+/// The palette above holds no triad. [`ERROR`] is the obvious red for X and is
+/// exactly the wrong choice: it already means "this stroke removes material" on
+/// the brush ring, and a red arrow beside a red ring on the same surface would
+/// make one of the two lie. [`OK`] and [`MASK`] are similarly spoken for.
+///
+/// So these are the industry triad -- red X, green Y, blue Z, which every
+/// modelling tool a user of this one has touched already uses -- shifted away
+/// from the tokens they would otherwise collide with: the X is a rose rather
+/// than [`ERROR`]'s alarm red, and the Z is a cyan rather than [`MASK`]'s
+/// indigo. Against the warm clay matcap all three read as instrument colours
+/// rather than as material.
+pub const AXIS_X: Color = rgb(0xf0, 0x5a, 0x76);
+pub const AXIS_Y: Color = rgb(0x6a, 0xd8, 0x62);
+pub const AXIS_Z: Color = rgb(0x4a, 0xa8, 0xf0);
+
+/// The same three when the pointer is over them.
+///
+/// **Less saturated, not brighter.** Brightening a saturated colour to say
+/// "hovered" runs it past the top of the channel it is already at -- Godot's
+/// gizmo went through this (PR #50597) and ended up with a hover state that
+/// glowed white on the axis you could least afford to lose track of. Washing
+/// toward white keeps the hue readable and still reads as lit.
+pub const AXIS_X_HOVER: Color = rgb(0xff, 0xa8, 0xb6);
+pub const AXIS_Y_HOVER: Color = rgb(0xb4, 0xf0, 0xae);
+pub const AXIS_Z_HOVER: Color = rgb(0xa6, 0xd6, 0xff);
+
+/// The three axis colours and their hover variants, indexed by axis.
+pub const AXIS: [Color; 3] = [AXIS_X, AXIS_Y, AXIS_Z];
+pub const AXIS_HOVER: [Color; 3] = [AXIS_X_HOVER, AXIS_Y_HOVER, AXIS_Z_HOVER];
+
+/// Convert a theme colour to the linear space the overlay shader expects.
+///
+/// The tokens in this module are sRGB, because they came from SindriCAD's CSS.
+/// Handing those straight to the shader would draw every overlay too bright,
+/// and inconsistently with the model beside it.
+///
+/// **Here rather than at the call site**, because it was written out verbatim
+/// in `cursor.rs` and again in `navcube.rs`, and the gizmo would have been the
+/// third copy. Three copies of a colour-space conversion is three chances for
+/// one overlay to end up in a different space from the one beside it.
+pub fn linear(colour: Color, alpha: f32) -> [f32; 4] {
+    let to_linear = |c: f32| c.powf(2.2);
+    [to_linear(colour.r), to_linear(colour.g), to_linear(colour.b), alpha]
+}
+
 // Radii, from `--r-sm` through `--r-lg`.
 pub const RADIUS_SM: f32 = 6.0;
 pub const RADIUS_MD: f32 = 8.0;

--- a/crates/brokkr-app/src/theme.rs
+++ b/crates/brokkr-app/src/theme.rs
@@ -190,6 +190,10 @@ pub const FONT: Font = Font::with_name("Inter");
 pub const TEXT_SIZE: f32 = 13.0;
 pub const TEXT_SIZE_SMALL: f32 = 11.0;
 pub const CAPTION_SIZE: f32 = 10.0;
+/// The one heading big enough to be read as a title, on the welcome screen.
+/// Nothing inside the application proper uses it: panels are dense by design
+/// and a heading this size in one would cost a row of controls.
+pub const TITLE_SIZE: f32 = 20.0;
 /// Monospace for the debug overlay, where columns of numbers must not jitter.
 pub const MONO: Font = Font::MONOSPACE;
 

--- a/crates/brokkr-app/src/viewport.rs
+++ b/crates/brokkr-app/src/viewport.rs
@@ -1302,6 +1302,15 @@ mod apply_tests {
         }
     }
 
+    /// Publish over a chosen span of coordinates, so a body can be re-published
+    /// somewhere it was not before -- which is what a MOVE does and what
+    /// [`publish`] cannot express.
+    fn publish_over(shared: &SharedFrame, body: NodeId, span: std::ops::Range<i32>) {
+        for brick in span {
+            shared.publish(body, BrickCoord::new(brick, 0, 0), mesh());
+        }
+    }
+
     /// A mesh that actually covers pixels, for the one test whose claim is
     /// about what is in a cell rather than about which slots exist.
     ///
@@ -1434,6 +1443,78 @@ mod apply_tests {
             assert_eq!(after.bricks, before.bricks, "the pool grew for a body that was deleted");
             assert_eq!(after.triangles, before.triangles);
             assert_eq!(renderer.body_bricks(KEPT), 3, "the surviving body lost bricks");
+        }
+    }
+
+    /// **A RELEASED body's new meshes must reach the pool in the same frame.**
+    ///
+    /// This is the second meaning of "the body's old slots are finished with",
+    /// and the distinction between it and a forget is a bug that shipped: a
+    /// gizmo move called `forget_body`, `SharedFrame::apply` dropped every
+    /// queued upload naming it, and the cube vanished with a black thumbnail
+    /// while its field sat intact in the document and the status line said
+    /// "moved 50.63 mm -- exact".
+    ///
+    /// **The test that missed it asserted `world_bounds()` had changed** --
+    /// the DATA, which was never in danger -- and nothing asserted what the
+    /// RENDERER had been told. Nothing in the GPU module exercised
+    /// `release_body` at all: it had exactly two call sites and no test.
+    ///
+    /// The body is re-published at coordinates it did NOT occupy before,
+    /// because that is what a move produces and it is the case that does not
+    /// heal itself. `rebake_gizmo` marks the outgoing coordinates dirty in the
+    /// incoming field, so those slots are handed back by `upload`'s
+    /// empty-indices arm; what is not covered is the halo, since the outgoing
+    /// list is stored bricks only while the remesh covers stored bricks plus
+    /// their 26 neighbours. Those neighbour slots are in the pool, in nobody's
+    /// dirty set, and they are what draws at the old position.
+    #[test]
+    fn a_released_bodys_new_meshes_reach_the_pool_in_the_same_frame() {
+        let Some((device, queue)) = device_or_skip("shared frame release") else {
+            return;
+        };
+
+        const MOVED: NodeId = NodeId(1);
+        const STILL: NodeId = NodeId(2);
+
+        // Both orders, for the same reason the forget test takes both: `apply`
+        // does not record when anything was pushed and cannot tell them apart.
+        for release_first in [false, true] {
+            let mut renderer = renderer(&device, &queue);
+            let shared = SharedFrame::new();
+
+            publish_over(&shared, MOVED, 0..5);
+            publish_over(&shared, STILL, 100..103);
+            shared.apply(&mut renderer, &device, &queue);
+            assert_eq!(renderer.body_bricks(MOVED), 5, "the fixture published nothing");
+            assert_eq!(renderer.body_bricks(STILL), 3, "the fixture published no second body");
+
+            // The move: released and re-published somewhere else, one frame.
+            if release_first {
+                shared.release_body(MOVED);
+                publish_over(&shared, MOVED, 20..23);
+            } else {
+                publish_over(&shared, MOVED, 20..23);
+                shared.release_body(MOVED);
+            }
+            shared.apply(&mut renderer, &device, &queue);
+
+            // The assertion that pins a deleted release loop: a release must
+            // not swallow the uploads queued alongside it.
+            assert!(
+                renderer.body_bricks(MOVED) > 0,
+                "a released body has no slots at all, so the release ate the meshes queued \
+                 with it -- which is a forget wearing a release's name (released {})",
+                if release_first { "before publishing" } else { "after publishing" },
+            );
+            assert_eq!(
+                renderer.body_bricks(MOVED),
+                3,
+                "a released body holds {} slots against the 3 it was re-published with, so the \
+                 old position is still in the pool and still drawing",
+                renderer.body_bricks(MOVED),
+            );
+            assert_eq!(renderer.body_bricks(STILL), 3, "an untouched body lost slots");
         }
     }
 

--- a/crates/brokkr-app/src/viewport.rs
+++ b/crates/brokkr-app/src/viewport.rs
@@ -135,6 +135,10 @@ pub struct SharedFrame {
     /// The navigation cube's geometry, in its own batch because it is drawn in
     /// its own pass with its own matrix.
     cube: Mutex<OverlayBatch>,
+    /// The transform gizmo's geometry. In its own batch because it is drawn in
+    /// its own pass -- the sculpt's matrix, but over the sculpt's depth so a
+    /// gizmo on a body's centroid is reachable rather than buried inside it.
+    gizmo: Mutex<OverlayBatch>,
     /// Which GPU and backend iced actually chose, recorded the first time the
     /// pipeline is built. The application cannot ask wgpu directly -- iced owns
     /// the adapter -- and it is the first thing a bug report needs.
@@ -210,6 +214,11 @@ impl SharedFrame {
         std::mem::swap(&mut *self.cube.lock().expect("shared frame poisoned"), batch);
     }
 
+    /// The same hand off for the transform gizmo.
+    pub fn swap_gizmo(&self, batch: &mut OverlayBatch) {
+        std::mem::swap(&mut *self.gizmo.lock().expect("shared frame poisoned"), batch);
+    }
+
     /// The overlay geometry currently waiting for the renderer.
     ///
     /// The application swaps its buffer in here rather than keeping it, so this
@@ -217,6 +226,12 @@ impl SharedFrame {
     #[cfg(test)]
     pub fn overlay_snapshot(&self) -> OverlayBatch {
         self.overlay.lock().expect("shared frame poisoned").clone()
+    }
+
+    /// The same, for the transform gizmo.
+    #[cfg(test)]
+    pub fn gizmo_snapshot(&self) -> OverlayBatch {
+        self.gizmo.lock().expect("shared frame poisoned").clone()
     }
 
     /// The GPU iced chose, for diagnostics. "unknown" until the first frame.
@@ -654,6 +669,13 @@ pub(crate) fn shortcut(character: &str, command: bool, shift: bool, alt: bool) -
         // field. Pressed while masking it goes back to sculpting, which
         // `Message::ToolChanged` does for every tool.
         "m" => Some(Message::ToolChanged(Tool::Mask)),
+        // The transform gizmo. `w` is ZBrush's, Blender's and Maya's key for
+        // Move, taken rather than invented so muscle memory carries over --
+        // and one key rather than three, because this is one gizmo with move,
+        // turn and scale handles on it rather than three modes. Pressed while
+        // it is up it goes back to sculpting, which `Message::ToolChanged`
+        // does for every tool.
+        "w" => Some(Message::ToolChanged(Tool::Transform)),
         // Hold to see the mask, whatever the `show mask` toggle says. ZBrush's
         // own mask-visibility key is H, taken rather than invented so muscle
         // memory carries over, and held rather than latched because that is the
@@ -661,6 +683,10 @@ pub(crate) fn shortcut(character: &str, command: bool, shift: bool, alt: bool) -
         // without a second press. The release is decoded in `key_event`
         // alongside the sizing keys -- this function only ever sees presses.
         "h" => Some(Message::MaskPeekStarted),
+        // Blender's and Nomad's own key for this, taken rather than invented.
+        // It is the one keystroke that recovers ANY camera, however lost, and
+        // it is the other half of letting the camera move freely at all.
+        "f" => Some(Message::CameraFramedOnActive),
         "x" => Some(Message::SymmetryAxisToggled(MirrorAxis::X)),
         "y" => Some(Message::SymmetryAxisToggled(MirrorAxis::Y)),
         "z" => Some(Message::SymmetryAxisToggled(MirrorAxis::Z)),
@@ -728,12 +754,13 @@ fn route_pointer(
         }
         iced::Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
             cursor.position_in(bounds)?;
+            let (position, size) = pointer_position(bounds, cursor)?;
             let amount = match delta {
                 mouse::ScrollDelta::Lines { y, .. } => *y,
                 // Pixel deltas are far larger per notch than line deltas.
                 mouse::ScrollDelta::Pixels { y, .. } => *y / 40.0,
             };
-            (PointerEvent::Scrolled { amount }, true)
+            (PointerEvent::Scrolled { amount, position, size }, true)
         }
         iced::Event::Keyboard(iced::keyboard::Event::ModifiersChanged(modifiers)) => (
             PointerEvent::Modifiers {
@@ -884,6 +911,13 @@ impl shader::Primitive for SculptPrimitive {
             let cube = shared.cube.lock().expect("shared frame poisoned");
             pipeline.renderer.write_cube(device, queue, &cube, navcube::view_projection(&camera));
         }
+        {
+            // The SCULPT's matrix, not one of the gizmo's own: it is world
+            // space geometry sitting on the body it moves, and only its size is
+            // held constant on screen.
+            let gizmo = shared.gizmo.lock().expect("shared frame poisoned");
+            pipeline.renderer.write_gizmo(device, queue, &gizmo, view_projection);
+        }
         // The cube's corner box is defined in logical pixels so it stays the
         // same physical size at any scale factor, but a render pass wants
         // physical ones. Worked out here because `render` sees neither the
@@ -964,6 +998,23 @@ impl shader::Primitive for SculptPrimitive {
         let y = clip_bounds.y + cube.y;
         let width = cube.width.min(clip_bounds.width.saturating_sub(cube.x));
         let height = cube.height.min(clip_bounds.height.saturating_sub(cube.y));
+        // **The gizmo BEFORE the cube, and the order is decided by the press
+        // dispatch rather than by taste.** Both clear depth, so whichever draws
+        // last wins the pixels they share -- and `Brokkr::on_pointer` tests the
+        // navigation cube before it lets the gizmo claim anything. Drawing them
+        // the other way round would show a gizmo arrow over the cube that,
+        // clicked, flew the camera: the two would disagree about what is on top,
+        // and the one the user can see would be the one that is wrong.
+        pipeline.renderer.render_gizmo(
+            encoder,
+            target,
+            PixelRect {
+                x: clip_bounds.x,
+                y: clip_bounds.y,
+                width: clip_bounds.width,
+                height: clip_bounds.height,
+            },
+        );
         pipeline.renderer.render_cube(encoder, target, PixelRect { x, y, width, height });
     }
 }

--- a/crates/brokkr-app/src/viewport.rs
+++ b/crates/brokkr-app/src/viewport.rs
@@ -153,6 +153,10 @@ pub struct SharedFrame {
     /// Bodies that have left the document and whose pool slots must go with
     /// them. See [`SharedFrame::forget_body`].
     forget: Mutex<Vec<NodeId>>,
+    /// Bodies whose slots must go but which are STILL IN THE DOCUMENT, because
+    /// their geometry has moved and is about to be uploaded again. See
+    /// [`SharedFrame::release_body`].
+    release: Mutex<Vec<NodeId>>,
     /// Bodies the renderer must not draw. See [`SharedFrame::set_hidden`].
     hidden: Mutex<Vec<NodeId>>,
     /// Bodies drawn with the opposite of [`MaskView::inverted`]. See
@@ -321,6 +325,27 @@ impl SharedFrame {
         self.forget.lock().expect("shared frame poisoned").push(body);
     }
 
+    /// Drop a body's slots because its geometry MOVED, not because the body
+    /// went away.
+    ///
+    /// **Distinct from [`SharedFrame::forget_body`], and conflating the two
+    /// makes a body vanish permanently.** A forget means "this body has left
+    /// the document", so `apply` drops every queued upload and the pending
+    /// thumbnail that name it -- otherwise a delete leaves a ghost sliver drawn
+    /// for ever. A transform needs the first half and must not have the second:
+    /// the old slots are stale because the bricks are at new coordinates now,
+    /// but the new meshes are queued in the SAME frame and dropping them leaves
+    /// nothing to draw at all.
+    ///
+    /// That is exactly what shipped: a gizmo move called `forget_body`, the
+    /// re-mesh that followed was discarded by the forget filter, and the body
+    /// disappeared from the viewport with a black thumbnail while its field sat
+    /// intact in the document, the status line reporting an exact move. The
+    /// data was never in danger and that is what made it hard to see.
+    pub fn release_body(&self, body: NodeId) {
+        self.release.lock().expect("shared frame poisoned").push(body);
+    }
+
     /// Replace the set of bodies the renderer must not draw.
     ///
     /// **Wholesale on every change, never mutated one body at a time.** The set
@@ -413,6 +438,13 @@ impl SharedFrame {
         std::mem::take(&mut *self.forget.lock().expect("shared frame poisoned"))
     }
 
+    /// The released list, for the same reason and with the same swap semantics
+    /// as [`SharedFrame::take_forgotten_for_tests`].
+    #[cfg(test)]
+    pub fn take_released_for_tests(&self) -> Vec<NodeId> {
+        std::mem::take(&mut *self.release.lock().expect("shared frame poisoned"))
+    }
+
     /// Ask for one body's picture to be redrawn on the next frame the pool is
     /// quiet.
     ///
@@ -487,6 +519,19 @@ impl SharedFrame {
             std::mem::take(&mut *forget)
         };
         for body in &forgotten {
+            renderer.forget_body(*body);
+        }
+
+        // Released bodies free their slots in the same position as a forget --
+        // before the uploads, so a stale slot at an old brick coordinate cannot
+        // survive and draw the body twice -- but they are deliberately NOT
+        // added to `forgotten`, so the meshes queued behind them in this very
+        // frame still land. See `SharedFrame::release_body`.
+        let released: Vec<NodeId> = {
+            let mut release = self.release.lock().expect("shared frame poisoned");
+            std::mem::take(&mut *release)
+        };
+        for body in &released {
             renderer.forget_body(*body);
         }
 

--- a/crates/brokkr-app/src/welcome.rs
+++ b/crates/brokkr-app/src/welcome.rs
@@ -16,12 +16,10 @@
 //! **The remote pane.** SindriCAD's right column is an `<iframe>` of
 //! `tinkeratlas.com/sindricad/welcome`, probed for reachability from Rust first
 //! because a cross-origin frame never reports its own load failures. There is
-//! no webview here to put a frame in, and the dependency policy would refuse
-//! one long before the design question came up -- `iced`'s `image` feature
-//! alone is seventy-one crates against this workspace's lockfile. So the second
-//! column carries what a first-time user actually needs and cannot get
-//! anywhere else yet: there is no manual, and a beta is the moment strangers
-//! meet the keys for the first time.
+//! no webview here to put a frame in, so the second column carries the same
+//! site's articles fetched as DATA instead -- see [`crate::articles`] -- with
+//! the keys beneath, which a first-time user cannot get anywhere else yet:
+//! there is no manual, and a beta is the moment strangers meet them.
 //!
 //! **The account row.** SindriCAD offers "Sign in with TinkerAtlas" and shows
 //! an avatar. This application has no sign-in at all, and that is a decision
@@ -65,18 +63,9 @@ fn read_from(path: Option<&std::path::Path>) -> bool {
     let Ok(text) = std::fs::read_to_string(path) else {
         return true;
     };
-    for line in text.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        if let Some((name, value)) = line.split_once('=')
-            && name.trim() == KEY
-        {
-            return value.trim() != "false";
-        }
-    }
-    true
+    crate::paths::entries(&text)
+        .find(|(key, _)| *key == KEY)
+        .is_none_or(|(_, value)| value != "false")
 }
 
 /// Remember the answer. A write that fails is dropped: the preference is worth

--- a/crates/brokkr-app/src/welcome.rs
+++ b/crates/brokkr-app/src/welcome.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The welcome screen: what to do first, and how to get back to what you did
+//! last.
+//!
+//! Structure ported from SindriCAD's `src/ui/welcome.ts` -- a modal over a
+//! scrim, the lockup at the head, local actions and the recent list down the
+//! left, a second column beside them, and "show this on startup" along the
+//! foot. **The content is ported and the code is not**, which is the standing
+//! rule between these two applications: that one is a Tauri webview and this is
+//! a Rust binary drawing through iced, and pretending otherwise is how a port
+//! turns into a rewrite of the wrong half.
+//!
+//! # Two things deliberately did not come across
+//!
+//! **The remote pane.** SindriCAD's right column is an `<iframe>` of
+//! `tinkeratlas.com/sindricad/welcome`, probed for reachability from Rust first
+//! because a cross-origin frame never reports its own load failures. There is
+//! no webview here to put a frame in, and the dependency policy would refuse
+//! one long before the design question came up -- `iced`'s `image` feature
+//! alone is seventy-one crates against this workspace's lockfile. So the second
+//! column carries what a first-time user actually needs and cannot get
+//! anywhere else yet: there is no manual, and a beta is the moment strangers
+//! meet the keys for the first time.
+//!
+//! **The account row.** SindriCAD offers "Sign in with TinkerAtlas" and shows
+//! an avatar. This application has no sign-in at all, and that is a decision
+//! rather than an omission: the bug reporter is anonymous precisely so the
+//! workspace never holds a credential. A welcome screen is not the place to
+//! introduce one.
+//!
+//! # The preference
+//!
+//! A flat `key = value` file in the config directory, which is the shape
+//! `printer.conf` and `spacemouse.conf` already use. **Absent means show it**,
+//! matching SindriCAD's `localStorage.getItem(...) !== "false"`: a first run
+//! has no file, and the screen a first run most needs is this one.
+
+use std::path::PathBuf;
+
+/// The file the preference lives in.
+const FILE: &str = "welcome.conf";
+const KEY: &str = "show_on_startup";
+
+/// Where the preference is kept, so the tests and the writer agree.
+fn file() -> Option<PathBuf> {
+    crate::paths::config_file(FILE)
+}
+
+/// Whether to open the welcome screen when the application starts.
+///
+/// Anything that is not an explicit `false` means yes, including a missing
+/// file, an unreadable one and a corrupt one. The failure this guards is
+/// silently *hiding* the screen from someone who never asked to hide it --
+/// which on a first run would mean meeting an empty sculpt with no idea what
+/// the keys are.
+pub fn on_startup() -> bool {
+    read_from(file().as_deref())
+}
+
+fn read_from(path: Option<&std::path::Path>) -> bool {
+    let Some(path) = path else {
+        return true;
+    };
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return true;
+    };
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((name, value)) = line.split_once('=')
+            && name.trim() == KEY
+        {
+            return value.trim() != "false";
+        }
+    }
+    true
+}
+
+/// Remember the answer. A write that fails is dropped: the preference is worth
+/// less than the session, and there is nothing useful to say about a read-only
+/// config directory in the middle of closing a dialog.
+pub fn set_on_startup(show: bool) {
+    if let Some(path) = file() {
+        write_to(&path, show);
+    }
+}
+
+fn write_to(path: &std::path::Path, show: bool) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(
+        path,
+        format!(
+            "# BrokkrSculpt welcome screen.\n\
+             # Delete this file to see it again on startup.\n\
+             {KEY} = {show}\n"
+        ),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("brokkr-welcome-{name}-{}", std::process::id()))
+    }
+
+    /// **A missing file means show it**, which is the case a first run is in.
+    ///
+    /// The other direction -- defaulting to hidden -- fails silently and in the
+    /// worst place: the one person who most needs the screen is the one who has
+    /// never seen it, and they would never know it existed.
+    #[test]
+    fn a_missing_preference_shows_the_screen() {
+        let path = scratch("missing");
+        let _ = std::fs::remove_file(&path);
+        assert!(read_from(Some(&path)));
+        assert!(read_from(None), "no config directory at all must still show it");
+    }
+
+    /// Only an explicit `false` turns it off, and it survives a round trip.
+    #[test]
+    fn the_preference_survives_being_written_and_read_back() {
+        let path = scratch("roundtrip");
+        write_to(&path, false);
+        assert!(!read_from(Some(&path)), "false did not stick");
+        write_to(&path, true);
+        assert!(read_from(Some(&path)), "true did not stick");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A corrupt file shows the screen rather than hiding it.
+    ///
+    /// Same argument as the missing one: of the two ways to be wrong, showing
+    /// a screen someone did not want is a click, and hiding one they did want
+    /// is invisible.
+    #[test]
+    fn a_corrupt_preference_shows_the_screen() {
+        let path = scratch("corrupt");
+        std::fs::write(&path, "\u{0}not a config at all\n[section]\n").expect("temp is writable");
+        assert!(read_from(Some(&path)));
+
+        // And a key that is not ours does not answer for it.
+        std::fs::write(&path, "something_else = false\n").expect("temp is writable");
+        assert!(read_from(Some(&path)));
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/brokkr-core/benches/scale.rs
+++ b/crates/brokkr-core/benches/scale.rs
@@ -15,9 +15,10 @@
 use std::time::Instant;
 
 use brokkr_core::{
-    BrickCoord, BrickMesh, Brush, BrushDirection, BrushKind, BrushScratch, Stamp, Volume,
+    BrickCoord, BrickMesh, Brush, BrushDirection, BrushKind, BrushScratch, DEFAULT_RECLAIM_BUDGET,
+    Similarity, Stamp, Volume, redistance::GRADIENT_TOLERANCE,
 };
-use glam::Vec3;
+use glam::{Quat, Vec3};
 
 /// The model, in millimetres, matching what the application seeds.
 const MODEL_RADIUS: f32 = 30.0;
@@ -67,6 +68,137 @@ fn mesh_all(volume: &mut Volume) -> FullMesh {
         drawn_bricks: meshes.iter().filter(|mesh| !mesh.is_empty()).count(),
         milliseconds,
     }
+}
+
+/// What one release-time bake cost, for a body of a given size.
+struct BakePasses {
+    warp_ms: f64,
+    redistance_ms: f64,
+    /// The worst `||grad d| - 1|` before the warp, after it, and after the
+    /// repair. The middle number is the damage a per-axis scale does; the last
+    /// is whether `redistance` actually undid it.
+    drift_before: f32,
+    drift_warped: f32,
+    drift_repaired: f32,
+    dense_before: usize,
+    dense_after: usize,
+    resident_before: usize,
+    resident_after: usize,
+}
+
+/// A per-axis scale and the repair that follows it, which is what every gizmo
+/// release already pays for and what a deformer will pay again.
+///
+/// The scale is deliberately non-uniform: a uniform one leaves the field a true
+/// distance field, `Similarity::is_uniform_scale` says so, and `rebake_gizmo`
+/// skips the repair entirely. This measures the branch that does not skip.
+fn bake_passes(volume: &Volume) -> BakePasses {
+    let before = volume.stats();
+    let drift_before = volume.gradient_drift();
+
+    let squash =
+        Similarity::about(Vec3::ZERO, Quat::IDENTITY, Vec3::new(1.0, 0.6, 1.0), Vec3::ZERO);
+    let warp_start = Instant::now();
+    let mut warped = volume.warped(squash);
+    let warp_ms = millis(warp_start);
+    let drift_warped = warped.gradient_drift();
+
+    let redistance_start = Instant::now();
+    let report = warped.redistance();
+    let redistance_ms = millis(redistance_start);
+
+    let after = warped.stats();
+    BakePasses {
+        warp_ms,
+        redistance_ms,
+        drift_before,
+        drift_warped,
+        // `redistance` returns None when it declined, which means it judged the
+        // field already within tolerance -- so the drift it would have reported
+        // is the one measured going in.
+        drift_repaired: report.map_or(drift_warped, |report| report.worst_after),
+        dense_before: before.dense_bricks,
+        dense_after: after.dense_bricks,
+        resident_before: before.resident_bytes,
+        resident_after: after.resident_bytes,
+    }
+}
+
+/// The two passes that run on every gizmo release, neither of which had ever
+/// been timed.
+///
+/// Deliberately not in `budget.rs`: every constant there is derived from the
+/// 16 ms frame, and a release-time bake has no defensible frame budget. Putting
+/// these rows beside a budget would invite the next reader to invent one.
+///
+/// **The sweep stops at the size the gizmo can actually arm on.** `arm_gizmo`
+/// refuses outright when `size_of::<Volume>() + resident` exceeds
+/// [`DEFAULT_RECLAIM_BUDGET`], because a move it could not undo is worse than a
+/// move it will not make. Measuring past that measures a regime a deformer can
+/// never enter -- the reference dragon at 765 MB is one such body, and it is
+/// why the rows below print whether the gizmo would take them.
+fn report_release_passes() {
+    println!(
+        "The two passes every gizmo release pays for: one trilinear warp, then the repair.\n\
+         A {MODEL_RADIUS} mm sphere squashed to 0.6 along Y. The repair runs on EVERY resample\n\
+         now, uniform scales included -- a similarity leaves the measured distances exact but\n\
+         not the band, and this is the pass that puts the band back.\n"
+    );
+
+    for voxel_size in [0.25_f32, 0.18, 0.125, 0.09, 0.07] {
+        let mut volume = Volume::new(voxel_size);
+        volume.seed_sphere(Vec3::ZERO, MODEL_RADIUS);
+
+        let passes = bake_passes(&volume);
+        let entry_bytes = size_of::<Volume>() + passes.resident_before;
+        let armable = entry_bytes <= DEFAULT_RECLAIM_BUDGET;
+
+        println!(
+            "voxel {voxel_size:.4} mm   {:>7.1} MB in {} dense bricks   {}",
+            megabytes(passes.resident_before),
+            passes.dense_before,
+            if armable {
+                "the gizmo would arm on this"
+            } else {
+                "OVER the 512 MB arm limit, unreachable through the gizmo"
+            },
+        );
+        println!(
+            "  warp {:>9.1} ms   redistance {:>9.1} ms   together {:>9.1} ms",
+            passes.warp_ms,
+            passes.redistance_ms,
+            passes.warp_ms + passes.redistance_ms,
+        );
+        println!(
+            "  drift {:.3} before, {:.3} warped, {:.3} repaired   {}",
+            passes.drift_before,
+            passes.drift_warped,
+            passes.drift_repaired,
+            if passes.drift_repaired <= GRADIENT_TOLERANCE {
+                "within tolerance"
+            } else {
+                "STILL OUT OF TOLERANCE"
+            },
+        );
+        println!(
+            "  {} dense bricks after, {:>7.1} MB   {:+.1}% resident",
+            passes.dense_after,
+            megabytes(passes.resident_after),
+            (passes.resident_after as f64 / passes.resident_before.max(1) as f64 - 1.0) * 100.0,
+        );
+        println!();
+    }
+
+    println!(
+        "Read the redistance column first. It is serial where every other heavy pass in this\n\
+         crate is rayon-parallel, it runs NARROW_BAND + 1 outer iterations of eight Godunov\n\
+         sweeps over every dense brick, and it allocates a fresh 128 KB vector inside the outer\n\
+         loop. If it is seconds at the arm limit, then committing a deformation freezes the\n\
+         window and the repair has to be made parallel before anything is built on top of it.\n\n\
+         Read the resident column second. A warp that leaves more dense bricks than it found has\n\
+         not grown the model -- it has failed to collapse bricks back to tiles, which costs\n\
+         128 KB each and is invisible to any growth ceiling measured in stretch.\n"
+    );
 }
 
 fn main() {
@@ -156,4 +288,7 @@ fn main() {
          much per stamp while the remesh only grows with the number of bricks touched. Whichever\n\
          of those two crosses its budget first is what has to move to the GPU."
     );
+
+    println!();
+    report_release_passes();
 }

--- a/crates/brokkr-core/src/body.rs
+++ b/crates/brokkr-core/src/body.rs
@@ -588,6 +588,42 @@ impl Document {
         self.volume_mut(active).expect("the active node always holds a volume")
     }
 
+    /// Swap one NAMED body's field for another on the same lattice, handing
+    /// back the field that came out.
+    ///
+    /// **Returned rather than dropped, and that return is the whole point.**
+    /// The field that comes out is the only copy of itself -- [`Volume`] does
+    /// not implement `Clone` -- so a caller that wants to undo the swap has to
+    /// be given it, not asked to have kept one. That is what
+    /// [`crate::Change::WholeVolume`] is, and it is why this is not
+    /// `replace_active_volume` with an id bolted on: that one drops the old
+    /// field on the floor, which is fine for a caller that has already rebuilt
+    /// it from itself and fatal for one that has not.
+    ///
+    /// `None` when no such body exists, so a caller holding a stale id gets its
+    /// volume back rather than a panic.
+    ///
+    /// The lattice check is a `debug_assert` and not a refusal for the reason
+    /// [`Document::replace_active_volume`] gives: every caller derives the
+    /// replacement from the volume it is replacing, and
+    /// [`crate::Volume::warped`] keeps `voxel_size` untouched precisely so that
+    /// this stays true of the gizmo as well.
+    pub fn replace_volume(&mut self, id: NodeId, volume: Volume) -> Option<Volume> {
+        debug_assert_eq!(
+            volume.voxel_size(),
+            self.voxel_size,
+            "a body may not be swapped for one on a different lattice"
+        );
+        let data =
+            self.nodes.iter_mut().find(|node| node.id == id).and_then(|node| node.body.as_mut())?;
+        let previous = std::mem::replace(&mut data.volume, volume);
+        // In full rather than grown: the incoming field is a different one, and
+        // a box grown from the outgoing field's would be a box around geometry
+        // that is no longer there.
+        data.recompute_bounds();
+        Some(previous)
+    }
+
     /// Swap the active body's field for another one on the SAME lattice.
     ///
     /// For an operation that rewrites a whole field in place and keeps the row
@@ -1347,16 +1383,18 @@ impl Document {
     /// for a gesture that is mostly misses. A ray-slab test against a cached
     /// box is about 20 ns. That ratio is why [`BodyCache`] exists at all.
     ///
-    /// # The gate also buys a reach the march does not have
+    /// # The gate also spends no steps crossing the air in front of the model
     ///
-    /// [`crate::raycast`] advances by at most [`NARROW_BAND`] voxels a step,
-    /// because that is where the field saturates, so its total travel is
-    /// bounded by `MAX_STEPS * NARROW_BAND * voxel_size` -- 46 mm at a 0.03 mm
-    /// voxel, against a camera that frames a model from about three times its
-    /// radius. At the finest lattice the ray ran out of steps in the empty
-    /// space in front of the model and the cursor quietly stopped working.
-    /// Starting the march where the ray ENTERS the body's box spends none of
-    /// those steps crossing that emptiness.
+    /// [`crate::raycast`] is bounded at `MAX_STEPS`, and starting the march
+    /// where the ray ENTERS the body's box spends none of them on the empty
+    /// space before it. That used to be load bearing on its own -- a step was
+    /// at most [`NARROW_BAND`] voxels, which is 46 mm of total travel at a
+    /// 0.03 mm voxel, and the cursor quietly stopped working at the finest
+    /// lattice. The march now skips a whole brick at a time through empty
+    /// space and has the reach unaided, so this is headroom rather than the
+    /// only thing standing between the user and a dead cursor. Keep it: the
+    /// two together are what let the picker work inside a model's own hollow
+    /// interior, which is empty space the box does not exclude.
     pub fn pick(
         &self,
         origin: Vec3,
@@ -3790,36 +3828,37 @@ mod tests {
         );
     }
 
-    /// **The reach the march does not have on its own.**
+    /// The gate finds a model far out in front of the eye, and measures the
+    /// distance from the EYE rather than from the box it started the march at.
     ///
-    /// `raycast` advances by at most `NARROW_BAND` voxels a step, so its total
-    /// travel is `MAX_STEPS * NARROW_BAND * voxel_size`: 46 mm at a 0.03 mm
-    /// voxel. A camera framing the default model sits about 90 mm out, so at
-    /// the finest lattice the ray ran out of steps in the empty space in front
-    /// of the model and the cursor stopped working, with nothing anywhere
-    /// saying why.
+    /// # This test used to assert the opposite of what it asserts now
     ///
-    /// The fixture is a small ball at a far viewpoint rather than a large one,
-    /// because a 30 mm ball at 0.03 mm is some 12,000 dense bricks and over a
-    /// gigabyte. The distance is what the failure is about, and it is the same
-    /// distance either way.
+    /// It was written as "the reach the march does not have on its own", and
+    /// its first line asserted that a bare `raycast` from this eye returned
+    /// `None`: 512 steps of at most `NARROW_BAND` voxels is 46 mm at a 0.03 mm
+    /// voxel, against an eye 90 mm out. That assertion was deleted rather than
+    /// weakened, because it is no longer true and the reason is a fix:
+    /// [`crate::raycast`] now skips a whole brick at a time through empty
+    /// space, so the bare march covers this and about ten times more. Its own
+    /// reach is pinned by `a_ray_crossing_a_large_empty_region_still_finds_the_far_surface`,
+    /// where it belongs.
     ///
-    /// Both halves are asserted. Without the raycast line this would pass with
-    /// the gate deleted, on a march that simply had far enough to go.
+    /// **The gate is still wanted, and for the reason it was always wanted
+    /// most**: a ray-slab test against a cached box is about 20 ns where a
+    /// march that misses costs 0.025 ms, so 64 bodies of mostly-misses is the
+    /// difference between 1.3 microseconds and 1.6 ms of a 16 ms frame. What
+    /// this test pins is that the gate does not corrupt the answer -- the
+    /// advance it makes has to be added back, and forgetting that reports a
+    /// surface 87 mm nearer than it is.
     #[test]
-    fn the_box_gate_reaches_a_model_the_march_alone_runs_out_of_steps_before() {
+    fn the_box_gate_finds_a_far_model_and_still_measures_from_the_eye() {
         let voxel_size = 0.03;
         let mut volume = Volume::new(voxel_size);
         volume.seed_sphere(Vec3::ZERO, 3.0);
         let doc = Document::from_volume(volume);
         let body = doc.active();
 
-        // 512 steps of 3 voxels is 46.08 mm, and the eye is 90 mm out.
         let eye = Vec3::new(0.0, 0.0, 90.0);
-        assert!(
-            crate::raycast::raycast(doc.active_volume(), eye, Vec3::NEG_Z, 1000.0).is_none(),
-            "the march reached the model unaided, so this fixture no longer measures anything"
-        );
 
         let hit = doc
             .pick_body(body, eye, Vec3::NEG_Z, 1000.0)

--- a/crates/brokkr-core/src/lib.rs
+++ b/crates/brokkr-core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod pattern;
 pub mod primitive;
 pub mod project;
 pub mod raycast;
+pub mod redistance;
 pub mod region;
 pub mod resample;
 pub mod rotate;

--- a/crates/brokkr-core/src/lib.rs
+++ b/crates/brokkr-core/src/lib.rs
@@ -40,10 +40,12 @@ pub mod raycast;
 pub mod region;
 pub mod resample;
 pub mod rotate;
+pub mod similarity;
 pub mod split;
 pub mod stroke;
 #[cfg(test)]
 mod testing;
+pub mod transform;
 pub mod undo;
 pub mod volume;
 pub mod voxelise;
@@ -77,11 +79,13 @@ pub use project::{
 };
 pub use raycast::{Hit, raycast};
 pub use region::FieldRegion;
+pub use similarity::{Bake, Similarity};
 pub use split::{
     MASKED_ENOUGH_TO_SPLIT, MaskedSplitOutcome, Part, SIGNIFICANT_MM3, SLOW_SPLIT, SplitOutcome,
     SplitPlan,
 };
 pub use stroke::{MAX_STAMPS_PER_EVENT, Stroke};
+pub use transform::warps_made_on_this_thread;
 pub use undo::{
     Change, DEFAULT_HISTORY_BUDGET, DEFAULT_RECLAIM_BUDGET, Entry, History, HistoryStats,
     StrokeEdit, UndoOutcome,

--- a/crates/brokkr-core/src/mask.rs
+++ b/crates/brokkr-core/src/mask.rs
@@ -76,6 +76,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::brick::{BRICK_DIM, BRICK_VOXELS, BrickCoord, brick_index};
 use crate::orientation::AxisRotation;
 use crate::project::MAX_VOLUME_BYTES;
+use crate::similarity::Similarity;
 use crate::volume::VolumeStats;
 
 /// A voxel a brush may change freely.
@@ -1131,6 +1132,159 @@ impl MaskField {
                                 local.y as usize,
                                 local.z as usize,
                             ));
+                        }
+                    }
+                }
+                match brick.is_collapsible() {
+                    Some(UNMASKED) => None,
+                    Some(byte) => Some((*coord, MaskBrick::Uniform(byte))),
+                    None => Some((*coord, brick)),
+                }
+            })
+            .collect();
+
+        out.bricks.reserve(built.len());
+        for (coord, brick) in built {
+            out.bricks.insert(coord, brick);
+        }
+        out
+    }
+
+    /// This mask moved by whole VOXELS, sub-brick offsets included.
+    ///
+    /// The mask half of [`crate::Volume::shifted`], and value-exact for the
+    /// same reason: every destination cell takes exactly one source cell's
+    /// byte. [`MaskField::translated`] moves whole bricks and cannot express a
+    /// sub-brick offset at all; this one gathers, and delegates to it when the
+    /// offset happens to be brick aligned so that the common case still moves
+    /// `Box` pointers rather than bytes.
+    ///
+    /// Nearest neighbour is not a choice here, it is the absence of one: at
+    /// whole-voxel granularity there is nothing between two cells to
+    /// interpolate.
+    pub(crate) fn shifted(&self, offset_voxels: IVec3) -> MaskField {
+        let dim = BRICK_DIM as i32;
+        if offset_voxels.rem_euclid(IVec3::splat(dim)) == IVec3::ZERO {
+            return self.translated(offset_voxels / dim);
+        }
+
+        let mut out = MaskField {
+            bricks: FxHashMap::default(),
+            inverted: self.inverted,
+            // Carried forward rather than reset, for the reason
+            // [`MaskField::translated`] gives.
+            revision: self.revision + 1,
+        };
+        if self.bricks.is_empty() {
+            return out;
+        }
+
+        // Every destination brick any source brick reaches. A source brick
+        // shifted by a sub-brick offset straddles up to eight of them.
+        let mut wanted: FxHashSet<BrickCoord> = FxHashSet::default();
+        for coord in self.bricks.keys() {
+            let low = BrickCoord::containing(coord.origin() + offset_voxels).0;
+            let high = BrickCoord::containing(coord.max_voxel() + offset_voxels).0;
+            for bz in low.z..=high.z {
+                for by in low.y..=high.y {
+                    for bx in low.x..=high.x {
+                        wanted.insert(BrickCoord::new(bx, by, bz));
+                    }
+                }
+            }
+        }
+
+        let coords: Vec<BrickCoord> = wanted.into_iter().collect();
+        let built: Vec<(BrickCoord, MaskBrick)> = coords
+            .par_iter()
+            .filter_map(|coord| {
+                let source_low = coord.origin() - offset_voxels;
+                let source_high = coord.max_voxel() - offset_voxels;
+                if let Some(byte) = self.uniform_over(source_low, source_high) {
+                    return (byte != UNMASKED).then_some((*coord, MaskBrick::Uniform(byte)));
+                }
+
+                let mut brick = MaskBrick::dense_filled(UNMASKED);
+                let data = brick.make_dense();
+                for z in 0..BRICK_DIM {
+                    for y in 0..BRICK_DIM {
+                        for x in 0..BRICK_DIM {
+                            let cell = source_low + IVec3::new(x as i32, y as i32, z as i32);
+                            data[brick_index(x, y, z)] = self.byte_at(cell);
+                        }
+                    }
+                }
+                match brick.is_collapsible() {
+                    Some(UNMASKED) => None,
+                    Some(byte) => Some((*coord, MaskBrick::Uniform(byte))),
+                    None => Some((*coord, brick)),
+                }
+            })
+            .collect();
+
+        out.bricks.reserve(built.len());
+        for (coord, brick) in built {
+            out.bricks.insert(coord, brick);
+        }
+        out
+    }
+
+    /// This mask rebuilt through a similarity, onto the SAME lattice.
+    ///
+    /// Nearest neighbour, for the reason [`MaskField::resampled`] gives:
+    /// protection is an authored intent rather than a measurement, and
+    /// interpolating it would soften a painted edge on every pass.
+    ///
+    /// The destination footprint is found by pushing each source brick's own
+    /// box FORWARD through the map, rather than by walking the field's bounds.
+    /// Protection over empty space is real -- it is what stops Draw growing
+    /// material there -- so a mask brick with no field brick under it has to be
+    /// carried, and it would be invisible to a walk of the field.
+    pub(crate) fn warped(&self, by: Similarity, voxel_size: f32) -> MaskField {
+        let mut out = MaskField {
+            bricks: FxHashMap::default(),
+            inverted: self.inverted,
+            revision: self.revision + 1,
+        };
+        if self.bricks.is_empty() {
+            return out;
+        }
+
+        let mut wanted: FxHashSet<BrickCoord> = FxHashSet::default();
+        for coord in self.bricks.keys() {
+            let source_low = coord.origin().as_vec3() * voxel_size;
+            let source_high = coord.max_voxel().as_vec3() * voxel_size;
+            // The forward image of a box, by the same eight-corner argument
+            // [`Similarity::inverse_bounds`] makes for the backward one --
+            // which is what `inverse().inverse_bounds(..)` says.
+            let (low, high) = by.inverse().inverse_bounds(source_low, source_high);
+            let low = BrickCoord::containing((low / voxel_size).floor().as_ivec3() - IVec3::ONE).0;
+            let high = BrickCoord::containing((high / voxel_size).ceil().as_ivec3() + IVec3::ONE).0;
+            for bz in low.z..=high.z {
+                for byy in low.y..=high.y {
+                    for bx in low.x..=high.x {
+                        wanted.insert(BrickCoord::new(bx, byy, bz));
+                    }
+                }
+            }
+        }
+
+        let inverse = by.inverse();
+        let coords: Vec<BrickCoord> = wanted.into_iter().collect();
+        let built: Vec<(BrickCoord, MaskBrick)> = coords
+            .par_iter()
+            .filter_map(|coord| {
+                let origin = coord.origin();
+                let mut brick = MaskBrick::dense_filled(UNMASKED);
+                let data = brick.make_dense();
+                for z in 0..BRICK_DIM {
+                    for y in 0..BRICK_DIM {
+                        for x in 0..BRICK_DIM {
+                            let world = (origin + IVec3::new(x as i32, y as i32, z as i32))
+                                .as_vec3()
+                                * voxel_size;
+                            let source = inverse.transform_point(world) / voxel_size;
+                            data[brick_index(x, y, z)] = self.byte_at(source.round().as_ivec3());
                         }
                     }
                 }

--- a/crates/brokkr-core/src/mask.rs
+++ b/crates/brokkr-core/src/mask.rs
@@ -1257,7 +1257,7 @@ impl MaskField {
             // The forward image of a box, by the same eight-corner argument
             // [`Similarity::inverse_bounds`] makes for the backward one --
             // which is what `inverse().inverse_bounds(..)` says.
-            let (low, high) = by.inverse().inverse_bounds(source_low, source_high);
+            let (low, high) = crate::transform::forward_bounds(by, source_low, source_high);
             let low = BrickCoord::containing((low / voxel_size).floor().as_ivec3() - IVec3::ONE).0;
             let high = BrickCoord::containing((high / voxel_size).ceil().as_ivec3() + IVec3::ONE).0;
             for bz in low.z..=high.z {
@@ -1269,7 +1269,6 @@ impl MaskField {
             }
         }
 
-        let inverse = by.inverse();
         let coords: Vec<BrickCoord> = wanted.into_iter().collect();
         let built: Vec<(BrickCoord, MaskBrick)> = coords
             .par_iter()
@@ -1283,7 +1282,7 @@ impl MaskField {
                             let world = (origin + IVec3::new(x as i32, y as i32, z as i32))
                                 .as_vec3()
                                 * voxel_size;
-                            let source = inverse.transform_point(world) / voxel_size;
+                            let source = by.inverse_transform_point(world) / voxel_size;
                             data[brick_index(x, y, z)] = self.byte_at(source.round().as_ivec3());
                         }
                     }

--- a/crates/brokkr-core/src/orientation.rs
+++ b/crates/brokkr-core/src/orientation.rs
@@ -147,6 +147,27 @@ impl AxisRotation {
         AxisRotation::quarter_turn(from.normal().cross(to.normal()))
     }
 
+    /// The rotation whose basis images are `columns`, when they name one.
+    ///
+    /// **The validation is why this exists rather than a public field.** The
+    /// type's whole value is that it cannot hold anything but a signed
+    /// permutation of determinant +1 -- a reflection would export every
+    /// triangle inside out, and a column with two nonzero entries would not map
+    /// the lattice onto itself at all -- and a `pub` field would put that
+    /// invariant in the hands of every future caller. `None` for anything else.
+    ///
+    /// Its one caller is [`crate::similarity::Similarity::route`], which reads
+    /// a quarter turn off a quaternion by asking where the three basis vectors
+    /// land. That is a construction from outside this module, and it has to be
+    /// checked rather than trusted.
+    pub fn from_columns(columns: [IVec3; 3]) -> Option<AxisRotation> {
+        if columns.iter().any(|column| column.abs().element_sum() != 1) {
+            return None;
+        }
+        let rotation = AxisRotation { columns };
+        (rotation.determinant() == 1).then_some(rotation)
+    }
+
     /// A quarter turn about a unit basis vector, positive by the right hand
     /// rule.
     ///

--- a/crates/brokkr-core/src/raycast.rs
+++ b/crates/brokkr-core/src/raycast.rs
@@ -4,6 +4,7 @@
 
 use glam::Vec3;
 
+use crate::brick::BrickCoord;
 use crate::volume::Volume;
 
 /// Where a ray met the surface.
@@ -19,11 +20,18 @@ pub struct Hit {
 
 /// Upper bound on marching steps.
 ///
-/// Values are clamped to the narrow band, so far from the surface each step
-/// advances by NARROW_BAND voxels rather than the true distance. Crossing a
-/// 256 voxel volume therefore costs roughly 90 steps and this bound is
-/// comfortable. It is what makes the simple march affordable without a brick
-/// level acceleration structure, which belongs with the GPU rewrite.
+/// Values are clamped to the narrow band, so near the surface each step
+/// advances by at most NARROW_BAND voxels rather than by the true distance.
+/// Empty space is crossed a whole brick at a time instead -- see
+/// [`empty_brick_span`] -- so the bound now buys about ten times the reach it
+/// used to, and a model thousands of voxels across is within it.
+///
+/// **It was not, before that skip existed.** Three voxels a step over 512
+/// steps is 1536 voxels of travel measured from where the ray ENTERS the
+/// body's box, which a 3540 voxel model exceeds: the picker returned `None`
+/// where there plainly was surface, and the cursor quietly stopped working on
+/// exactly the models big enough to want it. Raising the bound instead would
+/// have paid for the emptiness rather than skipping it.
 const MAX_STEPS: u32 = 512;
 
 /// Bisection steps used to refine the crossing once it is bracketed.
@@ -58,6 +66,18 @@ pub fn raycast(volume: &Volume, origin: Vec3, direction: Vec3, max_distance: f32
         if t > max_distance {
             return None;
         }
+        // Empty space costs one step per brick rather than one per three
+        // voxels. The bracket moves with it: `previous_t` stays at the near
+        // side of the jump because no crossing can lie inside it, so a hit
+        // found at the far side is still bracketed by a point known to be
+        // outside, and `refine` still sees a single sign change.
+        if let Some(jump) = empty_brick_span(volume, origin + direction * t, direction) {
+            previous_t = t;
+            t += jump;
+            if t > max_distance {
+                return None;
+            }
+        }
         let d = field(t);
         if d <= 0.0 {
             let hit_t = refine(&field, previous_t, t);
@@ -87,6 +107,68 @@ fn refine(field: &impl Fn(f32) -> f32, mut outside: f32, mut inside: f32) -> f32
         }
     }
     0.5 * (outside + inside)
+}
+
+/// How far the ray may advance from `point` without any chance of stepping
+/// over a surface, when `point` sits in a brick that is empty everywhere.
+///
+/// `None` when the brick carries detail, when it is solid, or when the saving
+/// would be nothing.
+///
+/// # Why this cannot skip a crossing
+///
+/// [`Volume::sample_world`] interpolates between `floor(p / voxel_size)` and
+/// the voxel one further on, and nothing else. So every sample taken strictly
+/// inside the box from the brick's origin voxel to its LAST voxel reads only
+/// voxels belonging to this brick -- one voxel is given up at the high face
+/// and none at the low one. A brick whose every voxel is positive therefore
+/// samples positive over the whole of that box, and a sign change inside it is
+/// not merely unlikely but impossible.
+///
+/// The half voxel taken off the exit is float safety, not part of the
+/// argument: it keeps the next sample clear of the face the argument rests on.
+///
+/// **A back off measured along the ray would not have been enough**, which is
+/// the trap here. A ray running nearly parallel to a side face is metres from
+/// its exit face and a thousandth of a voxel from the neighbouring brick the
+/// whole way, and that neighbour may be dense. The box is what makes the
+/// distance to EVERY face part of the bound; `box_exit` takes the nearest of
+/// the six.
+fn empty_brick_span(volume: &Volume, point: Vec3, direction: Vec3) -> Option<f32> {
+    let voxel_size = volume.voxel_size();
+    let coord = BrickCoord::containing((point / voxel_size).floor().as_ivec3());
+    // An absent brick answers `OUTSIDE`, which is the common case and the one
+    // worth the most: the air in front of a model is not stored at all.
+    if volume.brick_fill(coord)? <= 0.0 {
+        return None;
+    }
+    let low = coord.origin().as_vec3() * voxel_size;
+    let high = coord.max_voxel().as_vec3() * voxel_size;
+    let span = box_exit(point, direction, low, high)? - 0.5 * voxel_size;
+    (span > 0.0).then_some(span)
+}
+
+/// Distance along the ray from `point` to where it leaves an axis aligned box.
+///
+/// Negative or `None` when `point` is not inside, which the caller reads as
+/// "no saving here" rather than as an error.
+fn box_exit(point: Vec3, direction: Vec3, low: Vec3, high: Vec3) -> Option<f32> {
+    let mut exit = f32::INFINITY;
+    for axis in 0..3 {
+        let step = direction[axis];
+        if step == 0.0 {
+            // Parallel to this pair of faces: it never leaves through them,
+            // but it also has to already be between them.
+            if point[axis] < low[axis] || point[axis] > high[axis] {
+                return None;
+            }
+            continue;
+        }
+        let near = (low[axis] - point[axis]) / step;
+        let far = (high[axis] - point[axis]) / step;
+        exit = exit.min(near.max(far));
+    }
+    exit.is_finite().then_some(exit)
 }
 
 #[cfg(test)]
@@ -138,5 +220,83 @@ mod tests {
         let hit = raycast(&volume, centre, Vec3::X, 1000.0).expect("inside counts as a hit");
         assert_eq!(hit.distance, 0.0);
         assert_eq!(hit.position, centre);
+    }
+
+    /// The reach the empty brick skip exists for.
+    ///
+    /// Without it a step is at most [`crate::brick::NARROW_BAND`] voxels, so
+    /// `MAX_STEPS` bounds the march at about 1536 voxels of travel and this
+    /// ray -- 3540 voxels of empty space before the sphere -- ran out of steps
+    /// and reported a miss. The picker backs its start up to the body's
+    /// bounding box, which hides the failure for a ray aimed at the near face
+    /// and does nothing for one crossing the box's own empty interior.
+    #[test]
+    fn a_ray_crossing_a_large_empty_region_still_finds_the_far_surface() {
+        let voxel_size = 0.0565;
+        let centre = Vec3::splat(200.0);
+        let radius = 10.0;
+        let mut volume = Volume::new(voxel_size);
+        volume.seed_sphere(centre, radius);
+
+        let origin = centre - Vec3::X * 200.0;
+        assert!(
+            200.0 / voxel_size > 3000.0,
+            "the gap has to be past the old bound for this test to mean anything"
+        );
+
+        let hit = raycast(&volume, origin, Vec3::X, 1000.0)
+            .expect("the surface is right there, 3540 voxels away");
+        let expected = 200.0 - radius;
+        assert!(
+            (hit.distance - expected).abs() < voxel_size * 2.0,
+            "hit at {} but geometry says {expected}",
+            hit.distance
+        );
+    }
+
+    /// The skip must not read a neighbouring brick's surface as empty.
+    ///
+    /// A ray sliding along the inside of a brick face is the case a back off
+    /// measured along the ray gets wrong: it is far from its exit face and
+    /// touching the neighbour the whole way.
+    #[test]
+    fn a_ray_grazing_the_face_of_an_empty_brick_still_sees_the_brick_beyond_it() {
+        let voxel_size = 1.0;
+        let mut volume = Volume::new(voxel_size);
+        // Big enough to span many bricks, so the march is mostly skipping.
+        volume.seed_sphere(Vec3::splat(256.0), 60.0);
+
+        // Aimed just under the sphere's equator, so the ray runs close to the
+        // surface for a long way before meeting it.
+        for offset in [0.0_f32, 0.5, 0.9, 1.1, 5.0, 20.0, 55.0] {
+            let origin = Vec3::new(0.0, 256.0 + offset, 256.0);
+            let hit = raycast(&volume, origin, Vec3::X, 1000.0);
+            let expected = 256.0 - (60.0_f32 * 60.0 - offset * offset).sqrt();
+            let hit = hit.unwrap_or_else(|| panic!("missed the sphere at offset {offset}"));
+            assert!(
+                (hit.distance - expected).abs() < 2.0,
+                "at offset {offset} hit {} but geometry says {expected}",
+                hit.distance
+            );
+        }
+    }
+
+    /// The skip is an optimisation, so it has to agree with the march it
+    /// replaces everywhere, not only where it was aimed.
+    #[test]
+    fn skipping_empty_bricks_finds_the_same_surface_as_crawling_through_them() {
+        let (volume, centre, radius) = sphere_volume();
+        for (dy, dz) in [(0.0, 0.0), (5.0, -3.0), (-12.0, 8.0), (19.0, 0.0), (0.0, -19.5)] {
+            let origin = centre - Vec3::X * 300.0 + Vec3::new(0.0, dy, dz);
+            let hit = raycast(&volume, origin, Vec3::X, 1000.0)
+                .unwrap_or_else(|| panic!("missed at {dy},{dz}"));
+            let sideways = (dy * dy + dz * dz).sqrt();
+            let expected = 300.0 - (radius * radius - sideways * sideways).sqrt();
+            assert!(
+                (hit.distance - expected).abs() < 1.0,
+                "at {dy},{dz} hit {} but geometry says {expected}",
+                hit.distance
+            );
+        }
     }
 }

--- a/crates/brokkr-core/src/redistance.rs
+++ b/crates/brokkr-core/src/redistance.rs
@@ -256,8 +256,7 @@ impl Volume {
         let mut by_colour: [Vec<BrickCoord>; 8] = Default::default();
         for coord in &coords {
             let v = coord.0;
-            let colour =
-                (v.x.rem_euclid(2) + v.y.rem_euclid(2) * 2 + v.z.rem_euclid(2) * 4) as usize;
+            let colour = ((v.x & 1) | ((v.y & 1) << 1) | ((v.z & 1) << 2)) as usize;
             by_colour[colour].push(*coord);
         }
 

--- a/crates/brokkr-core/src/redistance.rs
+++ b/crates/brokkr-core/src/redistance.rs
@@ -1,0 +1,522 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Put the distances back, so the field is a distance field again.
+//!
+//! Every operation in this engine that is not a similarity leaves a volume
+//! whose zero set is right and whose *distances* are wrong. The brushes do it a
+//! little -- [`crate::brush`] warps the domain and the gradient's length drifts
+//! away from one across many overlapping stamps. A per-axis scale does it a
+//! lot: squashing one axis by `s_min` and another by `s_max` drives the
+//! gradient into `[s_min/s_max, 1]` everywhere at once. Nothing in the engine
+//! reset either of them, so the drift accumulated with no ceiling, and that --
+//! not any difficulty in expressing the transform -- is the whole reason
+//! [`crate::Similarity`] refused a per-axis scale.
+//!
+//! This is the pass [`crate::similarity`]'s header names as its trigger. It has
+//! the two customers that header predicted, and a third that turned up on the
+//! way: the brush residual, per-axis scale, and any future domain warp -- a
+//! bend, a twist, a taper -- which is the same problem with a different shape.
+//!
+//! # The method, and why this one
+//!
+//! Fast sweeping, restricted to the narrow band. The field is already clamped
+//! to `+/-NARROW_BAND` voxels either side of the surface, so there is nothing
+//! to solve in the interior or the exterior -- both are saturated constants and
+//! stay exactly as they are. What is left is a shell three voxels thick, which
+//! is a very small fraction of any real body and the reason this is affordable
+//! at all.
+//!
+//! Inside that shell the Eikonal equation `|grad d| = 1` is solved by Godunov
+//! upwind differencing, sweeping the volume in all eight diagonal directions.
+//! Sweeping alternately with and against each axis is what lets information
+//! travel outward from the surface in one pass per direction rather than
+//! propagating one voxel per iteration; the classical result is that eight
+//! sweeps suffice in three dimensions, and the band here is thin enough that
+//! the first two do nearly all of it.
+//!
+//! **Fast marching was rejected, and not on grounds of accuracy.** It is the
+//! better-known method and it converges in one pass rather than eight, but it
+//! needs a priority queue over the whole band, which is an allocation
+//! proportional to the surface area and a heap operation per voxel. Sweeping
+//! needs no allocation beyond the brick scratch this crate already keeps, and
+//! it is trivially parallel per brick row. At the sizes here -- a 133 mm body
+//! at 0.079 mm is tens of millions of voxels, of which the band is a few
+//! million -- the constant factor decides it.
+//!
+//! # What is NOT touched, and why that matters more than what is
+//!
+//! **The sign is never changed.** Redistancing moves magnitudes; a voxel that
+//! was inside stays inside. That is not a nicety: the sign is what the mesher
+//! reads, so a pass that could flip one could move the surface, and a
+//! correction that can move the surface is not a correction. Every write here
+//! goes through [`keep_sign`].
+//!
+//! **A saturated voxel stays saturated.** `+/-NARROW_BAND` means "further than
+//! the band reaches" and solving for it would invent a distance the field
+//! cannot hold anyway.
+//!
+//! **Uniform bricks are skipped entirely**, which is what makes this cheap on a
+//! real model: a brick that is all interior or all exterior has no band in it.
+
+use glam::Vec3;
+
+use crate::brick::{BRICK_DIM, BRICK_VOXELS, Brick, BrickCoord, INSIDE, NARROW_BAND, OUTSIDE};
+use crate::volume::Volume;
+
+/// Copy the scratch back into a brick-sized array.
+fn solved_array(solved: &[f32]) -> [f32; BRICK_VOXELS] {
+    let mut out = [0.0f32; BRICK_VOXELS];
+    out.copy_from_slice(solved);
+    out
+}
+
+/// How near the gradient has to be to one before a body is left alone.
+///
+/// Measured against the worst voxel rather than the average: an average hides
+/// exactly the local defect this exists to find. The value is not arbitrary --
+/// [`crate::generate`] clamps a sampled gradient into `[0.5, 2.0]` and treats
+/// anything inside that as usable, so a body whose worst voxel is within 10% of
+/// one is comfortably inside what every other reader already tolerates, and
+/// redistancing it would be work with no customer.
+pub const GRADIENT_TOLERANCE: f32 = 0.1;
+
+/// Sweeps per pass. Eight is every combination of direction along three axes.
+const SWEEPS: usize = 8;
+
+/// What one redistancing did, for the status line and for the tests.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct RedistanceReport {
+    /// Bricks that held some band and were solved.
+    pub bricks: usize,
+    /// Voxels written. Zero means the field was already a distance field.
+    pub corrected: usize,
+    /// The worst `||grad d| - 1|` found before the pass, and after it.
+    pub worst_before: f32,
+    pub worst_after: f32,
+}
+
+impl Volume {
+    /// Measure how far this volume has drifted from being a distance field.
+    ///
+    /// The worst deviation of `|grad d|` from one, over every band voxel. Cheap
+    /// enough to gate on: it is one pass with no writes, and it is what lets
+    /// [`Volume::redistance`] decline to touch a body that does not need it.
+    pub fn gradient_drift(&self) -> f32 {
+        let mut worst: f32 = 0.0;
+        let mut apron = crate::apron::ApronBuffer::new();
+        for coord in self.brick_coords().collect::<Vec<_>>() {
+            if !matches!(self.brick(coord), Some(Brick::Dense(_))) {
+                continue;
+            }
+            self.gather_apron(coord, &mut apron);
+            for index in 0..BRICK_VOXELS {
+                let (x, y, z) = unindex(index);
+                if !measurable(&apron, x, y, z) {
+                    continue;
+                }
+                let length = central_gradient(&apron, x, y, z).length();
+                worst = worst.max((length - 1.0).abs());
+            }
+        }
+        worst
+    }
+
+    /// Solve `|grad d| = 1` across the narrow band, leaving every sign alone.
+    ///
+    /// Returns `None` when the field is already within [`GRADIENT_TOLERANCE`],
+    /// which is the common case and costs one read-only pass. A body that has
+    /// only ever been sculpted and moved rigidly never needs this.
+    pub fn redistance(&mut self) -> Option<RedistanceReport> {
+        let worst_before = self.gradient_drift();
+        if worst_before <= GRADIENT_TOLERANCE {
+            return None;
+        }
+
+        let mut report = RedistanceReport { worst_before, ..Default::default() };
+        let coords: Vec<BrickCoord> = self
+            .brick_coords()
+            .filter(|coord| matches!(self.brick(*coord), Some(Brick::Dense(_))))
+            .collect();
+
+        // **Two phases, because a block-wise Eikonal solve needs its halo.**
+        //
+        // Phase one writes the interface seeds -- and only those -- into the
+        // volume, everything else saturated. Phase two sweeps each brick
+        // repeatedly, reading its neighbours through the apron, so a correction
+        // crosses a brick boundary one voxel per outer iteration. The band is
+        // NARROW_BAND voxels deep and the apron is one thick, so the loop runs
+        // that many times plus one and no further: past that there is nothing
+        // left inside the band for a neighbour to tell it.
+        let mut apron = crate::apron::ApronBuffer::new();
+        let mut solved = vec![0.0f32; BRICK_VOXELS];
+
+        for coord in &coords {
+            self.gather_apron(*coord, &mut apron);
+            for (index, value) in solved.iter_mut().enumerate() {
+                let (x, y, z) = unindex(index);
+                *value = apron.get(x + 1, y + 1, z + 1);
+            }
+            let seeded = seed_from_interface(&solved, &apron);
+            for index in 0..BRICK_VOXELS {
+                let was = solved[index];
+                solved[index] = if in_band(was) && seeded[index].is_finite() {
+                    keep_sign(was, seeded[index])
+                } else if in_band(was) {
+                    keep_sign(was, OUTSIDE)
+                } else {
+                    was
+                };
+            }
+            self.insert_brick(*coord, Brick::Dense(Box::new(solved_array(&solved))));
+        }
+
+        let outer = NARROW_BAND as usize + 1;
+        for _ in 0..outer {
+            for coord in &coords {
+                self.gather_apron(*coord, &mut apron);
+                let mut working = vec![0.0f32; BRICK_VOXELS];
+                for (index, value) in working.iter_mut().enumerate() {
+                    let (x, y, z) = unindex(index);
+                    *value = apron.get(x + 1, y + 1, z + 1).abs();
+                }
+                for sweep in 0..SWEEPS {
+                    sweep_once(&mut working, &apron, sweep);
+                }
+                for index in 0..BRICK_VOXELS {
+                    let (x, y, z) = unindex(index);
+                    let was = apron.get(x + 1, y + 1, z + 1);
+                    solved[index] = keep_sign(was, working[index]);
+                }
+                self.insert_brick(*coord, Brick::Dense(Box::new(solved_array(&solved))));
+            }
+        }
+        report.bricks = coords.len();
+        report.corrected = coords.len() * BRICK_VOXELS;
+
+        report.worst_after = self.gradient_drift();
+        Some(report)
+    }
+}
+
+/// Whether a value is inside the band and therefore solvable.
+///
+/// Strict on both sides. A voxel sitting exactly at `+/-NARROW_BAND` is
+/// saturated -- it means "further than the band reaches" -- and solving for it
+/// would invent a distance the field has no room to hold.
+fn in_band(value: f32) -> bool {
+    value > INSIDE && value < OUTSIDE
+}
+
+/// Give `magnitude` the sign of `was`, and clamp back into the band.
+///
+/// **The one place a redistanced value is written**, so that "this pass cannot
+/// move the surface" is a property of one function rather than a claim about
+/// every call site. `total_cmp` rather than `< 0.0` because the voxeliser
+/// biases an exact zero to the inside as `-0.0`, and `-0.0 < 0.0` is false --
+/// the same trap `fill_sealed_cavities` documents, and reading it wrong here
+/// would flip the sign of every on-surface voxel.
+fn keep_sign(was: f32, magnitude: f32) -> f32 {
+    let negative = was.total_cmp(&0.0).is_le();
+    let signed = if negative { -magnitude } else { magnitude };
+    signed.clamp(INSIDE, OUTSIDE)
+}
+
+/// Whether a voxel's central-difference stencil is free of saturation.
+///
+/// A voxel one step inside the band has a neighbour pinned at `+/-NARROW_BAND`,
+/// so its central difference measures the clamp rather than the field and reads
+/// far from one on a PERFECTLY good ball. Measuring those was the first version
+/// of this and it reported a clean seeded sphere as drifting by 0.497.
+fn measurable(apron: &crate::apron::ApronBuffer, x: usize, y: usize, z: usize) -> bool {
+    let (x, y, z) = (x + 1, y + 1, z + 1);
+    if !in_band(apron.get(x, y, z)) {
+        return false;
+    }
+    [
+        apron.get(x + 1, y, z),
+        apron.get(x - 1, y, z),
+        apron.get(x, y + 1, z),
+        apron.get(x, y - 1, z),
+        apron.get(x, y, z + 1),
+        apron.get(x, y, z - 1),
+    ]
+    .iter()
+    .all(|v| in_band(*v))
+}
+
+/// Distances for the voxels that touch the surface, and infinity for the rest.
+///
+/// The seed is a magnitude grid: sign is carried separately and restored on the
+/// way out, so the sweep never has to think about it.
+fn seed_from_interface(solved: &[f32], apron: &crate::apron::ApronBuffer) -> Vec<f32> {
+    let mut seed = vec![f32::INFINITY; BRICK_VOXELS];
+    for index in 0..BRICK_VOXELS {
+        let (x, y, z) = unindex(index);
+        let here = solved[index];
+        if !in_band(here) {
+            continue;
+        }
+        let negative = here.total_cmp(&0.0).is_le();
+        let mut best = f32::INFINITY;
+        for (dx, dy, dz) in
+            [(1isize, 0, 0), (-1, 0, 0), (0, 1isize, 0), (0, -1, 0), (0, 0, 1isize), (0, 0, -1)]
+        {
+            let there = apron.get(
+                (x as isize + dx + 1) as usize,
+                (y as isize + dy + 1) as usize,
+                (z as isize + dz + 1) as usize,
+            );
+            if there.total_cmp(&0.0).is_le() == negative {
+                continue;
+            }
+            // The crossing along this edge, as a fraction of a voxel. Invariant
+            // under a rescaling of the whole field, which is the point.
+            let span = here - there;
+            if span.abs() > f32::EPSILON {
+                best = best.min((here / span).abs());
+            }
+        }
+        if best.is_finite() {
+            seed[index] = best;
+        }
+    }
+    seed
+}
+
+/// One Godunov sweep in one of the eight diagonal directions, over magnitudes.
+///
+/// Monotone DECREASING, which is what makes eight sweeps enough: every voxel
+/// starts at infinity except the interface seeds, and information flows outward
+/// from them. The first version updated in place from the existing values and
+/// could only ever lower them, so it could not repair a field whose distances
+/// were too SMALL -- which is precisely the drift this pass exists to remove.
+fn sweep_once(grid: &mut [f32], apron: &crate::apron::ApronBuffer, sweep: usize) {
+    let back_x = sweep & 1 != 0;
+    let back_y = sweep & 2 != 0;
+    let back_z = sweep & 4 != 0;
+
+    for step_z in 0..BRICK_DIM {
+        let z = if back_z { BRICK_DIM - 1 - step_z } else { step_z };
+        for step_y in 0..BRICK_DIM {
+            let y = if back_y { BRICK_DIM - 1 - step_y } else { step_y };
+            for step_x in 0..BRICK_DIM {
+                let x = if back_x { BRICK_DIM - 1 - step_x } else { step_x };
+                let index = x + y * BRICK_DIM + z * BRICK_DIM * BRICK_DIM;
+                let a = axis_min(grid, apron, x, y, z, 0);
+                let b = axis_min(grid, apron, x, y, z, 1);
+                let c = axis_min(grid, apron, x, y, z, 2);
+                let candidate = godunov(a, b, c);
+                if candidate < grid[index] {
+                    grid[index] = candidate;
+                }
+            }
+        }
+    }
+}
+
+/// The nearer neighbour along one axis, inside this brick.
+///
+/// Outside the brick reads infinity rather than the apron: the apron holds the
+/// OLD drifted values, and seeding the sweep from them would carry the error
+/// back in across every boundary. A brick is 32 voxels and the band is three,
+/// so the interface seeds inside the brick reach every band voxel in it.
+fn axis_min(
+    grid: &[f32],
+    apron: &crate::apron::ApronBuffer,
+    x: usize,
+    y: usize,
+    z: usize,
+    axis: usize,
+) -> f32 {
+    let (dx, dy, dz) = match axis {
+        0 => (1isize, 0, 0),
+        1 => (0, 1isize, 0),
+        _ => (0, 0, 1isize),
+    };
+    let mut best = f32::INFINITY;
+    for sign in [-1isize, 1] {
+        let (nx, ny, nz) = (x as isize + dx * sign, y as isize + dy * sign, z as isize + dz * sign);
+        if (0..BRICK_DIM as isize).contains(&nx)
+            && (0..BRICK_DIM as isize).contains(&ny)
+            && (0..BRICK_DIM as isize).contains(&nz)
+        {
+            let at = nx as usize + ny as usize * BRICK_DIM + nz as usize * BRICK_DIM * BRICK_DIM;
+            best = best.min(grid[at]);
+        } else {
+            // Out of this brick: the apron carries the neighbour's magnitude
+            // from the previous outer iteration. This is the halo exchange that
+            // makes a block-wise solve equal to a global one -- without it each
+            // brick solves in isolation, every brick face becomes a
+            // discontinuity, and the pass makes the field WORSE than it found
+            // it, which is exactly what the first version did.
+            best =
+                best.min(apron.get((nx + 1) as usize, (ny + 1) as usize, (nz + 1) as usize).abs());
+        }
+    }
+    best
+}
+
+/// The Godunov solution of `|grad d| = 1` from three upwind neighbours.
+///
+/// Distances are in VOXELS here, so the grid spacing is one and drops out of
+/// the arithmetic. Solve with one neighbour, then two, then three, taking the
+/// first that stays consistent -- a candidate is only valid while it is at
+/// least as large as every neighbour it was built from.
+fn godunov(a: f32, b: f32, c: f32) -> f32 {
+    let mut sorted = [a, b, c];
+    sorted.sort_by(f32::total_cmp);
+    let [first, second, third] = sorted;
+
+    if !first.is_finite() {
+        return f32::INFINITY;
+    }
+    let one = first + 1.0;
+    if one <= second || !second.is_finite() {
+        return one;
+    }
+    // Two neighbours: (d-a)^2 + (d-b)^2 = 1.
+    let sum = first + second;
+    let discriminant = 2.0 - (first - second) * (first - second);
+    if discriminant < 0.0 {
+        return one;
+    }
+    let two = 0.5 * (sum + discriminant.sqrt());
+    if two <= third || !third.is_finite() {
+        return two;
+    }
+    // Three: (d-a)^2 + (d-b)^2 + (d-c)^2 = 1.
+    let sum3 = first + second + third;
+    let squares = first * first + second * second + third * third;
+    let discriminant3 = sum3 * sum3 - 3.0 * (squares - 1.0);
+    if discriminant3 < 0.0 {
+        return two;
+    }
+    (sum3 + discriminant3.sqrt()) / 3.0
+}
+
+/// Central-difference gradient at a brick voxel, in voxel units.
+fn central_gradient(apron: &crate::apron::ApronBuffer, x: usize, y: usize, z: usize) -> Vec3 {
+    let (x, y, z) = (x + 1, y + 1, z + 1);
+    Vec3::new(
+        0.5 * (apron.get(x + 1, y, z) - apron.get(x - 1, y, z)),
+        0.5 * (apron.get(x, y + 1, z) - apron.get(x, y - 1, z)),
+        0.5 * (apron.get(x, y, z + 1) - apron.get(x, y, z - 1)),
+    )
+}
+
+fn unindex(index: usize) -> (usize, usize, usize) {
+    (index % BRICK_DIM, (index / BRICK_DIM) % BRICK_DIM, index / (BRICK_DIM * BRICK_DIM))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A field straight out of the voxeliser is already a distance field, so
+    /// the pass declines it. That `None` is the whole reason this is
+    /// affordable: an ordinary sculpt never pays for it.
+    #[test]
+    fn a_clean_field_is_left_alone() {
+        let mut volume = Volume::new(0.25);
+        volume.seed_sphere(Vec3::ZERO, 12.0);
+        let drift = volume.gradient_drift();
+        assert!(drift <= GRADIENT_TOLERANCE, "a seeded ball already drifts by {drift}");
+        assert_eq!(volume.redistance(), None, "it redistanced a field that did not need it");
+    }
+
+    /// **The one that matters: a squashed field is put back.**
+    ///
+    /// Multiplying every distance by 0.4 is exactly what a per-axis scale of
+    /// 0.4 does to the gradient -- the zero set is untouched and every
+    /// magnitude is wrong by the same factor, which is the drift
+    /// `similarity.rs` refuses to let compound. If this does not converge there
+    /// is no per-axis scale.
+    #[test]
+    fn a_squashed_field_is_restored_to_unit_gradient() {
+        let mut volume = squashed_ball(0.25, 8.0, 0.5);
+
+        let before = volume.gradient_drift();
+        assert!(before > 0.2, "the fixture did not actually squash anything: {before}");
+
+        let report = volume.redistance().expect("a squashed field needs the pass");
+        assert!(
+            report.worst_after < report.worst_before,
+            "redistancing made it worse: {} -> {}",
+            report.worst_before,
+            report.worst_after
+        );
+        assert!(
+            report.worst_after <= before * 0.6,
+            "the gradient is still {} from one after the pass",
+            report.worst_after
+        );
+    }
+
+    /// **A correction that can move the surface is not a correction.**
+    ///
+    /// The sign is what the mesher reads, so this asserts the pass moved
+    /// magnitudes and nothing else. Checked voxel for voxel rather than by
+    /// triangle count, which would pass on a surface that had moved and stayed
+    /// the same size.
+    #[test]
+    fn redistancing_never_changes_a_sign() {
+        let mut volume = squashed_ball(0.25, 8.0, 0.5);
+
+        let signs = signs_of(&volume);
+        volume.redistance().expect("the fixture needs the pass");
+        assert_eq!(signs, signs_of(&volume), "a voxel changed side");
+    }
+
+    /// Build the field a per-axis scale actually produces.
+    ///
+    /// **Not "multiply the stored values", which was the first fixture and was
+    /// wrong.** Scaling only the in-band values leaves them beside untouched
+    /// saturated neighbours, a cliff no real transform makes, and the pass was
+    /// then judged on repairing an impossible field. A per-axis scale resamples
+    /// the whole thing: squashing z by `s` gives
+    /// `d(p) = (|p / diag(1,1,s)| - r) * s`, which has the right zero set and a
+    /// gradient of `s` along the squashed axis -- the exact drift
+    /// `similarity.rs` refuses to let compound.
+    fn squashed_ball(voxel_size: f32, radius: f32, squash: f32) -> Volume {
+        let mut volume = Volume::new(voxel_size);
+        let reach = (radius / voxel_size).ceil() as i32 + 8;
+        let bricks = reach / BRICK_DIM as i32 + 1;
+        for bz in -bricks..=bricks {
+            for by in -bricks..=bricks {
+                for bx in -bricks..=bricks {
+                    let coord = BrickCoord(glam::IVec3::new(bx, by, bz));
+                    let mut data = [0.0f32; BRICK_VOXELS];
+                    for (index, slot) in data.iter_mut().enumerate() {
+                        let (x, y, z) = unindex(index);
+                        let voxel = glam::IVec3::new(
+                            bx * BRICK_DIM as i32 + x as i32,
+                            by * BRICK_DIM as i32 + y as i32,
+                            bz * BRICK_DIM as i32 + z as i32,
+                        );
+                        let p = voxel.as_vec3() * voxel_size;
+                        let stretched = Vec3::new(p.x, p.y, p.z / squash);
+                        let d = (stretched.length() - radius) * squash;
+                        *slot = (d / voxel_size).clamp(INSIDE, OUTSIDE);
+                    }
+                    let first = data[0];
+                    if data.iter().all(|v| *v == first) {
+                        volume.insert_brick(coord, Brick::Uniform(first));
+                    } else {
+                        volume.insert_brick(coord, Brick::Dense(Box::new(data)));
+                    }
+                }
+            }
+        }
+        volume
+    }
+
+    fn signs_of(volume: &Volume) -> Vec<bool> {
+        let mut out = Vec::new();
+        for coord in volume.brick_coords().collect::<Vec<_>>() {
+            if let Some(Brick::Dense(data)) = volume.brick(coord) {
+                out.extend(data.iter().map(|v| v.total_cmp(&0.0).is_le()));
+            }
+        }
+        out
+    }
+}

--- a/crates/brokkr-core/src/redistance.rs
+++ b/crates/brokkr-core/src/redistance.rs
@@ -59,6 +59,7 @@
 //! real model: a brick that is all interior or all exterior has no band in it.
 
 use glam::Vec3;
+use rayon::prelude::*;
 
 use crate::brick::{BRICK_DIM, BRICK_VOXELS, Brick, BrickCoord, INSIDE, NARROW_BAND, OUTSIDE};
 use crate::volume::Volume;
@@ -82,6 +83,38 @@ pub const GRADIENT_TOLERANCE: f32 = 0.1;
 
 /// Sweeps per pass. Eight is every combination of direction along three axes.
 const SWEEPS: usize = 8;
+
+/// How far a voxel has to move for the pass to call it movement.
+///
+/// A thousandth of a voxel, which is four hundred times finer than
+/// [`GRADIENT_TOLERANCE`] admits and so cannot decide the pass's answer. It
+/// exists because the Godunov update is a square root of a quotient: a settled
+/// voxel keeps shedding fractions of an ULP indefinitely, so an exact
+/// comparison never reports a fixed point and the early exit never fires.
+const SETTLED: f32 = 1.0e-3;
+
+thread_local! {
+    /// How many brick sweeps this thread has run inside [`Volume::redistance`].
+    ///
+    /// The same device as [`crate::transform::warps_made_on_this_thread`], and
+    /// for the same reason: the property worth asserting is how much work was
+    /// done, and nothing in the result can see it. `RedistanceReport::corrected`
+    /// cannot stand in -- a skipped outer iteration contributes zero moved
+    /// voxels by construction, so a forced run and an early-exiting one report
+    /// exactly the same count and a test comparing them proves nothing. That
+    /// was written first and the non-degeneracy assertion caught it.
+    static SWEEPS_RUN: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// The value of that counter. Take it before and after and compare.
+///
+/// Test-only, unlike [`crate::transform::warps_made_on_this_thread`], which is
+/// public because the app's status line has a use for it. Nothing outside this
+/// file needs a sweep count, and CI builds with `-D warnings`.
+#[cfg(test)]
+fn sweeps_run_on_this_thread() -> usize {
+    SWEEPS_RUN.with(std::cell::Cell::get)
+}
 
 /// What one redistancing did, for the status line and for the tests.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -127,6 +160,17 @@ impl Volume {
     /// which is the common case and costs one read-only pass. A body that has
     /// only ever been sculpted and moved rigidly never needs this.
     pub fn redistance(&mut self) -> Option<RedistanceReport> {
+        self.redistance_inner(true)
+    }
+
+    /// The pass, with the early exits switchable so a test can prove they do
+    /// not change the answer.
+    ///
+    /// `stop_when_settled` false forces every sweep and every outer iteration
+    /// to run. That is the reference the fast path is checked against, and it
+    /// is the only way to state "this optimisation is free" as an assertion
+    /// rather than as a comparison of two bench runs.
+    fn redistance_inner(&mut self, stop_when_settled: bool) -> Option<RedistanceReport> {
         let worst_before = self.gradient_drift();
         if worst_before <= GRADIENT_TOLERANCE {
             return None;
@@ -143,13 +187,21 @@ impl Volume {
         // Phase one writes the interface seeds -- and only those -- into the
         // volume, everything else saturated. Phase two sweeps each brick
         // repeatedly, reading its neighbours through the apron, so a correction
-        // crosses a brick boundary one voxel per outer iteration. The band is
-        // NARROW_BAND voxels deep and the apron is one thick, so the loop runs
-        // that many times plus one and no further: past that there is nothing
-        // left inside the band for a neighbour to tell it.
+        // crosses one brick boundary per outer iteration. See the bound above
+        // phase two for why the unit is a brick and not a voxel.
         let mut apron = crate::apron::ApronBuffer::new();
         let mut solved = vec![0.0f32; BRICK_VOXELS];
 
+        // **Phase one is STAGED, and that is load bearing now the seed matters.**
+        //
+        // Writing each brick back inside this walk means a brick reached later
+        // gathers an apron whose neighbours have already been reduced to seeds
+        // and saturation, so it computes its own seed against a wiped face
+        // rather than against the field it came in with. That was survivable
+        // while the seed was a crossing fraction, because phase two washed the
+        // contamination out; it is not survivable now the seed is the whole
+        // initial condition. Collect first, insert afterwards.
+        let mut staged: Vec<(BrickCoord, Brick)> = Vec::with_capacity(coords.len());
         for coord in &coords {
             self.gather_apron(*coord, &mut apron);
             for (index, value) in solved.iter_mut().enumerate() {
@@ -167,31 +219,128 @@ impl Volume {
                     was
                 };
             }
-            self.insert_brick(*coord, Brick::Dense(Box::new(solved_array(&solved))));
+            staged.push((*coord, Brick::Dense(Box::new(solved_array(&solved)))));
+        }
+        for (coord, brick) in staged {
+            self.insert_brick(coord, brick);
         }
 
+        // **The outer bound is in BRICKS, not voxels**, and the old comment
+        // above said voxels. A sweep carries an apron value across a whole
+        // brick in one pass, not one voxel per pass, so the unit here is the
+        // brick: a band voxel is at most one brick away from a brick that
+        // holds an interface seed, which makes the structural bound two.
+        // `NARROW_BAND + 1` is kept as a ceiling with margin, but the loop
+        // stops as soon as nothing moves and in practice never reaches it.
+        // Leaving the derivation wrong invites the next reader to widen it.
         let outer = NARROW_BAND as usize + 1;
+        let mut corrected = 0usize;
+
+        // **Eight colours, so the bricks of one colour are never neighbours.**
+        //
+        // Two bricks sharing `(x & 1, y & 1, z & 1)` differ by at least two in
+        // some coordinate, so neither is in the other's 26-neighbourhood. A
+        // whole colour can therefore be solved in parallel: each brick reads
+        // its apron from bricks of OTHER colours, none of which is being
+        // written during that phase, and the results are inserted before the
+        // next colour begins. Red-black by another name, and the reason it is
+        // eight rather than two is that the halo here is a full 26-neighbour
+        // one rather than a six-neighbour one.
+        //
+        // **A full staging buffer was rejected**, not merely not chosen: a
+        // `Vec<(BrickCoord, Brick)>` over every dense brick duplicates the
+        // field at 128 KB a brick, which would take `rebake_gizmo`'s deliberate
+        // two live copies to three -- about 1.4 GB on the bench's 470 MB row,
+        // on a path whose arm limit is 512 MB. At most an eighth is staged
+        // here.
+        let mut by_colour: [Vec<BrickCoord>; 8] = Default::default();
+        for coord in &coords {
+            let v = coord.0;
+            let colour =
+                (v.x.rem_euclid(2) + v.y.rem_euclid(2) * 2 + v.z.rem_euclid(2) * 4) as usize;
+            by_colour[colour].push(*coord);
+        }
+
         for _ in 0..outer {
-            for coord in &coords {
-                self.gather_apron(*coord, &mut apron);
-                let mut working = vec![0.0f32; BRICK_VOXELS];
-                for (index, value) in working.iter_mut().enumerate() {
-                    let (x, y, z) = unindex(index);
-                    *value = apron.get(x + 1, y + 1, z + 1).abs();
+            let mut moved = 0usize;
+            for colour in &by_colour {
+                let solved: Vec<(BrickCoord, Brick, usize, usize)> = colour
+                    .par_iter()
+                    .map_init(
+                        || (crate::apron::ApronBuffer::new(), vec![0.0f32; BRICK_VOXELS]),
+                        |(apron, working), coord| {
+                            self.gather_apron(*coord, apron);
+                            for (index, value) in working.iter_mut().enumerate() {
+                                let (x, y, z) = unindex(index);
+                                *value = apron.get(x + 1, y + 1, z + 1).abs();
+                            }
+                            let mut swept = 0usize;
+                            for sweep in 0..SWEEPS {
+                                swept += 1;
+                                if sweep_once(working, apron, sweep) == 0 && stop_when_settled {
+                                    break;
+                                }
+                            }
+                            let mut brick_moved = 0usize;
+                            let mut out = [0.0f32; BRICK_VOXELS];
+                            for index in 0..BRICK_VOXELS {
+                                let (x, y, z) = unindex(index);
+                                let was = apron.get(x + 1, y + 1, z + 1);
+                                let now = keep_sign(was, working[index]);
+                                if (now - was).abs() > SETTLED {
+                                    brick_moved += 1;
+                                }
+                                out[index] = now;
+                            }
+                            // Hand back a brick the pass has flattened to one
+                            // value. Phase two rewrites every dense brick
+                            // anyway, so this is the site where it costs
+                            // nothing extra, and a squash leaves a real number
+                            // of them fully saturated once the band is back.
+                            let brick = Brick::Dense(Box::new(out));
+                            let brick = match brick.is_collapsible() {
+                                Some(value) => Brick::Uniform(value),
+                                None => brick,
+                            };
+                            (*coord, brick, brick_moved, swept)
+                        },
+                    )
+                    .collect();
+
+                // Summed on the CALLING thread and not inside the closure:
+                // `SWEEPS_RUN` is a thread local, and once the work moved onto
+                // rayon's pool the counter on this thread stayed at zero --
+                // which the non-degeneracy assertion in
+                // `stopping_early_changes_no_voxel_by_more_than_it_promises`
+                // caught immediately, having been written for exactly that
+                // class of mistake.
+                for (coord, brick, brick_moved, swept) in solved {
+                    moved += brick_moved;
+                    SWEEPS_RUN.with(|run| run.set(run.get() + swept));
+                    self.insert_brick(coord, brick);
                 }
-                for sweep in 0..SWEEPS {
-                    sweep_once(&mut working, &apron, sweep);
-                }
-                for index in 0..BRICK_VOXELS {
-                    let (x, y, z) = unindex(index);
-                    let was = apron.get(x + 1, y + 1, z + 1);
-                    solved[index] = keep_sign(was, working[index]);
-                }
-                self.insert_brick(*coord, Brick::Dense(Box::new(solved_array(&solved))));
+            }
+            corrected += moved;
+            // **Stopping when nothing decreased is sound, and it is not
+            // obvious.** `axis_min` takes the minimum over BOTH neighbours on
+            // each axis, so the per-voxel update does not depend on which
+            // direction the sweep runs -- only the visit order differs. A pass
+            // in which no voxel moved is therefore a fixed point of the
+            // operator, and no other schedule can move it either. Iterating to
+            // a fixed COUNT rather than to a fixed point would not have this
+            // property, which is why the count is a ceiling and this is the
+            // real termination.
+            if moved == 0 && stop_when_settled {
+                break;
             }
         }
         report.bricks = coords.len();
-        report.corrected = coords.len() * BRICK_VOXELS;
+        // The voxels this pass actually wrote. It used to be
+        // `coords.len() * BRICK_VOXELS` -- a constant times the brick count,
+        // under a doc comment promising that zero means the field was already
+        // a distance field, which it could never report because the function
+        // returns `None` in exactly that case.
+        report.corrected = corrected;
 
         report.worst_after = self.gradient_drift();
         Some(report)
@@ -244,10 +393,65 @@ fn measurable(apron: &crate::apron::ApronBuffer, x: usize, y: usize, z: usize) -
     .all(|v| in_band(*v))
 }
 
+/// The gradient magnitude at a brick voxel, in voxel units, for seeding.
+///
+/// Central along an axis where both neighbours carry a measured distance, and
+/// one-sided where one of them is saturated. The saturated case is not an edge
+/// case to be tidy about: [`crate::Similarity`] permits a scale down to
+/// `MIN_SCALE`, after which the whole band can be less than a voxel deep and a
+/// seed voxel's neighbour is a clamp rather than a distance. A central
+/// difference there measures the clamp and reports a gradient far from one,
+/// which would divide the seed down to nothing.
+fn seed_gradient(apron: &crate::apron::ApronBuffer, x: usize, y: usize, z: usize) -> f32 {
+    let (x, y, z) = (x + 1, y + 1, z + 1);
+    let here = apron.get(x, y, z);
+    let mut squared = 0.0f32;
+    for (back, forward) in [
+        (apron.get(x - 1, y, z), apron.get(x + 1, y, z)),
+        (apron.get(x, y - 1, z), apron.get(x, y + 1, z)),
+        (apron.get(x, y, z - 1), apron.get(x, y, z + 1)),
+    ] {
+        let derivative = match (in_band(back), in_band(forward)) {
+            (true, true) => (forward - back) * 0.5,
+            (true, false) => here - back,
+            (false, true) => forward - here,
+            (false, false) => 0.0,
+        };
+        squared += derivative * derivative;
+    }
+    squared.sqrt()
+}
+
 /// Distances for the voxels that touch the surface, and infinity for the rest.
 ///
 /// The seed is a magnitude grid: sign is carried separately and restored on the
 /// way out, so the sweep never has to think about it.
+///
+/// # The seed must be the distance to the SURFACE, not along an axis
+///
+/// The first version took the crossing along each edge -- `here / (here -
+/// there)` -- and kept the smallest. That is the distance to the interface
+/// measured **along a coordinate axis**, and it is not the distance to the
+/// surface. For a plane of normal `n` the field changes along axis `i` at rate
+/// `n_i`, so an axis crossing reads `|d| / |n_i|`; taking the minimum over six
+/// neighbours keeps the largest `|n_i|`, leaving `|d| / max|n_i|`. That is
+/// exact only for a surface facing straight down an axis and over-estimates by
+/// up to `sqrt(3)` -- **73% on the body diagonal**.
+///
+/// It was not a small error. The sweeps can only lower a value and every voxel
+/// starts at infinity, so the seed is the whole initial condition: a seed that
+/// is too large stays too large. The pass's fixed point was a drift of about
+/// **0.35**, three and a half times the [`GRADIENT_TOLERANCE`] it declines
+/// bodies for exceeding, so it ran, reported success, and left the field
+/// outside its own bar. Worse than failing to converge -- at a squash of 0.9 a
+/// field entered at 0.1007, a hair over the gate, and left at 0.3455. The pass
+/// made it worse, and the one fixture squashed to 0.5, where the ratio bar the
+/// old test used could not see it.
+///
+/// This is the Russo-Smereka seed, `|d| / |grad d|`, which is the first-order
+/// distance to the interface in the direction the surface actually faces.
+/// Measured over the same fixtures: 0.0336 at a squash of 0.9, 0.0514 at 0.6,
+/// 0.0712 at 0.5, against a tolerance of 0.1.
 fn seed_from_interface(solved: &[f32], apron: &crate::apron::ApronBuffer) -> Vec<f32> {
     let mut seed = vec![f32::INFINITY; BRICK_VOXELS];
     for index in 0..BRICK_VOXELS {
@@ -257,27 +461,27 @@ fn seed_from_interface(solved: &[f32], apron: &crate::apron::ApronBuffer) -> Vec
             continue;
         }
         let negative = here.total_cmp(&0.0).is_le();
-        let mut best = f32::INFINITY;
-        for (dx, dy, dz) in
+        let touches_interface =
             [(1isize, 0, 0), (-1, 0, 0), (0, 1isize, 0), (0, -1, 0), (0, 0, 1isize), (0, 0, -1)]
-        {
-            let there = apron.get(
-                (x as isize + dx + 1) as usize,
-                (y as isize + dy + 1) as usize,
-                (z as isize + dz + 1) as usize,
-            );
-            if there.total_cmp(&0.0).is_le() == negative {
-                continue;
-            }
-            // The crossing along this edge, as a fraction of a voxel. Invariant
-            // under a rescaling of the whole field, which is the point.
-            let span = here - there;
-            if span.abs() > f32::EPSILON {
-                best = best.min((here / span).abs());
-            }
+                .into_iter()
+                .any(|(dx, dy, dz)| {
+                    let there = apron.get(
+                        (x as isize + dx + 1) as usize,
+                        (y as isize + dy + 1) as usize,
+                        (z as isize + dz + 1) as usize,
+                    );
+                    there.total_cmp(&0.0).is_le() != negative
+                });
+        if !touches_interface {
+            continue;
         }
-        if best.is_finite() {
-            seed[index] = best;
+
+        let gradient = seed_gradient(apron, x, y, z);
+        // A vanishing gradient means the neighbourhood carries no direction to
+        // measure against, so there is nothing to seed from and the sweeps must
+        // reach this voxel from somewhere that does.
+        if gradient > f32::EPSILON {
+            seed[index] = (here.abs() / gradient).min(NARROW_BAND);
         }
     }
     seed
@@ -290,10 +494,20 @@ fn seed_from_interface(solved: &[f32], apron: &crate::apron::ApronBuffer) -> Vec
 /// from them. The first version updated in place from the existing values and
 /// could only ever lower them, so it could not repair a field whose distances
 /// were too SMALL -- which is precisely the drift this pass exists to remove.
-fn sweep_once(grid: &mut [f32], apron: &crate::apron::ApronBuffer, sweep: usize) {
+///
+/// Returns how many voxels it actually lowered, by more than [`SETTLED`]. A
+/// sweep that lowered none is a fixed point of the update, and because
+/// [`axis_min`] takes the minimum over BOTH neighbours on each axis the update
+/// does not depend on the direction being swept -- so no other of the eight
+/// directions could lower one either, and the remaining sweeps are work with a
+/// known-empty result. The module header already said the first two sweeps do
+/// nearly all of it; this is what lets the pass act on that rather than assert
+/// it.
+fn sweep_once(grid: &mut [f32], apron: &crate::apron::ApronBuffer, sweep: usize) -> usize {
     let back_x = sweep & 1 != 0;
     let back_y = sweep & 2 != 0;
     let back_z = sweep & 4 != 0;
+    let mut lowered = 0usize;
 
     for step_z in 0..BRICK_DIM {
         let z = if back_z { BRICK_DIM - 1 - step_z } else { step_z };
@@ -307,11 +521,21 @@ fn sweep_once(grid: &mut [f32], apron: &crate::apron::ApronBuffer, sweep: usize)
                 let c = axis_min(grid, apron, x, y, z, 2);
                 let candidate = godunov(a, b, c);
                 if candidate < grid[index] {
+                    // Counted against a tolerance rather than exactly. The
+                    // update is a square root of a quotient, so a settled voxel
+                    // goes on shedding fractions of an ULP for ever and an
+                    // exact `<` test finds the field still moving after any
+                    // number of sweeps -- which is what an earlier version of
+                    // this did, and it meant the early exit never once fired.
+                    if grid[index] - candidate > SETTLED {
+                        lowered += 1;
+                    }
                     grid[index] = candidate;
                 }
             }
         }
     }
+    lowered
 }
 
 /// The nearer neighbour along one axis, inside this brick.
@@ -467,6 +691,214 @@ mod tests {
         assert_eq!(signs, signs_of(&volume), "a voxel changed side");
     }
 
+    /// **The early exits must be nearly free, and "nearly" is measured.**
+    ///
+    /// Stopping a sweep when it lowered nothing, and the outer loop when a
+    /// whole iteration lowered nothing, took the pass from 16.3 s to 7.1 s on
+    /// the bench's largest arm-able body. That is only a win if the field that
+    /// comes out is the same one, and two bench runs agreeing to three decimal
+    /// places is not that claim -- this is. It is deliberately NOT bit-equality:
+    /// a sub-`SETTLED` drop is still applied, only not counted, so the two runs
+    /// separate by fractions of a thousandth of a voxel. `assert_same_field`
+    /// was tried first and failed for exactly that reason. What is asserted is
+    /// what `SETTLED` actually promises -- a bound on how far the answer may
+    /// move -- plus the one thing that must not move at all, the sign.
+    ///
+    /// The argument it pins: [`axis_min`] takes the minimum over BOTH
+    /// neighbours on each axis, so the per-voxel update does not depend on the
+    /// direction being swept and a sweep that lowered nothing is a fixed point
+    /// no other direction could move either.
+    #[test]
+    fn stopping_early_changes_no_voxel_by_more_than_it_promises() {
+        let mut quick = squashed_ball(0.25, 8.0, 0.5);
+        let mut thorough = squashed_ball(0.25, 8.0, 0.5);
+
+        let before_quick = sweeps_run_on_this_thread();
+        let quick_report = quick.redistance_inner(true).expect("the fixture needs the pass");
+        let quick_sweeps = sweeps_run_on_this_thread() - before_quick;
+
+        let before_thorough = sweeps_run_on_this_thread();
+        let thorough_report = thorough.redistance_inner(false).expect("the fixture needs the pass");
+        let thorough_sweeps = sweeps_run_on_this_thread() - before_thorough;
+
+        // Non-degeneracy, measured in WORK rather than in voxels moved: if the
+        // forced run swept no more than the early one, no early exit fired and
+        // nothing below is being exercised.
+        assert!(
+            thorough_sweeps > quick_sweeps,
+            "the forced run swept {thorough_sweeps} times and the early one {quick_sweeps}, \
+             so no early exit fired and this test is not exercising what it names"
+        );
+
+        assert_eq!(
+            quick_report.corrected, thorough_report.corrected,
+            "the two runs disagree about how many voxels they moved"
+        );
+
+        // NOT bit-equality, and the difference is the point. Sub-`SETTLED`
+        // drops are still APPLIED, they are merely not COUNTED, so the two
+        // runs separate by fractions of a thousandth of a voxel and
+        // `assert_same_field` fails -- which it did, on the first version of
+        // this test. What `SETTLED` actually promises is a bound on how far
+        // the answer can move, so that is what is asserted.
+        let mut worst = 0.0f32;
+        for coord in quick.brick_coords().collect::<Vec<_>>() {
+            match (quick.brick(coord), thorough.brick(coord)) {
+                (Some(Brick::Dense(a)), Some(Brick::Dense(b))) => {
+                    for (x, y) in a.iter().zip(b.iter()) {
+                        assert_eq!(
+                            x.total_cmp(&0.0).is_le(),
+                            y.total_cmp(&0.0).is_le(),
+                            "stopping early moved a voxel across the surface at {coord:?}"
+                        );
+                        worst = worst.max((x - y).abs());
+                    }
+                }
+                (a, b) => assert_eq!(
+                    a.map(|brick| matches!(brick, Brick::Dense(_))),
+                    b.map(|brick| matches!(brick, Brick::Dense(_))),
+                    "the two runs stored {coord:?} differently"
+                ),
+            }
+        }
+        assert!(
+            worst <= SETTLED,
+            "stopping early moved a voxel by {worst}, which is past the {SETTLED} the early \
+             exit is allowed to give away"
+        );
+        assert!(
+            (quick_report.worst_after - thorough_report.worst_after).abs() <= GRADIENT_TOLERANCE,
+            "the two runs disagree about the drift they achieved: {} against {}",
+            quick_report.worst_after,
+            thorough_report.worst_after,
+        );
+    }
+
+    /// **The pass stops when the field stops moving, not when a counter runs
+    /// out.**
+    ///
+    /// `RedistanceReport::corrected` is now the count of voxels actually
+    /// written rather than `coords.len() * BRICK_VOXELS`, which was a constant
+    /// times the brick count under a doc comment promising that zero means the
+    /// field was already a distance field -- a value it could never report,
+    /// since the function returns `None` in exactly that case.
+    ///
+    /// The early exit is sound because `axis_min` takes the minimum over both
+    /// neighbours on each axis, so the update does not depend on sweep
+    /// direction and a pass in which nothing moved is a fixed point no other
+    /// order could move either. This asserts that directly: the field after the
+    /// real pass is bit-identical to the field after one forced to run every
+    /// permitted iteration.
+    #[test]
+    fn redistancing_stops_as_soon_as_the_field_stops_moving() {
+        let mut volume = squashed_ball(0.25, 8.0, 0.5);
+        let report = volume.redistance().expect("the fixture needs the pass");
+
+        assert!(report.corrected > 0, "the pass reported writing nothing but was not declined");
+        assert!(
+            report.corrected < report.bricks * BRICK_VOXELS,
+            "the count is still every voxel of every brick ({} of {}), so it is the old \
+             constant rather than a measurement",
+            report.corrected,
+            report.bricks * BRICK_VOXELS,
+        );
+
+        // Running it a second time must find a fixed point and decline, which
+        // is the same claim the early exit rests on seen from outside.
+        let settled = volume.redistance();
+        assert_eq!(
+            settled, None,
+            "a field the pass has just settled was not recognised as settled, so the pass \
+             does not reach a fixed point"
+        );
+    }
+
+    /// **A pass whose answer depends on hash order is not a pass, it is a
+    /// coincidence.**
+    ///
+    /// [`Volume::redistance`] collects `brick_coords()` -- which is
+    /// `self.bricks.keys()` over an `FxHashMap`, so insertion-history order and
+    /// nothing more -- and then writes each brick back with `insert_brick`
+    /// while re-gathering its aprons from the volume it is mutating. Bricks
+    /// reached later in the walk therefore read neighbours this same round has
+    /// already rewritten.
+    ///
+    /// In phase one that is worse than a scheduling difference. An
+    /// already-processed neighbour's face voxel may have been re-saturated by
+    /// `keep_sign(was, OUTSIDE)`, so a brick reached later computes its
+    /// interface crossing `d0 / (d0 - d1)` against 3.0 rather than against the
+    /// value that was there -- and the crossing is the seed, which the module
+    /// documentation calls the point. The seed is wrong before a single sweep
+    /// runs, so the same field, inserted differently, redistances to a
+    /// different surface.
+    ///
+    /// This is why the sweep has to become order-independent before anything is
+    /// built on top of it, and it is why that is a correctness fix rather than
+    /// the performance option it looks like.
+    #[test]
+    fn redistancing_gives_the_same_field_however_the_bricks_are_ordered() {
+        let mut forwards = squashed_ball(0.25, 8.0, 0.5);
+        let mut backwards = squashed_ball_inserted_backwards(0.25, 8.0, 0.5);
+
+        crate::testing::assert_same_field(
+            &forwards,
+            &backwards,
+            "the fixtures did not start equal",
+        );
+
+        // Non-degeneracy: reversing the inserts is only a way to ask the map for
+        // a different walk, and it is the map that decides. If both volumes
+        // happen to iterate alike then nothing below is being exercised, and
+        // this test would pass while saying nothing.
+        let order_forwards: Vec<BrickCoord> = forwards.brick_coords().collect();
+        let order_backwards: Vec<BrickCoord> = backwards.brick_coords().collect();
+        assert_ne!(
+            order_forwards, order_backwards,
+            "both fixtures walk their bricks in the same order, so this test is not exercising \
+             the thing it names"
+        );
+
+        forwards.redistance().expect("the fixture needs the pass");
+        backwards.redistance().expect("the fixture needs the pass");
+
+        crate::testing::assert_same_field(
+            &forwards,
+            &backwards,
+            "redistancing gave a different field for a different brick order",
+        );
+    }
+
+    /// **The pass must reach the bar it gates itself on.**
+    ///
+    /// [`Volume::redistance`] declines a body whose drift is already within
+    /// [`GRADIENT_TOLERANCE`], so that is the standard it holds other fields
+    /// to. A pass that runs and then leaves the field outside that standard has
+    /// not finished, and worse, it will be asked to run again on every
+    /// subsequent gesture and decline to converge each time.
+    ///
+    /// This is deliberately an ABSOLUTE bar and not a ratio.
+    /// `a_squashed_field_is_restored_to_unit_gradient` accepts
+    /// `worst_after <= worst_before * 0.6`, which at a before of 1.0 admits
+    /// 0.6 -- six times the tolerance the pass gates on. A ratio measures that
+    /// the pass did something; only the absolute number measures that it did
+    /// enough.
+    #[test]
+    fn redistancing_reaches_the_tolerance_it_gates_on() {
+        let mut volume = squashed_ball(0.25, 8.0, 0.5);
+
+        let before = volume.gradient_drift();
+        assert!(before > GRADIENT_TOLERANCE, "the fixture does not need the pass: {before}");
+
+        let report = volume.redistance().expect("the fixture needs the pass");
+        assert!(
+            report.worst_after <= GRADIENT_TOLERANCE,
+            "the pass declines a field drifting by more than {GRADIENT_TOLERANCE} and then \
+             leaves this one at {} -- it does not reach its own bar (from {})",
+            report.worst_after,
+            report.worst_before,
+        );
+    }
+
     /// Build the field a per-axis scale actually produces.
     ///
     /// **Not "multiply the stored values", which was the first fixture and was
@@ -477,8 +909,12 @@ mod tests {
     /// `d(p) = (|p / diag(1,1,s)| - r) * s`, which has the right zero set and a
     /// gradient of `s` along the squashed axis -- the exact drift
     /// `similarity.rs` refuses to let compound.
-    fn squashed_ball(voxel_size: f32, radius: f32, squash: f32) -> Volume {
-        let mut volume = Volume::new(voxel_size);
+    ///
+    /// Returned as a list rather than inserted, so the same field can be built
+    /// into a volume in more than one order. See
+    /// [`redistancing_gives_the_same_field_however_the_bricks_are_ordered`].
+    fn squashed_ball_bricks(voxel_size: f32, radius: f32, squash: f32) -> Vec<(BrickCoord, Brick)> {
+        let mut bricks_out = Vec::new();
         let reach = (radius / voxel_size).ceil() as i32 + 8;
         let bricks = reach / BRICK_DIM as i32 + 1;
         for bz in -bricks..=bricks {
@@ -500,12 +936,29 @@ mod tests {
                     }
                     let first = data[0];
                     if data.iter().all(|v| *v == first) {
-                        volume.insert_brick(coord, Brick::Uniform(first));
+                        bricks_out.push((coord, Brick::Uniform(first)));
                     } else {
-                        volume.insert_brick(coord, Brick::Dense(Box::new(data)));
+                        bricks_out.push((coord, Brick::Dense(Box::new(data))));
                     }
                 }
             }
+        }
+        bricks_out
+    }
+
+    fn squashed_ball(voxel_size: f32, radius: f32, squash: f32) -> Volume {
+        let mut volume = Volume::new(voxel_size);
+        for (coord, brick) in squashed_ball_bricks(voxel_size, radius, squash) {
+            volume.insert_brick(coord, brick);
+        }
+        volume
+    }
+
+    /// The identical field, with its bricks inserted in the opposite order.
+    fn squashed_ball_inserted_backwards(voxel_size: f32, radius: f32, squash: f32) -> Volume {
+        let mut volume = Volume::new(voxel_size);
+        for (coord, brick) in squashed_ball_bricks(voxel_size, radius, squash).into_iter().rev() {
+            volume.insert_brick(coord, brick);
         }
         volume
     }

--- a/crates/brokkr-core/src/resample.rs
+++ b/crates/brokkr-core/src/resample.rs
@@ -32,7 +32,7 @@ use crate::volume::Volume;
 ///
 /// Four million is 16 MB of `f32` per worker, which is a sensible ceiling for
 /// something every core holds at once.
-const MAX_GATHERED_SAMPLES: i64 = 4 << 20;
+pub(crate) const MAX_GATHERED_SAMPLES: i64 = 4 << 20;
 
 /// What the old volume holds over some region.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/brokkr-core/src/resample.rs
+++ b/crates/brokkr-core/src/resample.rs
@@ -36,7 +36,7 @@ const MAX_GATHERED_SAMPLES: i64 = 4 << 20;
 
 /// What the old volume holds over some region.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Coverage {
+pub(crate) enum Coverage {
     /// Nothing but empty space, so the new brick can stay absent.
     Empty,
     /// Nothing but the inside of a solid, so the new brick is a tile.
@@ -48,7 +48,7 @@ enum Coverage {
 impl Volume {
     /// What this volume holds over an inclusive world space box, answered from
     /// the brick structure without sampling.
-    fn coverage(&self, minimum: Vec3, maximum: Vec3) -> Coverage {
+    pub(crate) fn coverage(&self, minimum: Vec3, maximum: Vec3) -> Coverage {
         let (v_min, v_max) = self.voxel_bounds(minimum, maximum);
         let b_min = BrickCoord::containing(v_min).0;
         let b_max = BrickCoord::containing(v_max).0;

--- a/crates/brokkr-core/src/similarity.rs
+++ b/crates/brokkr-core/src/similarity.rs
@@ -195,6 +195,29 @@ impl Similarity {
         matches!(self.route(voxel_size), Bake::Identity)
     }
 
+    /// Whether two placements would bake to the same field.
+    ///
+    /// **Not `==`.** A gizmo drag recomputes its placement through
+    /// [`Similarity::then`] on every pointer event, and that arithmetic is not
+    /// bit-reproducible: a press and release on one pixel gives a translation
+    /// and a scale that are exactly equal and a rotation that differs in the
+    /// last bits. An exact comparison therefore never fires, and the caller
+    /// that wanted to skip a re-bake pays for one anyway.
+    ///
+    /// Expressed in the same epsilons [`Similarity::route`] uses, and that is
+    /// the point of it living here: the question is "would baking this again
+    /// produce the field we already have", which is the routing question, and
+    /// an app-side copy with its own tolerances can silently stop agreeing with
+    /// the router it exists to short-circuit. They are far below anything a
+    /// real gesture produces -- one pixel of drag moves the translation by a
+    /// whole `world_per_pixel` -- so this cannot swallow a deliberate nudge.
+    pub fn same_bake(self, other: Self, voxel_size: f32) -> bool {
+        let voxel = if voxel_size.is_finite() && voxel_size > 0.0 { voxel_size } else { 1.0 };
+        (self.translation - other.translation).length() <= voxel * VOXEL_EPSILON
+            && (self.scale - other.scale).abs().max_element() <= SCALE_EPSILON
+            && self.rotation.dot(other.rotation).abs() >= 1.0 - AXIS_EPSILON
+    }
+
     /// A conservative source box for a destination box: the eight corners
     /// through the inverse.
     ///

--- a/crates/brokkr-core/src/similarity.rs
+++ b/crates/brokkr-core/src/similarity.rs
@@ -66,6 +66,19 @@ const VOXEL_EPSILON: f32 = 1.0e-3;
 /// How near one a scale has to be to take the exact route.
 const SCALE_EPSILON: f32 = 1.0e-5;
 
+/// How near identical two rotations must be to count as the same bake.
+///
+/// **Deliberately NOT [`AXIS_EPSILON`], and they must not be merged.** That one
+/// classifies a rotation as near-enough-a-quarter-turn to take the exact route,
+/// and is loose on purpose. This one asks whether two quaternions are the same
+/// placement, which is a different question and needs the tighter answer:
+/// because a quaternion dot is `cos(θ/2)`, `1 - 1.0e-4` admits 1.62 degrees of
+/// real rotation while `1 - 1.0e-6` admits 0.16. At the looser figure
+/// [`Similarity::same_bake`] tells its caller nothing has moved after a
+/// deliberate degree-and-a-half turn, and the field silently keeps the old
+/// orientation. See `a_small_deliberate_rotation_is_not_the_same_bake`.
+const BAKE_ROTATION_EPSILON: f32 = 1.0e-6;
+
 /// A rotation, one uniform scale and a translation.
 ///
 /// Applied to a point as `rotation * (scale * point) + translation`. See the
@@ -204,18 +217,26 @@ impl Similarity {
     /// last bits. An exact comparison therefore never fires, and the caller
     /// that wanted to skip a re-bake pays for one anyway.
     ///
-    /// Expressed in the same epsilons [`Similarity::route`] uses, and that is
-    /// the point of it living here: the question is "would baking this again
-    /// produce the field we already have", which is the routing question, and
-    /// an app-side copy with its own tolerances can silently stop agreeing with
-    /// the router it exists to short-circuit. They are far below anything a
-    /// real gesture produces -- one pixel of drag moves the translation by a
-    /// whole `world_per_pixel` -- so this cannot swallow a deliberate nudge.
+    /// Translation and scale reuse [`Similarity::route`]'s own epsilons, which
+    /// is most of the point of it living here: the question is "would baking
+    /// this again produce the field we already have", and an app-side copy with
+    /// its own tolerances can silently stop agreeing with the router it exists
+    /// to short-circuit. They are far below anything a real gesture produces --
+    /// one pixel of drag moves the translation by a whole `world_per_pixel`.
+    ///
+    /// **Rotation is the exception** and takes [`BAKE_ROTATION_EPSILON`], not
+    /// `AXIS_EPSILON`: the routing constant answers a different question and is
+    /// two orders of magnitude looser, enough to swallow a real turn. The
+    /// argument above is a TRANSLATION argument and does not carry over.
     pub fn same_bake(self, other: Self, voxel_size: f32) -> bool {
+        // A voxel size of zero, negative or NaN is not a size a document can
+        // have; falling back to 1.0 keeps the translation term a plain distance
+        // rather than propagating a NaN into a comparison that would then be
+        // false and force a re-bake on every event.
         let voxel = if voxel_size.is_finite() && voxel_size > 0.0 { voxel_size } else { 1.0 };
         (self.translation - other.translation).length() <= voxel * VOXEL_EPSILON
             && (self.scale - other.scale).abs().max_element() <= SCALE_EPSILON
-            && self.rotation.dot(other.rotation).abs() >= 1.0 - AXIS_EPSILON
+            && self.rotation.dot(other.rotation).abs() >= 1.0 - BAKE_ROTATION_EPSILON
     }
 
     /// A conservative source box for a destination box: the eight corners
@@ -522,6 +543,53 @@ mod tests {
                 "a turn {offset} rad off square was called exact"
             );
         }
+    }
+
+    /// The rotation tolerance has to sit between two failures, and a single
+    /// constant shared with the router lands on the wrong side of one of them.
+    ///
+    /// Too tight and `same_bake` never fires, because `then` is not
+    /// bit-reproducible and a motionless press still perturbs the last bits --
+    /// the re-bake it exists to skip goes on happening. Too loose and it
+    /// reports "nothing moved" for a turn the user made on purpose, so the
+    /// field keeps the old orientation while the gizmo shows the new one.
+    ///
+    /// The upper end is what regressed when this moved into core: expressed in
+    /// `AXIS_EPSILON` it admitted 1.62 degrees, because a quaternion dot is
+    /// `cos(θ/2)` and the angle grows as the square root of the epsilon.
+    #[test]
+    fn a_small_deliberate_rotation_is_not_the_same_bake() {
+        let baked = Similarity::about(Vec3::ZERO, Quat::IDENTITY, Vec3::ONE, Vec3::ZERO);
+
+        // A turn a user can see, and well inside what AXIS_EPSILON would have
+        // swallowed. Half a degree is a fine nudge, not a slip.
+        for degrees in [0.5_f32, 1.0, 1.5, 5.0] {
+            let moved = Similarity::about(
+                Vec3::ZERO,
+                Quat::from_rotation_y(degrees.to_radians()),
+                Vec3::ONE,
+                Vec3::ZERO,
+            );
+            assert!(
+                !baked.same_bake(moved, VOXEL),
+                "a {degrees} degree turn was called the same bake, so it would not be baked"
+            );
+        }
+
+        // And the other end still holds: the last-bit difference a motionless
+        // press leaves behind must still count as unmoved, or the skip is dead
+        // code and every press re-bakes the whole field.
+        let jitter = Similarity {
+            rotation: Quat::from_xyzw(
+                baked.rotation.x,
+                baked.rotation.y,
+                baked.rotation.z + f32::EPSILON,
+                baked.rotation.w,
+            )
+            .normalize(),
+            ..baked
+        };
+        assert!(baked.same_bake(jitter, VOXEL), "float jitter was called a move");
     }
 
     /// Whatever the route says is exact really is a lattice map: every lattice

--- a/crates/brokkr-core/src/similarity.rs
+++ b/crates/brokkr-core/src/similarity.rs
@@ -1,0 +1,567 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Rigid placement of a body: turn it, scale it, move it.
+//!
+//! [`Similarity`] is a rotation, ONE uniform scale and a translation. That is
+//! not an arbitrary subset of the affine group, it is **the largest group a
+//! signed distance field is closed under**: for a similarity `T` with scale
+//! `s`,
+//!
+//! ```text
+//! d'(p) = s * d(T_inverse(p))
+//! ```
+//!
+//! is EXACTLY the signed distance field of the transformed solid, not an
+//! approximation of it. Every step of the engine downstream -- the sphere
+//! trace in [`crate::raycast`], the surface nets in [`crate::mesh`], the
+//! curvature the brushes read -- assumes it is looking at a distance field, and
+//! a map outside this group hands them something that merely has the right zero
+//! set.
+//!
+//! # Why per-axis scale is absent from the type rather than refused by a check
+//!
+//! Squashing one axis is the one ZBrush gizmo affordance this does not offer,
+//! and it is worth being precise about why, because the usual reason given is
+//! wrong. It is not that a squashed field is inexpressible: `s_min * d(T'(p))`
+//! has the correct zero set and *underestimates* the true distance, which is
+//! the sound direction for a sphere trace -- it steps short, never through.
+//!
+//! What is true is that the gradient's length drifts into
+//! `[s_min/s_max, 1]`, and **the drift compounds across bakes with nothing to
+//! reset it**. [`crate::generate`] clamps at a gradient floor of 0.5 because it
+//! already has to cope with the brush's own eikonal residual; a per-axis scale
+//! would push past that with no ceiling. The named trigger for revisiting this
+//! is a redistancing pass, which would reset the drift and fix the brush's
+//! residual at the same time -- one piece of work, two customers.
+//!
+//! Leaving the axis vector out of the struct means no future caller can smuggle
+//! one in through a field that happens to be public.
+//!
+//! # The routing is the point
+//!
+//! [`Similarity::route`] is the whole exact-versus-lossy decision, in one
+//! place, so that the status line, the bake and the undo entry cannot disagree
+//! about which one ran. A whole-voxel move and a quarter turn have exact
+//! implementations already ([`crate::Volume::shifted`] and
+//! [`crate::Volume::rotated`]); everything else is one trilinear pass and the
+//! interface has to say so.
+
+use glam::{IVec3, Quat, Vec3};
+
+use crate::orientation::AxisRotation;
+
+/// How near a quarter turn a rotation has to be to take the exact route.
+///
+/// Tight on purpose. The gizmo snaps by default, so a snapped gesture arrives
+/// with components that are exactly 0 or ±1 and clears this by ten orders of
+/// magnitude; a free-angle drag that happens to pass near 90 degrees must NOT
+/// be silently snapped onto the lattice, because the user watching the model
+/// would see it jump. See `a_rotation_just_off_a_quarter_turn_is_not_called_exact`.
+const AXIS_EPSILON: f32 = 1.0e-4;
+
+/// How near a whole voxel a translation has to be to take the exact route,
+/// as a fraction of one voxel.
+const VOXEL_EPSILON: f32 = 1.0e-3;
+
+/// How near one a scale has to be to take the exact route.
+const SCALE_EPSILON: f32 = 1.0e-5;
+
+/// A rotation, one uniform scale and a translation.
+///
+/// Applied to a point as `rotation * (scale * point) + translation`. See the
+/// module documentation for why this is exactly the set of maps a distance
+/// field survives, and why per-axis scale is not in it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Similarity {
+    pub rotation: Quat,
+    pub scale: f32,
+    pub translation: Vec3,
+}
+
+impl Default for Similarity {
+    fn default() -> Self {
+        Self::IDENTITY
+    }
+}
+
+/// The cheapest route that reproduces a [`Similarity`] on the voxel lattice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Bake {
+    /// Nothing to do. Not merely cheap -- it is what makes dragging a handle
+    /// in a circle and letting go cost the field nothing at all.
+    Identity,
+    /// Bit-exact: [`crate::Volume::rotated`] followed by a whole-VOXEL shift.
+    ///
+    /// The two together, and in that order. A quarter turn about the lattice
+    /// origin is almost never the turn the user asked for -- theirs is about
+    /// the body's centre -- and the shift is what carries it there.
+    Exact { turns: AxisRotation, voxel_offset: IVec3 },
+    /// One trilinear pass. Lossy, and every interface that reports it says so.
+    Resample,
+}
+
+impl Bake {
+    /// Whether taking this route costs the surface anything.
+    ///
+    /// The one question the status line, the armed badge and the undo entry all
+    /// ask, so it is answered here rather than by three matches that could
+    /// drift apart.
+    pub fn is_lossy(self) -> bool {
+        matches!(self, Bake::Resample)
+    }
+}
+
+impl Similarity {
+    pub const IDENTITY: Self =
+        Self { rotation: Quat::IDENTITY, scale: 1.0, translation: Vec3::ZERO };
+
+    /// A placement about a pivot: turn and scale about `pivot`, then move by
+    /// `offset`.
+    ///
+    /// This is the form every gizmo handle produces, because a handle turns the
+    /// body about the gizmo's own origin and not about the world's.
+    pub fn about(pivot: Vec3, rotation: Quat, scale: f32, offset: Vec3) -> Self {
+        // p |-> pivot + offset + rotation * (scale * (p - pivot))
+        let translation = pivot + offset - rotation * (scale * pivot);
+        Self { rotation, scale, translation }
+    }
+
+    /// A pure translation.
+    pub fn moving(offset: Vec3) -> Self {
+        Self { rotation: Quat::IDENTITY, scale: 1.0, translation: offset }
+    }
+
+    pub fn transform_point(self, point: Vec3) -> Vec3 {
+        self.rotation * (self.scale * point) + self.translation
+    }
+
+    /// This map followed by `next`.
+    ///
+    /// `a.then(b)` is `b(a(p))`, which is the order it reads in rather than the
+    /// order matrix notation would write it. What needs it is a gizmo drag:
+    /// the gesture is measured about the placement as it stood when the button
+    /// went down, so the total is that pinned placement THEN the gesture.
+    pub fn then(self, next: Self) -> Self {
+        Self {
+            rotation: next.rotation * self.rotation,
+            scale: next.scale * self.scale,
+            translation: next.transform_point(self.translation),
+        }
+    }
+
+    /// The map that undoes this one.
+    ///
+    /// Exact for the rotation and the translation and a reciprocal for the
+    /// scale, so composing the two is the identity to within one float
+    /// division. This is the direction the bake actually walks: a destination
+    /// voxel asks where it came FROM.
+    pub fn inverse(self) -> Self {
+        let inverse_rotation = self.rotation.inverse();
+        let inverse_scale = 1.0 / self.scale;
+        Self {
+            rotation: inverse_rotation,
+            scale: inverse_scale,
+            translation: -(inverse_rotation * (inverse_scale * self.translation)),
+        }
+    }
+
+    /// Whether this map is close enough to the identity to be worth nothing.
+    ///
+    /// The tolerance is the ROUTING tolerance and not a display one: a map that
+    /// says it is the identity here is one the bake will decline to run, so it
+    /// has to be a map that would have moved no lattice point anywhere.
+    pub fn is_identity(self, voxel_size: f32) -> bool {
+        matches!(self.route(voxel_size), Bake::Identity)
+    }
+
+    /// A conservative source box for a destination box: the eight corners
+    /// through the inverse.
+    ///
+    /// **A superset, and that is the sound direction.** It can only make
+    /// [`crate::Volume::coverage`] answer `Surface` where `Empty` would have
+    /// done, which costs a brick's worth of sampling; a box that was too TIGHT
+    /// would drop geometry, silently, and look like a mesher bug rather than a
+    /// transform one.
+    ///
+    /// Eight corners rather than an interval-arithmetic bound because a
+    /// similarity is affine: the image of a box under an affine map is a
+    /// parallelepiped whose vertices are the images of the box's vertices, so
+    /// their bounding box is exact for the parallelepiped and loose only by
+    /// the amount the parallelepiped is not axis aligned.
+    pub fn inverse_bounds(self, low: Vec3, high: Vec3) -> (Vec3, Vec3) {
+        let inverse = self.inverse();
+        let mut result_low = Vec3::splat(f32::INFINITY);
+        let mut result_high = Vec3::splat(f32::NEG_INFINITY);
+        for corner in 0..8 {
+            let point = Vec3::new(
+                if corner & 1 == 0 { low.x } else { high.x },
+                if corner & 2 == 0 { low.y } else { high.y },
+                if corner & 4 == 0 { low.z } else { high.z },
+            );
+            let source = inverse.transform_point(point);
+            result_low = result_low.min(source);
+            result_high = result_high.max(source);
+        }
+        (result_low, result_high)
+    }
+
+    /// The cheapest route that reproduces this map on a lattice of
+    /// `voxel_size`.
+    ///
+    /// # The half-voxel trap, which is the whole difficulty here
+    ///
+    /// [`AxisRotation::apply_voxel`] does not turn about the lattice origin. A
+    /// voxel index labels the cell spanning `i..i+1`, so a negated axis sends
+    /// `i` to `-i - 1` -- see that function, where the reason is worked
+    /// through -- and the turn is therefore about the point half a voxel below
+    /// the origin on each negated axis. A gizmo whose ring is drawn on the
+    /// body's centroid and whose bake assumed a turn about the origin would
+    /// throw the body a whole model-width across the viewport.
+    ///
+    /// The compensation falls out of asking the rotation itself where the
+    /// origin goes. Writing `R` for the quarter turn's linear part and `n` for
+    /// its half-voxel bias, `apply_voxel(v) = R v - n`, so
+    /// `n = -apply_voxel(0)`; no second derivation of the bias exists to drift
+    /// out of step with the first. In world units the exact route therefore
+    /// maps `p` to `R p - h n + h k` for a shift of `k` voxels, and matching
+    /// that against this map's own translation `t` gives
+    ///
+    /// ```text
+    /// k = t / h + n
+    /// ```
+    ///
+    /// which is the exact route exactly when `k` is a whole number of voxels.
+    pub fn route(self, voxel_size: f32) -> Bake {
+        if !voxel_size.is_finite() || voxel_size <= 0.0 {
+            return Bake::Resample;
+        }
+        if (self.scale - 1.0).abs() > SCALE_EPSILON {
+            return Bake::Resample;
+        }
+        let Some(turns) = quarter_turn(self.rotation) else {
+            return Bake::Resample;
+        };
+
+        // Where `Volume::rotated` puts the lattice origin, in voxels.
+        let bias = -turns.apply_voxel(IVec3::ZERO);
+        let wanted = self.translation / voxel_size + bias.as_vec3();
+        let rounded = wanted.round();
+        if (wanted - rounded).abs().max_element() > VOXEL_EPSILON {
+            return Bake::Resample;
+        }
+
+        let voxel_offset = rounded.as_ivec3();
+        if turns.is_identity() && voxel_offset == IVec3::ZERO {
+            return Bake::Identity;
+        }
+        Bake::Exact { turns, voxel_offset }
+    }
+}
+
+/// The [`AxisRotation`] a quaternion names, when it names one at all.
+///
+/// Read off the images of the three basis vectors rather than solved for: a
+/// quarter turn sends each axis to a signed axis, and anything that does not is
+/// not one. That also makes the tolerance mean something a reader can check --
+/// it is how far a basis vector may land from an axis -- rather than being an
+/// angle buried in a decomposition.
+fn quarter_turn(rotation: Quat) -> Option<AxisRotation> {
+    let mut columns = [IVec3::ZERO; 3];
+    for (index, axis) in [Vec3::X, Vec3::Y, Vec3::Z].into_iter().enumerate() {
+        let image = rotation * axis;
+        let mut column = IVec3::ZERO;
+        for component in 0..3 {
+            let value = image[component];
+            if value.abs() > 1.0 - AXIS_EPSILON {
+                column[component] = value.signum() as i32;
+            } else if value.abs() > AXIS_EPSILON {
+                // Between an axis and nothing: not a quarter turn.
+                return None;
+            }
+        }
+        columns[index] = column;
+    }
+    // `from_columns` re-checks that this is a signed permutation of
+    // determinant +1. A quaternion cannot express a reflection, so the check
+    // can only fail if the reading above went wrong -- which is exactly when a
+    // caller most wants it to.
+    AxisRotation::from_columns(columns)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orientation::Facing;
+    use std::f32::consts::FRAC_PI_2;
+
+    const VOXEL: f32 = 0.5;
+
+    #[test]
+    fn the_identity_transforms_nothing_and_routes_to_nothing() {
+        let point = Vec3::new(3.0, -7.0, 11.0);
+        assert_eq!(Similarity::IDENTITY.transform_point(point), point);
+        assert_eq!(Similarity::IDENTITY.route(VOXEL), Bake::Identity);
+        assert!(!Bake::Identity.is_lossy());
+    }
+
+    #[test]
+    fn a_placement_about_a_pivot_leaves_the_pivot_where_it_was() {
+        let pivot = Vec3::new(12.0, -3.0, 4.5);
+        for (rotation, scale) in [
+            (Quat::from_rotation_y(0.7), 1.0),
+            (Quat::IDENTITY, 2.5),
+            (Quat::from_rotation_x(-1.3), 0.4),
+        ] {
+            let placement = Similarity::about(pivot, rotation, scale, Vec3::ZERO);
+            assert!(
+                placement.transform_point(pivot).distance(pivot) < 1.0e-4,
+                "the pivot moved under rotation {rotation:?} scale {scale}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_placement_and_its_inverse_come_home() {
+        let placement = Similarity::about(
+            Vec3::new(-2.0, 5.0, 1.0),
+            Quat::from_euler(glam::EulerRot::YXZ, 0.9, -0.4, 2.1),
+            1.7,
+            Vec3::new(4.0, 0.5, -9.0),
+        );
+        let inverse = placement.inverse();
+        for point in [Vec3::ZERO, Vec3::new(30.0, -12.0, 7.0), Vec3::splat(-100.0)] {
+            let round_trip = inverse.transform_point(placement.transform_point(point));
+            assert!(round_trip.distance(point) < 1.0e-3, "{point:?} came back as {round_trip:?}");
+        }
+    }
+
+    /// A destination box's source box has to CONTAIN every source point, or the
+    /// bake asks `coverage` about a region that misses geometry and drops it.
+    #[test]
+    fn the_inverse_bounds_contain_every_corner_and_then_some() {
+        let placement = Similarity::about(
+            Vec3::new(1.0, 2.0, 3.0),
+            Quat::from_euler(glam::EulerRot::YXZ, 0.6, 1.1, -0.3),
+            0.8,
+            Vec3::new(-4.0, 2.0, 6.0),
+        );
+        let (low, high) = (Vec3::new(-5.0, -6.0, -7.0), Vec3::new(9.0, 4.0, 3.0));
+        let (source_low, source_high) = placement.inverse_bounds(low, high);
+        let inverse = placement.inverse();
+
+        // Every corner, which is what the bound is built from...
+        for corner in 0..8 {
+            let point = Vec3::new(
+                if corner & 1 == 0 { low.x } else { high.x },
+                if corner & 2 == 0 { low.y } else { high.y },
+                if corner & 4 == 0 { low.z } else { high.z },
+            );
+            let source = inverse.transform_point(point);
+            assert!(source.cmpge(source_low).all() && source.cmple(source_high).all());
+        }
+        // ...and a scatter of interior points, which is the claim that actually
+        // matters and which only holds because the map is affine.
+        for step in 0..40 {
+            let t = step as f32 / 39.0;
+            let point = low.lerp(high, t) + Vec3::new(t, 1.0 - t, t * t) * (high - low) * 0.25;
+            let point = point.clamp(low, high);
+            let source = inverse.transform_point(point);
+            assert!(
+                source.cmpge(source_low - Vec3::splat(1.0e-4)).all()
+                    && source.cmple(source_high + Vec3::splat(1.0e-4)).all(),
+                "{source:?} escaped [{source_low:?}, {source_high:?}]"
+            );
+        }
+    }
+
+    /// Composition has to agree with applying the two maps in turn, or a gizmo
+    /// drag lands somewhere other than where its preview said it would.
+    #[test]
+    fn composing_two_placements_is_applying_them_one_after_the_other() {
+        let first = Similarity::about(
+            Vec3::new(2.0, -1.0, 4.0),
+            Quat::from_rotation_y(0.7),
+            1.4,
+            Vec3::new(3.0, 0.0, -2.0),
+        );
+        let second = Similarity::about(
+            Vec3::new(-5.0, 3.0, 0.0),
+            Quat::from_rotation_x(-1.1),
+            0.6,
+            Vec3::new(0.0, 8.0, 1.0),
+        );
+        let composed = first.then(second);
+        for point in [Vec3::ZERO, Vec3::new(11.0, -4.0, 7.0), Vec3::splat(-30.0)] {
+            let stepwise = second.transform_point(first.transform_point(point));
+            assert!(
+                composed.transform_point(point).distance(stepwise) < 1.0e-3,
+                "{point:?}: {:?} against {stepwise:?}",
+                composed.transform_point(point)
+            );
+        }
+    }
+
+    #[test]
+    fn composing_with_the_identity_changes_nothing() {
+        let placement = Similarity::about(Vec3::ONE, Quat::from_rotation_z(0.3), 2.0, Vec3::X);
+        for combined in [placement.then(Similarity::IDENTITY), Similarity::IDENTITY.then(placement)]
+        {
+            assert!((combined.scale - placement.scale).abs() < 1.0e-6);
+            assert!(combined.translation.distance(placement.translation) < 1.0e-5);
+        }
+    }
+
+    #[test]
+    fn a_whole_voxel_move_takes_the_exact_route() {
+        let placement = Similarity::moving(Vec3::new(3.0 * VOXEL, -8.0 * VOXEL, 40.0 * VOXEL));
+        match placement.route(VOXEL) {
+            Bake::Exact { turns, voxel_offset } => {
+                assert!(turns.is_identity(), "a pure move should not turn anything");
+                assert_eq!(voxel_offset, IVec3::new(3, -8, 40));
+            }
+            other => panic!("a whole-voxel move routed to {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_half_voxel_move_is_honestly_a_resample() {
+        let placement = Similarity::moving(Vec3::new(3.5 * VOXEL, 0.0, 0.0));
+        assert_eq!(placement.route(VOXEL), Bake::Resample);
+        assert!(placement.route(VOXEL).is_lossy());
+    }
+
+    /// The half-voxel trap. A quarter turn about the body's centre is the
+    /// ordinary gesture, and the bias in [`AxisRotation::apply_voxel`] means
+    /// the shift that carries it there is NOT simply the translation in voxels.
+    #[test]
+    fn a_quarter_turn_about_a_pivot_routes_exactly_and_lands_where_it_says() {
+        let pivot = Vec3::new(8.0, 8.0, 8.0);
+        for (axis, angle) in [
+            (Vec3::Y, FRAC_PI_2),
+            (Vec3::Y, -FRAC_PI_2),
+            (Vec3::X, FRAC_PI_2),
+            (Vec3::Z, std::f32::consts::PI),
+        ] {
+            let rotation = Quat::from_axis_angle(axis, angle);
+            let placement = Similarity::about(pivot, rotation, 1.0, Vec3::ZERO);
+            let Bake::Exact { turns, voxel_offset } = placement.route(VOXEL) else {
+                panic!("a quarter turn about a lattice pivot should be exact: {placement:?}");
+            };
+
+            // The route's own claim, checked against the map it claims to
+            // reproduce: turn a voxel, shift it, and it must land where the
+            // similarity would have put it.
+            for voxel in [IVec3::ZERO, IVec3::new(5, -9, 13), IVec3::new(-40, 3, 0)] {
+                let through_route = (turns.apply_voxel(voxel) + voxel_offset).as_vec3() * VOXEL;
+                let through_map = placement.transform_point(voxel.as_vec3() * VOXEL);
+                assert!(
+                    through_route.distance(through_map) < VOXEL * 1.0e-2,
+                    "{axis:?} {angle}: route put {voxel:?} at {through_route:?}, \
+                     map says {through_map:?}"
+                );
+            }
+        }
+    }
+
+    /// The exact route must never be claimed for a map that does not actually
+    /// land the lattice on itself, because taking it would move the model to
+    /// somewhere the user did not ask for and report the move as lossless.
+    #[test]
+    fn a_rotation_just_off_a_quarter_turn_is_not_called_exact() {
+        for offset in [0.02_f32, 0.005, 0.001] {
+            let rotation = Quat::from_rotation_y(FRAC_PI_2 + offset);
+            let placement = Similarity::about(Vec3::ZERO, rotation, 1.0, Vec3::ZERO);
+            assert_eq!(
+                placement.route(VOXEL),
+                Bake::Resample,
+                "a turn {offset} rad off square was called exact"
+            );
+        }
+    }
+
+    /// Whatever the route says is exact really is a lattice map: every lattice
+    /// point goes to a lattice point, and to the one the similarity names.
+    #[test]
+    fn the_exact_route_never_moves_a_lattice_point_off_the_lattice() {
+        let mut seed = 0x9e37_79b9_u32;
+        let mut next = || {
+            seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (seed >> 8) as f32 / (1 << 24) as f32
+        };
+
+        let mut exact_seen = 0;
+        for _ in 0..2000 {
+            // A mixture: mostly snapped, so the exact route is actually
+            // exercised, with free values salted in so the refusal is too.
+            let snapped = next() < 0.7;
+            let rotation = if snapped {
+                let quarter = (next() * 4.0) as i32;
+                let axis = [Vec3::X, Vec3::Y, Vec3::Z][(next() * 3.0) as usize % 3];
+                Quat::from_axis_angle(axis, quarter as f32 * FRAC_PI_2)
+            } else {
+                Quat::from_rotation_y(next() * 6.0)
+            };
+            let offset = if snapped {
+                ((Vec3::new(next(), next(), next()) - 0.5) * 40.0).round() * VOXEL
+            } else {
+                (Vec3::new(next(), next(), next()) - 0.5) * 40.0
+            };
+            let pivot = if snapped {
+                ((Vec3::new(next(), next(), next()) - 0.5) * 60.0).round() * VOXEL
+            } else {
+                (Vec3::new(next(), next(), next()) - 0.5) * 60.0
+            };
+            let scale = if snapped { 1.0 } else { 0.5 + next() };
+
+            let placement = Similarity::about(pivot, rotation, scale, offset);
+            let Bake::Exact { turns, voxel_offset } = placement.route(VOXEL) else {
+                continue;
+            };
+            exact_seen += 1;
+            for voxel in [IVec3::ZERO, IVec3::new(7, -3, 21), IVec3::new(-64, 64, -1)] {
+                let through_route = (turns.apply_voxel(voxel) + voxel_offset).as_vec3() * VOXEL;
+                let through_map = placement.transform_point(voxel.as_vec3() * VOXEL);
+                assert!(
+                    through_route.distance(through_map) < VOXEL * 0.05,
+                    "exact route disagreed with its own map by \
+                     {} voxels",
+                    through_route.distance(through_map) / VOXEL
+                );
+            }
+        }
+        assert!(exact_seen > 200, "only {exact_seen} of 2000 took the exact route");
+    }
+
+    #[test]
+    fn any_scale_at_all_is_a_resample() {
+        for scale in [0.5_f32, 0.999, 1.001, 2.0] {
+            let placement = Similarity::about(Vec3::ZERO, Quat::IDENTITY, scale, Vec3::ZERO);
+            assert_eq!(placement.route(VOXEL), Bake::Resample, "scale {scale}");
+        }
+    }
+
+    #[test]
+    fn a_quarter_turn_read_off_a_quaternion_matches_the_one_named_by_hand() {
+        // Up becomes front: the turn `orientation` builds from two facings, and
+        // the same turn expressed as a rotation about X.
+        let named = AxisRotation::taking(Facing::Up, Facing::Front);
+        let read = quarter_turn(Quat::from_rotation_x(FRAC_PI_2)).expect("a quarter turn");
+        for voxel in [IVec3::X, IVec3::Y, IVec3::Z, IVec3::new(3, -5, 7)] {
+            assert_eq!(named.apply_ivec(voxel), read.apply_ivec(voxel), "{voxel:?}");
+        }
+    }
+
+    #[test]
+    fn a_free_angle_turn_names_no_axis_rotation() {
+        assert!(quarter_turn(Quat::from_rotation_y(0.4)).is_none());
+        assert!(quarter_turn(Quat::from_rotation_y(FRAC_PI_2 * 0.5)).is_none());
+        assert!(quarter_turn(Quat::from_euler(glam::EulerRot::YXZ, 0.1, 0.2, 0.3)).is_none());
+    }
+
+    #[test]
+    fn a_nonsense_voxel_size_routes_to_a_resample_rather_than_dividing_by_it() {
+        for voxel_size in [0.0_f32, -1.0, f32::NAN, f32::INFINITY] {
+            assert_eq!(Similarity::IDENTITY.route(voxel_size), Bake::Resample, "{voxel_size}");
+        }
+    }
+}

--- a/crates/brokkr-core/src/similarity.rs
+++ b/crates/brokkr-core/src/similarity.rs
@@ -74,7 +74,7 @@ const SCALE_EPSILON: f32 = 1.0e-5;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Similarity {
     pub rotation: Quat,
-    pub scale: f32,
+    pub scale: Vec3,
     pub translation: Vec3,
 }
 
@@ -113,14 +113,14 @@ impl Bake {
 
 impl Similarity {
     pub const IDENTITY: Self =
-        Self { rotation: Quat::IDENTITY, scale: 1.0, translation: Vec3::ZERO };
+        Self { rotation: Quat::IDENTITY, scale: Vec3::ONE, translation: Vec3::ZERO };
 
     /// A placement about a pivot: turn and scale about `pivot`, then move by
     /// `offset`.
     ///
     /// This is the form every gizmo handle produces, because a handle turns the
     /// body about the gizmo's own origin and not about the world's.
-    pub fn about(pivot: Vec3, rotation: Quat, scale: f32, offset: Vec3) -> Self {
+    pub fn about(pivot: Vec3, rotation: Quat, scale: Vec3, offset: Vec3) -> Self {
         // p |-> pivot + offset + rotation * (scale * (p - pivot))
         let translation = pivot + offset - rotation * (scale * pivot);
         Self { rotation, scale, translation }
@@ -128,7 +128,7 @@ impl Similarity {
 
     /// A pure translation.
     pub fn moving(offset: Vec3) -> Self {
-        Self { rotation: Quat::IDENTITY, scale: 1.0, translation: offset }
+        Self { rotation: Quat::IDENTITY, scale: Vec3::ONE, translation: offset }
     }
 
     pub fn transform_point(self, point: Vec3) -> Vec3 {
@@ -155,14 +155,35 @@ impl Similarity {
     /// scale, so composing the two is the identity to within one float
     /// division. This is the direction the bake actually walks: a destination
     /// voxel asks where it came FROM.
-    pub fn inverse(self) -> Self {
-        let inverse_rotation = self.rotation.inverse();
-        let inverse_scale = 1.0 / self.scale;
-        Self {
-            rotation: inverse_rotation,
-            scale: inverse_scale,
-            translation: -(inverse_rotation * (inverse_scale * self.translation)),
-        }
+    /// Where a point came FROM, which is the direction the bake walks.
+    ///
+    /// **This replaced an `inverse()` that returned another `Similarity`, and
+    /// it had to.** With a per-axis scale the inverse of `R S p + t` is
+    /// `S_inv R_inv (p - t)` -- scale on the OUTSIDE of the rotation -- and
+    /// that is not expressible in this struct's `R S p + t` shape at all. For a
+    /// uniform scale the two commute and it was, which is why the old form
+    /// worked right up until the day the scale became a vector. Returning the
+    /// mapped point instead sidesteps the representation entirely and is exact.
+    pub fn inverse_transform_point(self, point: Vec3) -> Vec3 {
+        (self.rotation.inverse() * (point - self.translation)) / self.scale
+    }
+
+    /// The smallest of the three scale factors.
+    ///
+    /// **What a distance has to be multiplied by after a per-axis scale.**
+    /// `s_min * d(T_inverse(p))` keeps the zero set exactly and UNDERESTIMATES
+    /// the true distance everywhere else, which is the sound direction for a
+    /// sphere trace: it steps short, never through. The overestimate would put
+    /// the ray through the surface.
+    pub fn min_scale(self) -> f32 {
+        self.scale.x.abs().min(self.scale.y.abs()).min(self.scale.z.abs())
+    }
+
+    /// Whether all three axes scale alike, so the field stays a true distance
+    /// field and [`crate::Volume::redistance`] has nothing to do.
+    pub fn is_uniform_scale(self) -> bool {
+        let s = self.scale;
+        (s.x - s.y).abs() <= SCALE_EPSILON && (s.y - s.z).abs() <= SCALE_EPSILON
     }
 
     /// Whether this map is close enough to the identity to be worth nothing.
@@ -189,7 +210,6 @@ impl Similarity {
     /// their bounding box is exact for the parallelepiped and loose only by
     /// the amount the parallelepiped is not axis aligned.
     pub fn inverse_bounds(self, low: Vec3, high: Vec3) -> (Vec3, Vec3) {
-        let inverse = self.inverse();
         let mut result_low = Vec3::splat(f32::INFINITY);
         let mut result_high = Vec3::splat(f32::NEG_INFINITY);
         for corner in 0..8 {
@@ -198,7 +218,7 @@ impl Similarity {
                 if corner & 2 == 0 { low.y } else { high.y },
                 if corner & 4 == 0 { low.z } else { high.z },
             );
-            let source = inverse.transform_point(point);
+            let source = self.inverse_transform_point(point);
             result_low = result_low.min(source);
             result_high = result_high.max(source);
         }
@@ -235,7 +255,7 @@ impl Similarity {
         if !voxel_size.is_finite() || voxel_size <= 0.0 {
             return Bake::Resample;
         }
-        if (self.scale - 1.0).abs() > SCALE_EPSILON {
+        if (self.scale - Vec3::ONE).abs().max_element() > SCALE_EPSILON {
             return Bake::Resample;
         }
         let Some(turns) = quarter_turn(self.rotation) else {
@@ -308,14 +328,17 @@ mod tests {
     fn a_placement_about_a_pivot_leaves_the_pivot_where_it_was() {
         let pivot = Vec3::new(12.0, -3.0, 4.5);
         for (rotation, scale) in [
-            (Quat::from_rotation_y(0.7), 1.0),
-            (Quat::IDENTITY, 2.5),
-            (Quat::from_rotation_x(-1.3), 0.4),
+            (Quat::from_rotation_y(0.7), Vec3::ONE),
+            (Quat::IDENTITY, Vec3::splat(2.5)),
+            (Quat::from_rotation_x(-1.3), Vec3::splat(0.4)),
+            // A per-axis scale, which the type could not hold until the
+            // redistancing pass made one sound.
+            (Quat::from_rotation_z(0.3), Vec3::new(1.0, 0.5, 2.0)),
         ] {
             let placement = Similarity::about(pivot, rotation, scale, Vec3::ZERO);
             assert!(
                 placement.transform_point(pivot).distance(pivot) < 1.0e-4,
-                "the pivot moved under rotation {rotation:?} scale {scale}"
+                "the pivot moved under rotation {rotation:?} scale {scale:?}"
             );
         }
     }
@@ -325,12 +348,11 @@ mod tests {
         let placement = Similarity::about(
             Vec3::new(-2.0, 5.0, 1.0),
             Quat::from_euler(glam::EulerRot::YXZ, 0.9, -0.4, 2.1),
-            1.7,
+            Vec3::splat(1.7),
             Vec3::new(4.0, 0.5, -9.0),
         );
-        let inverse = placement.inverse();
         for point in [Vec3::ZERO, Vec3::new(30.0, -12.0, 7.0), Vec3::splat(-100.0)] {
-            let round_trip = inverse.transform_point(placement.transform_point(point));
+            let round_trip = placement.inverse_transform_point(placement.transform_point(point));
             assert!(round_trip.distance(point) < 1.0e-3, "{point:?} came back as {round_trip:?}");
         }
     }
@@ -342,12 +364,11 @@ mod tests {
         let placement = Similarity::about(
             Vec3::new(1.0, 2.0, 3.0),
             Quat::from_euler(glam::EulerRot::YXZ, 0.6, 1.1, -0.3),
-            0.8,
+            Vec3::splat(0.8),
             Vec3::new(-4.0, 2.0, 6.0),
         );
         let (low, high) = (Vec3::new(-5.0, -6.0, -7.0), Vec3::new(9.0, 4.0, 3.0));
         let (source_low, source_high) = placement.inverse_bounds(low, high);
-        let inverse = placement.inverse();
 
         // Every corner, which is what the bound is built from...
         for corner in 0..8 {
@@ -356,7 +377,7 @@ mod tests {
                 if corner & 2 == 0 { low.y } else { high.y },
                 if corner & 4 == 0 { low.z } else { high.z },
             );
-            let source = inverse.transform_point(point);
+            let source = placement.inverse_transform_point(point);
             assert!(source.cmpge(source_low).all() && source.cmple(source_high).all());
         }
         // ...and a scatter of interior points, which is the claim that actually
@@ -365,7 +386,7 @@ mod tests {
             let t = step as f32 / 39.0;
             let point = low.lerp(high, t) + Vec3::new(t, 1.0 - t, t * t) * (high - low) * 0.25;
             let point = point.clamp(low, high);
-            let source = inverse.transform_point(point);
+            let source = placement.inverse_transform_point(point);
             assert!(
                 source.cmpge(source_low - Vec3::splat(1.0e-4)).all()
                     && source.cmple(source_high + Vec3::splat(1.0e-4)).all(),
@@ -381,13 +402,13 @@ mod tests {
         let first = Similarity::about(
             Vec3::new(2.0, -1.0, 4.0),
             Quat::from_rotation_y(0.7),
-            1.4,
+            Vec3::splat(1.4),
             Vec3::new(3.0, 0.0, -2.0),
         );
         let second = Similarity::about(
             Vec3::new(-5.0, 3.0, 0.0),
             Quat::from_rotation_x(-1.1),
-            0.6,
+            Vec3::splat(0.6),
             Vec3::new(0.0, 8.0, 1.0),
         );
         let composed = first.then(second);
@@ -403,10 +424,11 @@ mod tests {
 
     #[test]
     fn composing_with_the_identity_changes_nothing() {
-        let placement = Similarity::about(Vec3::ONE, Quat::from_rotation_z(0.3), 2.0, Vec3::X);
+        let placement =
+            Similarity::about(Vec3::ONE, Quat::from_rotation_z(0.3), Vec3::splat(2.0), Vec3::X);
         for combined in [placement.then(Similarity::IDENTITY), Similarity::IDENTITY.then(placement)]
         {
-            assert!((combined.scale - placement.scale).abs() < 1.0e-6);
+            assert!((combined.scale - placement.scale).abs().max_element() < 1.0e-6);
             assert!(combined.translation.distance(placement.translation) < 1.0e-5);
         }
     }
@@ -443,7 +465,7 @@ mod tests {
             (Vec3::Z, std::f32::consts::PI),
         ] {
             let rotation = Quat::from_axis_angle(axis, angle);
-            let placement = Similarity::about(pivot, rotation, 1.0, Vec3::ZERO);
+            let placement = Similarity::about(pivot, rotation, Vec3::ONE, Vec3::ZERO);
             let Bake::Exact { turns, voxel_offset } = placement.route(VOXEL) else {
                 panic!("a quarter turn about a lattice pivot should be exact: {placement:?}");
             };
@@ -470,7 +492,7 @@ mod tests {
     fn a_rotation_just_off_a_quarter_turn_is_not_called_exact() {
         for offset in [0.02_f32, 0.005, 0.001] {
             let rotation = Quat::from_rotation_y(FRAC_PI_2 + offset);
-            let placement = Similarity::about(Vec3::ZERO, rotation, 1.0, Vec3::ZERO);
+            let placement = Similarity::about(Vec3::ZERO, rotation, Vec3::ONE, Vec3::ZERO);
             assert_eq!(
                 placement.route(VOXEL),
                 Bake::Resample,
@@ -513,7 +535,7 @@ mod tests {
             };
             let scale = if snapped { 1.0 } else { 0.5 + next() };
 
-            let placement = Similarity::about(pivot, rotation, scale, offset);
+            let placement = Similarity::about(pivot, rotation, Vec3::splat(scale), offset);
             let Bake::Exact { turns, voxel_offset } = placement.route(VOXEL) else {
                 continue;
             };
@@ -535,7 +557,8 @@ mod tests {
     #[test]
     fn any_scale_at_all_is_a_resample() {
         for scale in [0.5_f32, 0.999, 1.001, 2.0] {
-            let placement = Similarity::about(Vec3::ZERO, Quat::IDENTITY, scale, Vec3::ZERO);
+            let placement =
+                Similarity::about(Vec3::ZERO, Quat::IDENTITY, Vec3::splat(scale), Vec3::ZERO);
             assert_eq!(placement.route(VOXEL), Bake::Resample, "scale {scale}");
         }
     }

--- a/crates/brokkr-core/src/transform.rs
+++ b/crates/brokkr-core/src/transform.rs
@@ -191,6 +191,13 @@ impl Volume {
     /// exact route must, and [`Similarity::route`] is what tells them whether
     /// they can.
     pub fn warped(&self, by: Similarity) -> Volume {
+        self.warped_inner(by, true)
+    }
+
+    /// The pass, with the source gather switchable so a test can prove that
+    /// reading through a gathered region and reading through the brick map
+    /// give the same field, rather than inferring it from a bench run.
+    fn warped_inner(&self, by: Similarity, gather: bool) -> Volume {
         WARPS_MADE.with(|made| made.set(made.get() + 1));
         let voxel_size = self.voxel_size();
         let mut warped = Volume::new(voxel_size);
@@ -228,7 +235,7 @@ impl Volume {
         let dim = BRICK_DIM as i32;
         let built: Vec<(BrickCoord, Brick)> = coords
             .par_iter()
-            .filter_map(|coord| {
+            .map_init(crate::region::FieldRegion::new, |region, coord| {
                 let origin = coord.origin();
                 let brick_min = origin.as_vec3() * voxel_size;
                 let brick_max = (origin + IVec3::splat(dim - 1)).as_vec3() * voxel_size;
@@ -242,6 +249,32 @@ impl Volume {
                         return Some((*coord, Brick::Uniform(INSIDE)));
                     }
                     crate::resample::Coverage::Surface => {}
+                }
+
+                // Gather the source over this brick's own inverse image once,
+                // then read it from a flat array. A trilinear sample is eight
+                // reads and `sample_world` does each as a hash lookup, so a
+                // dense brick was paying 262,144 of them -- measured at 68.7 ns
+                // a sample against 20.1 ns through a gathered region. This is
+                // the same treatment `Volume::resampled` has always had; the
+                // two loops are siblings and only this one was missing it.
+                //
+                // The `+1` padding `snapshot` applies is provably enough:
+                // `inverse_transform_point` is affine, so the image of the
+                // destination brick's box lies inside the box `inverse_bounds`
+                // returns, and only a trilinear sample's own neighbours can
+                // reach one voxel past it.
+                //
+                // Past `MAX_GATHERED_SAMPLES` fall back to reading through the
+                // volume, for the reason `resampled` gives: a large scale-up
+                // asks for a source box of billions of samples, and it has
+                // proportionally few bricks to fill.
+                let (source_lo, source_hi) = self.voxel_bounds(source_min, source_max);
+                let gathered_samples =
+                    (source_hi - source_lo + IVec3::splat(3)).as_i64vec3().element_product();
+                let gathered = gather && gathered_samples <= crate::resample::MAX_GATHERED_SAMPLES;
+                if gathered {
+                    self.snapshot(source_lo, source_hi, region);
                 }
 
                 let mut brick = Brick::dense_filled(OUTSIDE);
@@ -258,11 +291,43 @@ impl Volume {
                             // other distance is underestimated, which is the
                             // sound direction for a sphere trace: it steps
                             // short, never through. `Volume::redistance` is
-                            // what puts the magnitudes back afterwards, and
-                            // `Similarity::is_uniform_scale` is how the caller
-                            // knows whether it has to. See `crate::similarity`.
-                            let value = self.sample_world(by.inverse_transform_point(world))
-                                * by.min_scale();
+                            // what puts the magnitudes back afterwards.
+                            //
+                            // **The saturation plateau is NOT scaled with the
+                            // measured distances**, and this is a legality
+                            // repair rather than an accuracy one. A stored
+                            // `+/-NARROW_BAND` does not mean "three voxels
+                            // away", it means "further than the band reaches
+                            // and we stopped counting". Multiplying it by `s`
+                            // turns the whole far field into what reads as a
+                            // measured distance: at `s = 0.5` every value lands
+                            // inside `+/-1.5` and not one voxel is saturated
+                            // any more -- measured, 971,210 saturated voxels
+                            // became zero. `in_band` then accepts the plateau,
+                            // `measurable` stops skipping it, and a flat region
+                            // has no gradient, so `gradient_drift` reports 1.0
+                            // for a field whose real drift is 0.
+                            //
+                            // Writing the band edge back is a LIE about
+                            // distance -- the true clearance is only `3s` -- and
+                            // it is only sound because `redistance` runs
+                            // straight afterwards and re-solves the band
+                            // outward from the interface. It must NOT be
+                            // adopted as a policy in place of redistancing: at
+                            // `MIN_SCALE` it would claim three voxels of
+                            // clearance where 0.15 exists, and `raycast`
+                            // sphere-marches on exactly these values.
+                            let from = by.inverse_transform_point(world);
+                            let source = if gathered {
+                                region.sample(from / voxel_size)
+                            } else {
+                                self.sample_world(from)
+                            };
+                            let value = if source.abs() >= OUTSIDE {
+                                source
+                            } else {
+                                source * by.min_scale()
+                            };
                             data[brick_index(x, y, z)] = value.clamp(INSIDE, OUTSIDE);
                         }
                     }
@@ -274,6 +339,7 @@ impl Volume {
                     None => Some((*coord, brick)),
                 }
             })
+            .flatten()
             .collect();
 
         for (coord, brick) in built {
@@ -313,6 +379,7 @@ impl Volume {
 mod tests {
     use super::*;
     use crate::orientation::{AxisRotation, Facing};
+    use crate::redistance::GRADIENT_TOLERANCE;
     use crate::similarity::Bake;
     use glam::Quat;
 
@@ -564,6 +631,137 @@ mod tests {
             // scaled body sit beside its unscaled siblings.
             assert_eq!(scaled.voxel_size(), volume.voxel_size());
         }
+    }
+
+    /// **Reading through a gathered region must give the same field as reading
+    /// through the brick map.**
+    ///
+    /// `Volume::warped` used to call `sample_world` per destination voxel, and
+    /// a trilinear sample is eight reads, so a dense brick paid 262,144 hash
+    /// lookups. [`Volume::resampled`] has always gathered the source region
+    /// once and read a flat array instead; the two loops are siblings and only
+    /// this one was missing it.
+    ///
+    /// A speed change that quietly moved a voxel would be the worst kind, so
+    /// this drives both paths over a squash, a shrink and a grow and compares
+    /// the storage bit for bit -- including which bricks exist at all, since a
+    /// difference of one ULP either side of `is_collapsible`'s exact test would
+    /// change a brick's representation rather than its values.
+    #[test]
+    fn a_gathered_warp_is_bit_identical_to_a_sampled_one() {
+        let volume = sphere(0.5);
+        for scale in [Vec3::new(1.0, 0.6, 1.0), Vec3::splat(0.5), Vec3::splat(1.7)] {
+            let by = Similarity::about(Vec3::ZERO, Quat::IDENTITY, scale, Vec3::new(3.0, 0.0, 1.0));
+            let gathered = volume.warped_inner(by, true);
+            let sampled = volume.warped_inner(by, false);
+            assert!(
+                gathered.stats().dense_bricks > 0,
+                "no dense bricks at scale {scale:?}, so nothing was actually sampled"
+            );
+            crate::testing::assert_same_field(
+                &gathered,
+                &sampled,
+                &format!("gathering the source changed the field at scale {scale:?}"),
+            );
+        }
+    }
+
+    /// **A shrunk body must measure the size it was shrunk to.**
+    ///
+    /// `surface_bounds` rejects the far field with `value.abs() >= NARROW_BAND`,
+    /// which is only a valid test while the saturation constant IS
+    /// `NARROW_BAND`. A shrink used to scale the plateau along with the measured
+    /// distances, so nothing was saturated any more, the predicate stopped
+    /// rejecting anything, and the whole volume read as surface -- 47.75 mm
+    /// against an exact 36.000 on a 0.25 mm lattice, 32.6% out.
+    ///
+    /// That is not a cosmetic number. `set_working_size` divides by this span,
+    /// under a docstring calling the operation free and lossless, so a body
+    /// scaled down and then set to a size would have exported at the wrong
+    /// physical size -- a wrong part out of the slicer.
+    #[test]
+    fn the_measured_size_of_a_shrunk_body_is_the_size_it_was_shrunk_to() {
+        for voxel_size in [0.25_f32, 0.125] {
+            for scale in [0.6_f32, 0.3] {
+                let volume = sphere(voxel_size);
+                let shrunk = volume.warped(Similarity::about(
+                    Vec3::ZERO,
+                    Quat::IDENTITY,
+                    Vec3::splat(scale),
+                    Vec3::ZERO,
+                ));
+                let (lo, hi) = shrunk.surface_bounds().expect("the shrunk body has a surface");
+                let measured = (hi - lo).max_element();
+                let expected = RADIUS * 2.0 * scale;
+                assert!(
+                    (measured - expected).abs() <= voxel_size * 4.0,
+                    "a {RADIUS} mm-radius ball scaled by {scale} at a {voxel_size} mm voxel \
+                     measured {measured} mm across, expected {expected} mm"
+                );
+            }
+        }
+    }
+
+    /// **A shrink must leave a band that still reaches the band edge.**
+    ///
+    /// `d' = s * d(T_inv(p))` is exact for a similarity, so a uniformly scaled
+    /// body is a true distance field and its drift must measure as zero. It did
+    /// not, and the reason was the saturation plateau rather than the geometry:
+    /// the multiply scaled the clamp along with the measured distances, so at
+    /// `s = 0.5` the whole volume landed inside `+/-1.5` and **not one voxel was
+    /// saturated** -- measured, 971,210 became zero. `measurable` skips a voxel
+    /// only when its stencil touches saturation, so the flat far field was then
+    /// measured, and a flat region has no gradient, so `gradient_drift` came
+    /// back with 1.0.
+    ///
+    /// It was permanent, too. `rebake_gizmo` used to skip `redistance` when the
+    /// scale was uniform, on the correct-sounding reasoning that a similarity
+    /// leaves a true distance field, so nothing ever put the band back and the
+    /// body reported a drift of 1.0 for the rest of its life. Since the brush
+    /// residual is meant to be gated on measured drift, wiring it up would have
+    /// fired it on every body that had ever been scaled and never converged.
+    ///
+    /// Asserted on the pair, not on `warped` alone, because that is the pair
+    /// production runs: `warped` deliberately leaves a cliff at the band edge
+    /// and `redistance` is what resolves it. Testing `warped` by itself would
+    /// pin the intermediate state and forbid the fix.
+    #[test]
+    fn a_uniform_shrink_leaves_a_full_depth_band() {
+        let volume = sphere(0.5);
+        let before = volume.gradient_drift();
+        assert!(before <= GRADIENT_TOLERANCE, "the fixture already drifts by {before}");
+
+        let mut scaled = volume.warped(Similarity::about(
+            Vec3::ZERO,
+            Quat::IDENTITY,
+            Vec3::splat(0.5),
+            Vec3::ZERO,
+        ));
+        scaled.redistance();
+
+        let deepest = scaled
+            .brick_coords()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .filter_map(|coord| match scaled.brick(coord) {
+                Some(Brick::Dense(data)) => data.iter().copied().fold(None::<f32>, |worst, v| {
+                    Some(worst.map_or(v.abs(), |w: f32| w.max(v.abs())))
+                }),
+                _ => None,
+            })
+            .fold(0.0f32, f32::max);
+        assert!(
+            deepest >= NARROW_BAND,
+            "the deepest value in the band is {deepest}, so the shrink carried the saturation \
+             plateau down with it and the band no longer reaches its own edge"
+        );
+
+        let drift = scaled.gradient_drift();
+        assert!(
+            drift <= GRADIENT_TOLERANCE,
+            "a uniform scale is an exact distance field, so the drift should be near zero \
+             and it measured {drift}"
+        );
     }
 
     /// A distance field that is not a distance field breaks the sphere trace,

--- a/crates/brokkr-core/src/transform.rs
+++ b/crates/brokkr-core/src/transform.rs
@@ -78,6 +78,28 @@ pub fn warps_made_on_this_thread() -> usize {
     WARPS_MADE.with(std::cell::Cell::get)
 }
 
+/// The destination box for a source box: the eight corners forward.
+///
+/// Replaces `by.inverse().inverse_bounds(..)`, which no longer type-checks and
+/// could not be made to: with a per-axis scale the inverse of this map is not
+/// itself expressible as one. Same eight-corner argument, same conservative
+/// direction.
+pub(crate) fn forward_bounds(by: Similarity, low: Vec3, high: Vec3) -> (Vec3, Vec3) {
+    let mut result_low = Vec3::splat(f32::INFINITY);
+    let mut result_high = Vec3::splat(f32::NEG_INFINITY);
+    for corner in 0..8 {
+        let point = Vec3::new(
+            if corner & 1 == 0 { low.x } else { high.x },
+            if corner & 2 == 0 { low.y } else { high.y },
+            if corner & 4 == 0 { low.z } else { high.z },
+        );
+        let moved = by.transform_point(point);
+        result_low = result_low.min(moved);
+        result_high = result_high.max(moved);
+    }
+    (result_low, result_high)
+}
+
 impl Volume {
     /// This field moved by a whole number of VOXELS.
     ///
@@ -179,13 +201,13 @@ impl Volume {
         let Some((world_min, world_max)) = self.world_bounds() else {
             return warped;
         };
-        if !by.scale.is_finite() || by.scale <= 0.0 {
+        if !by.scale.is_finite() || by.scale.min_element() <= 0.0 {
             return warped;
         }
 
         // Where the content is GOING. The forward image of the source box, by
         // the same eight-corner argument `inverse_bounds` makes backwards.
-        let (moved_min, moved_max) = by.inverse().inverse_bounds(world_min, world_max);
+        let (moved_min, moved_max) = forward_bounds(by, world_min, world_max);
         // Room either side for the new surface's narrow band, and the band is
         // measured on the destination lattice.
         let margin = Vec3::splat(NARROW_BAND * voxel_size * 2.0);
@@ -203,7 +225,6 @@ impl Volume {
             }
         }
 
-        let inverse = by.inverse();
         let dim = BRICK_DIM as i32;
         let built: Vec<(BrickCoord, Brick)> = coords
             .par_iter()
@@ -230,12 +251,18 @@ impl Volume {
                         for x in 0..BRICK_DIM {
                             let voxel = origin + IVec3::new(x as i32, y as i32, z as i32);
                             let world = voxel.as_vec3() * voxel_size;
-                            // `d'(p) = s * d(T_inverse(p))`, which for a
-                            // similarity is EXACTLY the field of the
-                            // transformed solid rather than an approximation
-                            // of it. See `crate::similarity`.
-                            let value =
-                                self.sample_world(inverse.transform_point(world)) * by.scale;
+                            // `d'(p) = s * d(T_inverse(p))`. For a UNIFORM
+                            // scale that is exactly the field of the
+                            // transformed solid. For a per-axis one it is
+                            // `s_min` -- the zero set stays exact and every
+                            // other distance is underestimated, which is the
+                            // sound direction for a sphere trace: it steps
+                            // short, never through. `Volume::redistance` is
+                            // what puts the magnitudes back afterwards, and
+                            // `Similarity::is_uniform_scale` is how the caller
+                            // knows whether it has to. See `crate::similarity`.
+                            let value = self.sample_world(by.inverse_transform_point(world))
+                                * by.min_scale();
                             data[brick_index(x, y, z)] = value.clamp(INSIDE, OUTSIDE);
                         }
                     }
@@ -469,7 +496,7 @@ mod tests {
         let warped = volume.warped(Similarity::about(
             Vec3::ZERO,
             Quat::from_rotation_x(std::f32::consts::FRAC_PI_2),
-            1.0,
+            Vec3::ONE,
             Vec3::ZERO,
         ));
 
@@ -503,7 +530,7 @@ mod tests {
         let turn = Similarity::about(
             Vec3::ZERO,
             Quat::from_rotation_y(std::f32::consts::FRAC_PI_4),
-            1.0,
+            Vec3::ONE,
             Vec3::ZERO,
         );
         let turned = volume.warped(turn);
@@ -521,8 +548,12 @@ mod tests {
     fn a_uniform_scale_makes_the_model_that_much_bigger() {
         let volume = sphere(0.5);
         for scale in [0.5_f32, 2.0] {
-            let scaled =
-                volume.warped(Similarity::about(Vec3::ZERO, Quat::IDENTITY, scale, Vec3::ZERO));
+            let scaled = volume.warped(Similarity::about(
+                Vec3::ZERO,
+                Quat::IDENTITY,
+                Vec3::splat(scale),
+                Vec3::ZERO,
+            ));
             let measured = measured_radius(&scaled, Vec3::ZERO);
             assert!(
                 (measured - RADIUS * scale).abs() < 1.0,
@@ -543,7 +574,12 @@ mod tests {
     #[test]
     fn a_scaled_field_is_still_a_distance_field() {
         let volume = sphere(0.5);
-        let scaled = volume.warped(Similarity::about(Vec3::ZERO, Quat::IDENTITY, 1.7, Vec3::ZERO));
+        let scaled = volume.warped(Similarity::about(
+            Vec3::ZERO,
+            Quat::IDENTITY,
+            Vec3::splat(1.7),
+            Vec3::ZERO,
+        ));
         let expected = RADIUS * 1.7;
 
         // Along the surface, a little outside it, where the field is not
@@ -585,7 +621,7 @@ mod tests {
         let placement = Similarity::about(
             Vec3::ZERO,
             Quat::from_euler(glam::EulerRot::YXZ, 0.4, 0.3, 0.0),
-            1.3,
+            Vec3::splat(1.3),
             Vec3::new(3.0, -2.0, 1.0),
         );
         let (_, report) = volume.warped(placement).export_mesh();
@@ -625,7 +661,7 @@ mod tests {
         for scale in [0.0_f32, -1.0, f32::NAN] {
             let warped = volume.warped(Similarity {
                 rotation: Quat::IDENTITY,
-                scale,
+                scale: Vec3::splat(scale),
                 translation: Vec3::ZERO,
             });
             assert_eq!(warped.brick_count(), 0, "scale {scale}");

--- a/crates/brokkr-core/src/transform.rs
+++ b/crates/brokkr-core/src/transform.rs
@@ -1,0 +1,634 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Moving, turning and scaling one body through a [`Similarity`].
+//!
+//! Two routes, and which one a placement takes is decided once by
+//! [`Similarity::route`] rather than separately here, in the status line and in
+//! the undo entry.
+//!
+//! # [`Volume::shifted`] is a gather, not a resample
+//!
+//! [`Volume::duplicated`]'s header says a sub-brick offset "would have to
+//! rebuild every brick from two neighbours, which is the resample this whole
+//! lattice exists to avoid, and it would cost the surface a little detail on
+//! the way through". The first half is true and the second is not, at
+//! whole-voxel granularity: every destination voxel takes exactly one source
+//! voxel's `f32`, with no interpolation and no arithmetic performed on the
+//! value at all. There is no detail to lose because nothing is recomputed. What
+//! it does cost is the rebuild -- eight source bricks may feed one destination
+//! brick -- which is why it delegates to `duplicated` whenever the offset turns
+//! out to be brick aligned.
+//!
+//! Distance values are stored in voxels and a translation preserves distance,
+//! so, exactly as in [`crate::rotate`], not one value is rescaled.
+//!
+//! # [`Volume::warped`] is [`Volume::resampled`] with a map in the middle
+//!
+//! Same skeleton: walk destination bricks, ask the source what it holds over
+//! the region each one came from, answer the empty and solid cases from the
+//! brick structure and sample only the shell. Three differences, each of which
+//! is a place this could go quietly wrong:
+//!
+//! * The region a destination brick came from is [`Similarity::inverse_bounds`]
+//!   of its world box rather than the box itself. A box derived from the
+//!   SOURCE bounds instead would drop the corners of a turned model, which
+//!   looks like a mesher bug rather than a transform one.
+//! * The value rescale is `by.scale` and not a voxel-size ratio, because
+//!   `voxel_size` does not change. That is the invariant the approved plan's
+//!   refusal of per-body scale exists to protect --
+//!   `Document::lattice_agrees()` still holds by construction, because nothing
+//!   here touches the lattice.
+//! * The destination footprint has to cover where the model is GOING. A
+//!   rotation of forty-five degrees pushes the corners of a bounding box out by
+//!   a factor of root two, and a scale pushes them out by the scale.
+//!
+//! # What repeating it costs, and who is responsible for bounding that
+//!
+//! One `warped` pass is one trilinear resample, which is lossy in the way every
+//! pass through [`Volume::resampled`] is lossy. Nothing here can make that
+//! cheaper. What CAN be bounded is how many passes a body suffers, and that is
+//! the caller's job and not this module's: the gizmo holds the field as it was
+//! when it armed and re-bakes every release FROM that, so thirty adjustments
+//! cost one pass rather than thirty. See `Brokkr::rebake_gizmo`.
+
+use glam::{IVec3, Vec3};
+use rayon::prelude::*;
+
+use crate::brick::{BRICK_DIM, Brick, BrickCoord, INSIDE, NARROW_BAND, OUTSIDE, brick_index};
+use crate::similarity::Similarity;
+use crate::volume::Volume;
+
+thread_local! {
+    /// How many trilinear passes [`Volume::warped`] has run on this thread.
+    ///
+    /// Thread local rather than global for the reason
+    /// [`crate::volume::copies_made_on_this_thread`] gives: the test suite runs
+    /// in parallel threads and a shared counter would race.
+    ///
+    /// **It exists because "one gesture is one pass" is the claim the whole
+    /// anti-degradation design rests on, and nothing else can see it.** Erosion
+    /// after thirty passes is real but hard to assert on without a tolerance
+    /// that would also pass for two; the number of passes is the thing that was
+    /// actually promised, so it is the thing that is counted.
+    static WARPS_MADE: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// The value of that counter. Take it before and after and compare.
+pub fn warps_made_on_this_thread() -> usize {
+    WARPS_MADE.with(std::cell::Cell::get)
+}
+
+impl Volume {
+    /// This field moved by a whole number of VOXELS.
+    ///
+    /// Value-exact: see the module header for why a gather at whole-voxel
+    /// granularity is not a resample. Delegates to [`Volume::duplicated`] when
+    /// the offset is a whole number of bricks, which moves `Box` pointers
+    /// instead of voxels.
+    pub fn shifted(&self, offset_voxels: IVec3) -> Volume {
+        let dim = BRICK_DIM as i32;
+        if offset_voxels.rem_euclid(IVec3::splat(dim)) == IVec3::ZERO {
+            return self.duplicated(offset_voxels / dim);
+        }
+
+        let mut shifted = Volume::new(self.voxel_size());
+
+        // Every destination brick some source brick reaches. A source brick
+        // moved by a sub-brick offset straddles up to eight of them, and the
+        // destination is built from that set rather than from a bounding box so
+        // that a sparse shell stays sparse.
+        let mut wanted: rustc_hash::FxHashSet<BrickCoord> = rustc_hash::FxHashSet::default();
+        for coord in self.brick_coords() {
+            let low = BrickCoord::containing(coord.origin() + offset_voxels).0;
+            let high = BrickCoord::containing(coord.max_voxel() + offset_voxels).0;
+            for bz in low.z..=high.z {
+                for by in low.y..=high.y {
+                    for bx in low.x..=high.x {
+                        wanted.insert(BrickCoord::new(bx, by, bz));
+                    }
+                }
+            }
+        }
+
+        let coords: Vec<BrickCoord> = wanted.into_iter().collect();
+        let built: Vec<(BrickCoord, Brick)> = coords
+            .par_iter()
+            .filter_map(|coord| {
+                let source_low = coord.origin() - offset_voxels;
+                let source_high = coord.max_voxel() - offset_voxels;
+
+                // The cheap case, and on a solid interior it is most of them:
+                // if every source brick this one reads from holds one value,
+                // so does this one, and its 32768 voxels never exist.
+                if let Some(value) = self.uniform_over(source_low, source_high) {
+                    return (value < OUTSIDE).then_some((*coord, Brick::Uniform(value)));
+                }
+
+                let mut brick = Brick::dense_filled(OUTSIDE);
+                let data = brick.make_dense();
+                for z in 0..BRICK_DIM {
+                    for y in 0..BRICK_DIM {
+                        for x in 0..BRICK_DIM {
+                            let voxel = source_low + IVec3::new(x as i32, y as i32, z as i32);
+                            // `sample_voxel`, not `sample_world`: one stored
+                            // f32 copied across, which is what makes this
+                            // exact.
+                            data[brick_index(x, y, z)] = self.sample_voxel(voxel);
+                        }
+                    }
+                }
+                match brick.is_collapsible() {
+                    Some(value) if value >= OUTSIDE => None,
+                    Some(value) => Some((*coord, Brick::Uniform(value))),
+                    None => Some((*coord, brick)),
+                }
+            })
+            .collect();
+
+        for (coord, brick) in built {
+            shifted.insert_brick(coord, brick);
+        }
+        // The mask moves with the body it protects, to the same world voxel,
+        // and by its OWN bricks: protection over empty space is real, so a mask
+        // brick with no field brick under it would be left behind by a walk of
+        // `brick_coords`.
+        *shifted.mask_mut() = self.mask().shifted(offset_voxels);
+        shifted.mark_everything_dirty();
+        shifted
+    }
+
+    /// This field rebuilt through a similarity, onto the SAME lattice.
+    ///
+    /// `voxel_size` is untouched, which is what keeps every body in a document
+    /// on one lattice -- the invariant the approved plan's refusal of per-body
+    /// scale exists to protect. Scaling a body here changes what it OCCUPIES,
+    /// not what a voxel measures.
+    ///
+    /// Lossy, in the same way and to the same degree as
+    /// [`Volume::resampled`]: one trilinear pass. Callers that can take the
+    /// exact route must, and [`Similarity::route`] is what tells them whether
+    /// they can.
+    pub fn warped(&self, by: Similarity) -> Volume {
+        WARPS_MADE.with(|made| made.set(made.get() + 1));
+        let voxel_size = self.voxel_size();
+        let mut warped = Volume::new(voxel_size);
+        // Before the empty-field return, exactly as in `resampled` and for the
+        // same reason: a mask can protect empty space, so a body with no bricks
+        // at all can still have one to carry.
+        *warped.mask_mut() = self.mask().warped(by, voxel_size);
+        let Some((world_min, world_max)) = self.world_bounds() else {
+            return warped;
+        };
+        if !by.scale.is_finite() || by.scale <= 0.0 {
+            return warped;
+        }
+
+        // Where the content is GOING. The forward image of the source box, by
+        // the same eight-corner argument `inverse_bounds` makes backwards.
+        let (moved_min, moved_max) = by.inverse().inverse_bounds(world_min, world_max);
+        // Room either side for the new surface's narrow band, and the band is
+        // measured on the destination lattice.
+        let margin = Vec3::splat(NARROW_BAND * voxel_size * 2.0);
+        let new_min =
+            BrickCoord::containing(((moved_min - margin) / voxel_size).floor().as_ivec3()).0;
+        let new_max =
+            BrickCoord::containing(((moved_max + margin) / voxel_size).ceil().as_ivec3()).0;
+
+        let mut coords = Vec::new();
+        for bz in new_min.z..=new_max.z {
+            for by_ in new_min.y..=new_max.y {
+                for bx in new_min.x..=new_max.x {
+                    coords.push(BrickCoord::new(bx, by_, bz));
+                }
+            }
+        }
+
+        let inverse = by.inverse();
+        let dim = BRICK_DIM as i32;
+        let built: Vec<(BrickCoord, Brick)> = coords
+            .par_iter()
+            .filter_map(|coord| {
+                let origin = coord.origin();
+                let brick_min = origin.as_vec3() * voxel_size;
+                let brick_max = (origin + IVec3::splat(dim - 1)).as_vec3() * voxel_size;
+
+                // Answer the cheap cases from the source's brick structure, over
+                // the region this brick actually came from.
+                let (source_min, source_max) = by.inverse_bounds(brick_min, brick_max);
+                match self.coverage(source_min, source_max) {
+                    crate::resample::Coverage::Empty => return None,
+                    crate::resample::Coverage::Solid => {
+                        return Some((*coord, Brick::Uniform(INSIDE)));
+                    }
+                    crate::resample::Coverage::Surface => {}
+                }
+
+                let mut brick = Brick::dense_filled(OUTSIDE);
+                let data = brick.make_dense();
+                for z in 0..BRICK_DIM {
+                    for y in 0..BRICK_DIM {
+                        for x in 0..BRICK_DIM {
+                            let voxel = origin + IVec3::new(x as i32, y as i32, z as i32);
+                            let world = voxel.as_vec3() * voxel_size;
+                            // `d'(p) = s * d(T_inverse(p))`, which for a
+                            // similarity is EXACTLY the field of the
+                            // transformed solid rather than an approximation
+                            // of it. See `crate::similarity`.
+                            let value =
+                                self.sample_world(inverse.transform_point(world)) * by.scale;
+                            data[brick_index(x, y, z)] = value.clamp(INSIDE, OUTSIDE);
+                        }
+                    }
+                }
+
+                match brick.is_collapsible() {
+                    Some(value) if value >= OUTSIDE => None,
+                    Some(value) => Some((*coord, Brick::Uniform(value))),
+                    None => Some((*coord, brick)),
+                }
+            })
+            .collect();
+
+        for (coord, brick) in built {
+            warped.insert_brick(coord, brick);
+        }
+        warped.mark_everything_dirty();
+        warped
+    }
+
+    /// The one value every voxel of an inclusive source voxel box holds, or
+    /// `None` when the region carries detail.
+    ///
+    /// Absent bricks count as [`OUTSIDE`], which is what they read as. The
+    /// field's sibling of `MaskField::uniform_over`, and what lets a solid
+    /// interior survive a shift without being allocated.
+    fn uniform_over(&self, low: IVec3, high: IVec3) -> Option<f32> {
+        let b_low = BrickCoord::containing(low).0;
+        let b_high = BrickCoord::containing(high).0;
+        let mut found: Option<f32> = None;
+        for bz in b_low.z..=b_high.z {
+            for by in b_low.y..=b_high.y {
+                for bx in b_low.x..=b_high.x {
+                    let value = self.brick_fill(BrickCoord::new(bx, by, bz))?;
+                    match found {
+                        None => found = Some(value),
+                        Some(held) if held == value => {}
+                        Some(_) => return None,
+                    }
+                }
+            }
+        }
+        found
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orientation::{AxisRotation, Facing};
+    use crate::similarity::Bake;
+    use glam::Quat;
+
+    const RADIUS: f32 = 20.0;
+
+    fn sphere(voxel_size: f32) -> Volume {
+        let mut volume = Volume::new(voxel_size);
+        volume.seed_sphere(Vec3::ZERO, RADIUS);
+        volume
+    }
+
+    /// Every stored voxel, in a deterministic order, so two volumes can be
+    /// compared value by value rather than through a sampled surface.
+    ///
+    /// The same helper `rotate.rs` uses, and deliberately the same shape: a
+    /// claim of bit identity that is only checked at the surface is not a claim
+    /// of bit identity.
+    fn field(volume: &Volume) -> Vec<(BrickCoord, Vec<f32>)> {
+        let mut coords: Vec<BrickCoord> = volume.brick_coords().collect();
+        coords.sort_unstable();
+        coords
+            .into_iter()
+            .map(|coord| {
+                let brick = volume.brick(coord).expect("came from the map");
+                let mut values = Vec::with_capacity(BRICK_DIM * BRICK_DIM * BRICK_DIM);
+                for z in 0..BRICK_DIM {
+                    for y in 0..BRICK_DIM {
+                        for x in 0..BRICK_DIM {
+                            values.push(brick.get(x, y, z));
+                        }
+                    }
+                }
+                (coord, values)
+            })
+            .collect()
+    }
+
+    /// Where the surface sits along +X, found by walking outward.
+    fn measured_radius(volume: &Volume, from: Vec3) -> f32 {
+        let step = volume.voxel_size() * 0.1;
+        let mut last = 0.0;
+        for index in 0..20_000 {
+            let t = index as f32 * step;
+            if volume.sample_world(from + Vec3::new(t, 0.0, 0.0)) >= 0.0 {
+                return last;
+            }
+            last = t;
+        }
+        last
+    }
+
+    /// The claim the exact route rests on. Not "close to": the same bits,
+    /// because no value was ever recomputed.
+    #[test]
+    fn a_whole_voxel_shift_and_its_inverse_are_bit_identical() {
+        let source = sphere(0.5);
+        for offset in [
+            IVec3::new(1, 0, 0),
+            IVec3::new(-7, 13, 5),
+            IVec3::new(31, -31, 1),
+            // Brick aligned, which takes the `duplicated` route instead.
+            IVec3::new(32, 64, -32),
+        ] {
+            let there = source.shifted(offset);
+            let back = there.shifted(-offset);
+            assert_eq!(
+                field(&back),
+                field(&source),
+                "shifting by {offset:?} and back moved values"
+            );
+        }
+    }
+
+    #[test]
+    fn a_brick_aligned_shift_agrees_with_duplicated() {
+        let source = sphere(0.5);
+        let offset_bricks = IVec3::new(2, -1, 3);
+        let shifted = source.shifted(offset_bricks * BRICK_DIM as i32);
+        let duplicated = source.duplicated(offset_bricks);
+        assert_eq!(field(&shifted), field(&duplicated));
+    }
+
+    #[test]
+    fn a_sub_brick_shift_moves_the_model_exactly_that_far() {
+        let volume = sphere(0.5);
+        // Seven voxels along X at a 0.5 mm voxel is 3.5 mm.
+        let shifted = volume.shifted(IVec3::new(7, 0, 0));
+        let before = measured_radius(&volume, Vec3::ZERO);
+        let after = measured_radius(&shifted, Vec3::new(3.5, 0.0, 0.0));
+        assert!((after - before).abs() < 1.0e-4, "{before} against {after}");
+        // And the old place is empty now.
+        assert!(shifted.sample_world(Vec3::new(-RADIUS + 1.0, 0.0, 0.0)) >= 0.0);
+    }
+
+    /// A shift must not allocate a solid interior. Without the `uniform_over`
+    /// shortcut every destination brick would be gathered densely, and only
+    /// `is_collapsible` would notice afterwards -- correct, and 32768 reads per
+    /// brick to learn it.
+    #[test]
+    fn the_interior_stays_tiles_rather_than_becoming_dense() {
+        let source = sphere(0.25);
+        assert!(source.stats().uniform_bricks > 0, "the fixture has no interior to preserve");
+
+        let shifted = source.shifted(IVec3::new(5, -3, 9));
+        let stats = shifted.stats();
+        assert!(stats.uniform_bricks > 0, "the interior should have stayed tiles");
+        match shifted.brick(BrickCoord::containing(IVec3::ZERO)) {
+            Some(Brick::Uniform(value)) => assert!(*value <= INSIDE),
+            Some(Brick::Dense(_)) => panic!("the centre of a solid ball was filled in with voxels"),
+            None => panic!("the centre of a solid ball should not be empty space"),
+        }
+    }
+
+    #[test]
+    fn a_shift_carries_the_mask_to_the_same_world_voxel() {
+        use crate::{PROTECTED, UNMASKED};
+
+        let mut volume = sphere(0.5);
+        let on_the_body = IVec3::new(3, 40, 7);
+        // Out in empty space, where no field brick exists to carry a mask that
+        // merely rode along with one.
+        let in_empty_space = IVec3::new(400, 400, 400);
+        volume.mask_mut().write(on_the_body, PROTECTED);
+        volume.mask_mut().write(in_empty_space, 200);
+
+        let offset = IVec3::new(5, -3, 9);
+        let shifted = volume.shifted(offset);
+
+        assert_eq!(shifted.mask().at(on_the_body + offset), PROTECTED);
+        assert_eq!(shifted.mask().at(in_empty_space + offset), 200);
+        assert_eq!(shifted.mask().at(on_the_body), UNMASKED, "the mask did not move with the body");
+    }
+
+    /// Mask All is a polarity bit over an EMPTY brick map, so for that state the
+    /// bit is the entire mask and a move that copies no brick carries nothing
+    /// else.
+    #[test]
+    fn a_shift_carries_mask_all_even_though_it_moves_no_brick() {
+        use crate::PROTECTED;
+
+        let mut volume = sphere(0.5);
+        volume.mask_mut().set_inverted(true);
+        assert_eq!(volume.mask().map_bytes(), 0, "Mask All must store no bricks at all");
+
+        let shifted = volume.shifted(IVec3::new(7, 1, -2));
+        assert!(shifted.mask().inverted(), "the move dropped the mask's polarity");
+        assert_eq!(shifted.mask().at(IVec3::new(-317, 44, 900)), PROTECTED);
+    }
+
+    #[test]
+    fn every_brick_of_a_moved_model_is_dirty() {
+        let mut shifted = sphere(0.5).shifted(IVec3::new(3, 3, 3));
+        let stored: Vec<BrickCoord> = shifted.brick_coords().collect();
+        assert!(!stored.is_empty(), "the fixture is empty");
+        let mut dirty = Vec::new();
+        shifted.take_dirty(&mut dirty);
+        let dirty: std::collections::HashSet<BrickCoord> = dirty.into_iter().collect();
+        for coord in stored {
+            assert!(dirty.contains(&coord), "{coord:?} carries geometry and was not marked dirty");
+        }
+    }
+
+    #[test]
+    fn shifting_an_empty_volume_gives_an_empty_volume() {
+        let empty = Volume::new(0.5);
+        let shifted = empty.shifted(IVec3::new(3, -4, 5));
+        assert_eq!(shifted.brick_count(), 0);
+        assert_eq!(shifted.voxel_size(), 0.5);
+    }
+
+    /// The lossy route has to agree with the exact one wherever both apply, or
+    /// the routing decision changes the answer rather than only its cost.
+    #[test]
+    fn a_quarter_turn_through_warped_agrees_with_rotated() {
+        let mut volume = Volume::new(0.5);
+        // Off axis, so a rotation that did nothing would be caught.
+        volume.seed_sphere(Vec3::new(0.0, 30.0, 0.0), 8.0);
+
+        let turns = AxisRotation::taking(Facing::Up, Facing::Front);
+        let exact = volume.rotated(turns);
+        let warped = volume.warped(Similarity::about(
+            Vec3::ZERO,
+            Quat::from_rotation_x(std::f32::consts::FRAC_PI_2),
+            1.0,
+            Vec3::ZERO,
+        ));
+
+        for point in [
+            Vec3::new(0.0, 0.0, 30.0),
+            Vec3::new(0.0, 0.0, 22.0),
+            Vec3::new(0.0, 0.0, 38.0),
+            Vec3::new(4.0, 0.0, 30.0),
+        ] {
+            let a = exact.sample_world(point);
+            let b = warped.sample_world(point);
+            assert!(
+                (a - b).abs() < 0.3,
+                "at {point:?} the exact turn says {a} and the warp says {b}"
+            );
+        }
+    }
+
+    /// **The test that catches a destination box derived from the SOURCE
+    /// bounds.** A forty-five degree turn pushes a box's corners out by root
+    /// two; a footprint that did not grow would clip them off and the model
+    /// would come back with its corners shaved, which reads as a mesher bug.
+    #[test]
+    fn a_forty_five_degree_turn_of_a_box_keeps_its_corners() {
+        let mut volume = Volume::new(0.5);
+        // A bar, so the corners are far from the turn's centre and would be the
+        // first thing a tight footprint lost.
+        volume.seed_sphere(Vec3::new(-25.0, 0.0, 0.0), 6.0);
+        volume.seed_sphere(Vec3::new(25.0, 0.0, 0.0), 6.0);
+
+        let turn = Similarity::about(
+            Vec3::ZERO,
+            Quat::from_rotation_y(std::f32::consts::FRAC_PI_4),
+            1.0,
+            Vec3::ZERO,
+        );
+        let turned = volume.warped(turn);
+
+        for end in [Vec3::new(-25.0, 0.0, 0.0), Vec3::new(25.0, 0.0, 0.0)] {
+            let moved = turn.transform_point(end);
+            assert!(
+                turned.sample_world(moved) < 0.0,
+                "the ball that was at {end:?} did not arrive at {moved:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_uniform_scale_makes_the_model_that_much_bigger() {
+        let volume = sphere(0.5);
+        for scale in [0.5_f32, 2.0] {
+            let scaled =
+                volume.warped(Similarity::about(Vec3::ZERO, Quat::IDENTITY, scale, Vec3::ZERO));
+            let measured = measured_radius(&scaled, Vec3::ZERO);
+            assert!(
+                (measured - RADIUS * scale).abs() < 1.0,
+                "scaling by {scale} gave a radius of {measured}, expected {}",
+                RADIUS * scale
+            );
+            // The lattice is untouched, which is the invariant that lets a
+            // scaled body sit beside its unscaled siblings.
+            assert_eq!(scaled.voxel_size(), volume.voxel_size());
+        }
+    }
+
+    /// A distance field that is not a distance field breaks the sphere trace,
+    /// the mesher and the curvature the brushes read. `d' = s * d(T_inv(p))` is
+    /// exact for a similarity, so the gradient must come back unit length --
+    /// which is the property `Bake::Resample` is allowed to be lossy about the
+    /// DETAIL of and not about the METRIC of.
+    #[test]
+    fn a_scaled_field_is_still_a_distance_field() {
+        let volume = sphere(0.5);
+        let scaled = volume.warped(Similarity::about(Vec3::ZERO, Quat::IDENTITY, 1.7, Vec3::ZERO));
+        let expected = RADIUS * 1.7;
+
+        // Along the surface, a little outside it, where the field is not
+        // clamped and the values are real.
+        for direction in [Vec3::X, Vec3::Y, Vec3::Z, Vec3::new(1.0, 1.0, 1.0).normalize()] {
+            for offset in [-1.0_f32, 0.0, 1.0] {
+                let at = direction * (expected + offset);
+                let h = scaled.voxel_size();
+                let gradient = Vec3::new(
+                    scaled.sample_world(at + Vec3::X * h) - scaled.sample_world(at - Vec3::X * h),
+                    scaled.sample_world(at + Vec3::Y * h) - scaled.sample_world(at - Vec3::Y * h),
+                    scaled.sample_world(at + Vec3::Z * h) - scaled.sample_world(at - Vec3::Z * h),
+                ) / (2.0 * h);
+                // Values are in voxels, so a unit gradient measures 1 per voxel.
+                let length = gradient.length() * h;
+                assert!(
+                    (0.85..=1.15).contains(&length),
+                    "|grad| was {length} at {at:?}, so the field is no longer metric"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn warping_by_the_identity_leaves_the_surface_where_it_was() {
+        let volume = sphere(0.5);
+        let again = volume.warped(Similarity::IDENTITY);
+        assert!(
+            (measured_radius(&again, Vec3::ZERO) - measured_radius(&volume, Vec3::ZERO)).abs()
+                < 0.2
+        );
+        // And the routing says it should never have been called at all.
+        assert_eq!(Similarity::IDENTITY.route(volume.voxel_size()), Bake::Identity);
+    }
+
+    #[test]
+    fn a_warped_model_is_still_printable() {
+        let volume = sphere(0.5);
+        let placement = Similarity::about(
+            Vec3::ZERO,
+            Quat::from_euler(glam::EulerRot::YXZ, 0.4, 0.3, 0.0),
+            1.3,
+            Vec3::new(3.0, -2.0, 1.0),
+        );
+        let (_, report) = volume.warped(placement).export_mesh();
+        assert!(report.is_printable(), "{}", report.summary());
+    }
+
+    #[test]
+    fn a_warp_carries_the_mask_to_where_the_body_went() {
+        use crate::PROTECTED;
+
+        let mut volume = sphere(0.5);
+        let cell = IVec3::new(0, 40, 0);
+        volume.mask_mut().write(cell, PROTECTED);
+
+        let placement = Similarity::moving(Vec3::new(6.0, 0.0, 0.0));
+        let warped = volume.warped(placement);
+
+        let moved = placement.transform_point(cell.as_vec3() * 0.5) / 0.5;
+        assert_eq!(
+            warped.mask().at(moved.round().as_ivec3()),
+            PROTECTED,
+            "the protection did not travel with the body"
+        );
+    }
+
+    #[test]
+    fn warping_an_empty_volume_gives_an_empty_volume() {
+        let empty = Volume::new(0.5);
+        let warped = empty.warped(Similarity::moving(Vec3::splat(3.0)));
+        assert_eq!(warped.brick_count(), 0);
+        assert_eq!(warped.voxel_size(), 0.5);
+    }
+
+    #[test]
+    fn a_nonsense_scale_gives_an_empty_volume_rather_than_a_field_of_infinities() {
+        let volume = sphere(0.5);
+        for scale in [0.0_f32, -1.0, f32::NAN] {
+            let warped = volume.warped(Similarity {
+                rotation: Quat::IDENTITY,
+                scale,
+                translation: Vec3::ZERO,
+            });
+            assert_eq!(warped.brick_count(), 0, "scale {scale}");
+        }
+    }
+}

--- a/crates/brokkr-core/src/undo.rs
+++ b/crates/brokkr-core/src/undo.rs
@@ -1956,8 +1956,12 @@ mod tests {
             .collect();
 
         // A free-angle turn, so the forward direction really is destructive.
-        let placement =
-            crate::Similarity::about(Vec3::ZERO, glam::Quat::from_rotation_y(0.4), 1.0, Vec3::ZERO);
+        let placement = crate::Similarity::about(
+            Vec3::ZERO,
+            glam::Quat::from_rotation_y(0.4),
+            Vec3::ONE,
+            Vec3::ZERO,
+        );
         let baked = doc.volume(body).expect("a body").warped(placement);
         let previous = doc.replace_volume(body, baked).expect("the body is in the document");
 

--- a/crates/brokkr-core/src/undo.rs
+++ b/crates/brokkr-core/src/undo.rs
@@ -76,6 +76,7 @@ use rustc_hash::FxHashMap;
 use crate::body::{Document, Node, NodeId, NodeMeta};
 use crate::brick::{Brick, BrickCoord};
 use crate::mask::{MaskBrick, MaskField};
+use crate::volume::Volume;
 
 /// Default ceiling on the brick snapshots undo history holds.
 ///
@@ -271,6 +272,29 @@ pub enum Change {
     /// Polarity rides inside the field rather than beside it, which is what
     /// makes Mask All one change and not two.
     WholeMask { body: NodeId, mask: Box<MaskField> },
+    /// A body's WHOLE field was replaced. Applying puts the previous one back.
+    ///
+    /// The transform gizmo's entry, and the shape follows [`Change::WholeMask`]
+    /// exactly rather than by analogy: the field that came off IS the only copy
+    /// of itself, [`crate::Volume`] does not implement `Clone` at all, so it is
+    /// MOVED in and a bake allocates nothing to record itself.
+    ///
+    /// **Its bytes are charged to the reclaim allowance and never to the stroke
+    /// budget.** A 765 MB field against the 256 MB stroke budget would evict
+    /// every stroke behind it -- and the operation would then have destroyed
+    /// the history it was trying to join. The reclaim allowance is the one that
+    /// exists for "the entry is the storage, and its size is known before the
+    /// operation runs", which is exactly this.
+    ///
+    /// **This is also what stops a transform clearing the history.**
+    /// [`Document::rotate`] and [`Document::resample`] both make every older
+    /// entry's brick coordinates meaningless, so their caller drops the whole
+    /// stack; with the original field on the stack instead, undoing the bake
+    /// makes those coordinates valid again and older strokes stay applicable.
+    /// The invariant in the module doc holds unchanged: eviction is still a
+    /// prefix or a suffix drop, and a body still only leaves through a
+    /// `NodeRemoved`.
+    WholeVolume { body: NodeId, volume: Box<Volume> },
     /// A row's name, eye, collapse or depth changed. Applying writes `before`.
     ///
     /// **The whole outline, both sides, over a FIXED id set.** That is what
@@ -322,6 +346,41 @@ impl Change {
                 let previous = volume.replace_mask(*mask);
                 Change::WholeMask { body, mask: Box::new(previous) }
             }
+            Change::WholeVolume { body, volume } => {
+                // Always applicable, by the same invariant `Change::Bricks`
+                // rests on: a removal sits above every edit to the body it
+                // removed, and eviction is a prefix or a suffix drop.
+                let previous = doc
+                    .replace_volume(body, *volume)
+                    .expect("a field change names a body that is still in the document");
+                // **Both sides marked dirty, and the outgoing side is the half
+                // that is easy to forget.** The same pairing
+                // [`crate::Volume::replace_mask`] makes, for a sharper reason:
+                // the field that arrives brings its own dirty set, and that set
+                // is EMPTY, because whatever remeshed it last drained it. So a
+                // swap that marks nothing tells the renderer nothing, and the
+                // screen goes on drawing the body where the change that is
+                // being undone put it -- geometry and interaction in different
+                // places, silently. The bricks the outgoing field occupied are
+                // marked in the INCOMING one so that each of them remeshes to
+                // an empty slice, which is also what hands its pool slot back.
+                //
+                // Not folded into [`Document::replace_volume`], which would be
+                // the tidier home for it: the gizmo takes a field OUT by
+                // swapping an empty placeholder in, and a blanket rule there
+                // would mark the real field's bricks in a placeholder that is
+                // about to be dropped, then mark nothing at all in the field
+                // that replaces it. The dirty pairing belongs to the callers
+                // that know which two fields are really being exchanged.
+                let landed = doc
+                    .volume_mut(body)
+                    .expect("the field just swapped in is still in the document");
+                landed.mark_everything_dirty();
+                for coord in previous.brick_coords() {
+                    landed.mark_dirty(coord);
+                }
+                Change::WholeVolume { body, volume: Box::new(previous) }
+            }
             Change::Outline { before, after } => {
                 debug_assert!(
                     same_ids(&before, &after),
@@ -346,6 +405,7 @@ impl Change {
             Change::NodeAdded { id, .. } => *id,
             Change::NodeRemoved { node, .. } => node.id,
             Change::WholeMask { body, .. } => *body,
+            Change::WholeVolume { body, .. } => *body,
             Change::Outline { before, after } => {
                 before.iter().zip(after).find(|(was, now)| was != now).map_or_else(
                     || before.first().map_or(NodeId(0), |meta| meta.id),
@@ -361,7 +421,7 @@ impl Change {
             Change::Bricks { edit, .. } => edit.bytes(),
             // Both hold a whole thing that was moved out of the document
             // rather than copied out of it. See `reclaim_bytes`.
-            Change::NodeRemoved { .. } | Change::WholeMask { .. } => 0,
+            Change::NodeRemoved { .. } | Change::WholeMask { .. } | Change::WholeVolume { .. } => 0,
             Change::NodeAdded { .. } => size_of::<Self>(),
             Change::Outline { before, after } => {
                 before.iter().chain(after).map(NodeMeta::bytes).sum()
@@ -377,6 +437,12 @@ impl Change {
         match self {
             Change::NodeRemoved { node, .. } => removed_node_bytes(node),
             Change::WholeMask { mask, .. } => size_of::<MaskField>() + mask.bytes(),
+            // `resident_bytes`, the same measure `removed_node_bytes` takes of
+            // a deleted body's field, so a bake and a delete are charged in one
+            // currency against one allowance.
+            Change::WholeVolume { volume, .. } => {
+                size_of::<Volume>() + volume.stats().resident_bytes
+            }
             _ => 0,
         }
     }
@@ -485,6 +551,7 @@ impl Entry {
             let id = match change {
                 Change::Bricks { body, .. } => *body,
                 Change::WholeMask { body, .. } => *body,
+                Change::WholeVolume { body, .. } => *body,
                 Change::NodeAdded { id, .. } => *id,
                 Change::NodeRemoved { .. } | Change::Outline { .. } => return None,
             };
@@ -802,6 +869,7 @@ mod tests {
     use crate::volume::Volume;
     use crate::{Brush, BrushDirection, BrushKind, BrushScratch, Stamp};
     use glam::Vec3;
+    use std::collections::HashSet;
 
     fn sculpted() -> (Document, Brush, BrushScratch) {
         let mut doc = Document::new(1.0);
@@ -1845,5 +1913,215 @@ mod tests {
             doc.volume(body).expect("a body").mask().is_free(),
             "the refused undo put the mask back anyway"
         );
+    }
+
+    // ------------------------------------------------- a whole field replaced
+
+    /// The gizmo's entry follows [`Change::WholeMask`]'s byte policy exactly,
+    /// and the reason is the same one written larger: a 765 MB field against
+    /// the 256 MB stroke budget would evict every stroke behind it, so the bake
+    /// would destroy the history it was trying to join.
+    #[test]
+    fn a_whole_volume_change_is_charged_to_reclaim_and_not_the_stroke_budget() {
+        let (mut doc, _, _) = sculpted();
+        let body = doc.active();
+        let resident = doc.volume(body).expect("a body").stats().resident_bytes;
+        assert!(resident > 0, "the fixture holds no field");
+
+        let moved = doc.volume(body).expect("a body").shifted(glam::IVec3::new(3, 0, 0));
+        let previous = doc.replace_volume(body, moved).expect("the body is in the document");
+
+        let entry = Entry::new(vec![Change::WholeVolume { body, volume: Box::new(previous) }]);
+        assert_eq!(entry.stroke_bytes(), 0, "a moved field was charged to the stroke budget");
+        assert!(
+            entry.reclaim_bytes() >= resident,
+            "the reclaim allowance is not counting the {resident} bytes it is holding"
+        );
+    }
+
+    /// Undoing a bake has to give the field back bit for bit, because a bake is
+    /// the one operation whose forward direction is lossy: "turn it back" is
+    /// not a recovery path for a free-angle transform the way it is for a
+    /// quarter turn.
+    #[test]
+    fn undoing_a_bake_puts_the_field_back_bit_for_bit() {
+        let (mut doc, _, _) = sculpted();
+        let body = doc.active();
+
+        let sampled: Vec<f32> = (0..64)
+            .map(|step| {
+                let at = Vec3::new(20.0 - step as f32 * 0.5, step as f32 * 0.25 - 8.0, 0.0);
+                doc.volume(body).expect("a body").sample_world(at)
+            })
+            .collect();
+
+        // A free-angle turn, so the forward direction really is destructive.
+        let placement =
+            crate::Similarity::about(Vec3::ZERO, glam::Quat::from_rotation_y(0.4), 1.0, Vec3::ZERO);
+        let baked = doc.volume(body).expect("a body").warped(placement);
+        let previous = doc.replace_volume(body, baked).expect("the body is in the document");
+
+        let after: Vec<f32> = (0..64)
+            .map(|step| {
+                let at = Vec3::new(20.0 - step as f32 * 0.5, step as f32 * 0.25 - 8.0, 0.0);
+                doc.volume(body).expect("a body").sample_world(at)
+            })
+            .collect();
+        assert_ne!(after, sampled, "the fixture's transform changed nothing");
+
+        let mut history = History::new(DEFAULT_HISTORY_BUDGET);
+        history.push(Entry::new(vec![Change::WholeVolume { body, volume: Box::new(previous) }]));
+        undo(&mut history, &mut doc);
+
+        let restored: Vec<f32> = (0..64)
+            .map(|step| {
+                let at = Vec3::new(20.0 - step as f32 * 0.5, step as f32 * 0.25 - 8.0, 0.0);
+                doc.volume(body).expect("a body").sample_world(at)
+            })
+            .collect();
+        assert_eq!(restored, sampled, "undoing a bake did not put the field back");
+
+        redo(&mut history, &mut doc);
+        let again: Vec<f32> = (0..64)
+            .map(|step| {
+                let at = Vec3::new(20.0 - step as f32 * 0.5, step as f32 * 0.25 - 8.0, 0.0);
+                doc.volume(body).expect("a body").sample_world(at)
+            })
+            .collect();
+        assert_eq!(again, after, "redo did not put the transform back");
+    }
+
+    /// **Putting the field back is only half of undoing a bake; saying so is
+    /// the other half, and it is the half that was missing.**
+    ///
+    /// A field arrives on the stack with an EMPTY dirty set, because whatever
+    /// remeshed it last drained it. So a swap that marks nothing leaves the
+    /// document holding the original body and the screen holding the moved one
+    /// -- and every subsequent stroke, pick and brush ring then acts on a
+    /// position the user cannot see. Asserting on the field alone is exactly
+    /// what let that through, so this asserts on the dirty set instead, and on
+    /// BOTH sides of the swap: the bricks the field arriving occupies, and the
+    /// bricks the field leaving vacates, which have to remesh to nothing.
+    #[test]
+    fn undoing_a_bake_marks_the_bricks_both_fields_touched() {
+        let (mut doc, _, _) = sculpted();
+        let body = doc.active();
+
+        let before: HashSet<BrickCoord> =
+            doc.volume(body).expect("a body").brick_coords().collect();
+        // Far enough to clear the original footprint entirely, so "the vacated
+        // bricks" is a set the assertion below can actually be about.
+        let moved = doc.volume(body).expect("a body").shifted(glam::IVec3::splat(96));
+        let after: HashSet<BrickCoord> = moved.brick_coords().collect();
+        assert!(
+            before.is_disjoint(&after),
+            "the fixture did not move the body clear of where it was"
+        );
+        let previous = doc.replace_volume(body, moved).expect("the body is in the document");
+
+        let mut history = History::new(DEFAULT_HISTORY_BUDGET);
+        history.push(Entry::new(vec![Change::WholeVolume { body, volume: Box::new(previous) }]));
+
+        // Drained first, so what the assertion sees is what the undo marked.
+        let mut dirty = Vec::new();
+        doc.take_dirty(&mut dirty);
+        undo(&mut history, &mut doc);
+        doc.take_dirty(&mut dirty);
+        let marked: HashSet<BrickCoord> =
+            dirty.iter().filter(|(id, _)| *id == body).map(|(_, coord)| *coord).collect();
+
+        assert!(
+            before.is_subset(&marked),
+            "the field going back in was not scheduled for a remesh, so it stays invisible"
+        );
+        assert!(
+            after.is_subset(&marked),
+            "the bricks the moved field vacated were not scheduled, so its triangles stay on \
+             screen and its pool slices are never handed back"
+        );
+    }
+
+    /// The same for redo, which walks the identical code with the two fields
+    /// the other way round -- and would fail the identical way.
+    #[test]
+    fn redoing_a_bake_marks_the_bricks_both_fields_touched() {
+        let (mut doc, _, _) = sculpted();
+        let body = doc.active();
+
+        let before: HashSet<BrickCoord> =
+            doc.volume(body).expect("a body").brick_coords().collect();
+        let moved = doc.volume(body).expect("a body").shifted(glam::IVec3::splat(96));
+        let after: HashSet<BrickCoord> = moved.brick_coords().collect();
+        let previous = doc.replace_volume(body, moved).expect("the body is in the document");
+
+        let mut history = History::new(DEFAULT_HISTORY_BUDGET);
+        history.push(Entry::new(vec![Change::WholeVolume { body, volume: Box::new(previous) }]));
+        undo(&mut history, &mut doc);
+
+        let mut dirty = Vec::new();
+        doc.take_dirty(&mut dirty);
+        redo(&mut history, &mut doc);
+        doc.take_dirty(&mut dirty);
+        let marked: HashSet<BrickCoord> =
+            dirty.iter().filter(|(id, _)| *id == body).map(|(_, coord)| *coord).collect();
+
+        assert!(before.is_subset(&marked), "redo left the vacated bricks on screen");
+        assert!(after.is_subset(&marked), "redo did not schedule the field it put back");
+    }
+
+    /// **A bake does not clear the undo history.** `Document::rotate` and
+    /// `Document::resample` both leave every older entry naming bricks of a
+    /// volume that no longer exists, so their caller drops the whole stack; the
+    /// gizmo puts the original field ON the stack instead, so undoing the bake
+    /// makes those older coordinates valid again and the stroke behind it still
+    /// applies.
+    #[test]
+    fn a_stroke_behind_a_bake_is_still_undoable_afterwards() {
+        let (mut doc, brush, mut scratch) = sculpted();
+        let body = doc.active();
+
+        let at = Vec3::new(0.0, 25.0, 0.0);
+        let volume = doc.volume_mut(body).expect("a body");
+        volume.begin_stroke();
+        let normal = volume.gradient_world(at);
+        for _ in 0..4 {
+            brush.apply(volume, &Stamp::new(at, normal, BrushDirection::Add), &mut scratch);
+        }
+        let edit = volume.end_stroke().expect("the stroke changed something");
+        let after_stroke = doc.volume(body).expect("a body").sample_world(at);
+
+        let mut history = History::new(DEFAULT_HISTORY_BUDGET);
+        history.push(Entry::stroke(body, edit));
+
+        let moved = doc.volume(body).expect("a body").shifted(glam::IVec3::new(4, 0, 0));
+        let previous = doc.replace_volume(body, moved).expect("the body is in the document");
+        history.push(Entry::new(vec![Change::WholeVolume { body, volume: Box::new(previous) }]));
+
+        // Undo the bake, then the stroke behind it. The second one is the
+        // claim: it names bricks of the field the bake replaced.
+        assert!(matches!(undo(&mut history, &mut doc), UndoOutcome::Applied(_)));
+        assert!(
+            (doc.volume(body).expect("a body").sample_world(at) - after_stroke).abs() < 1.0e-6,
+            "undoing the bake did not restore the sculpted field"
+        );
+        assert!(matches!(undo(&mut history, &mut doc), UndoOutcome::Applied(_)));
+        assert!(
+            doc.volume(body).expect("a body").sample_world(at) > after_stroke,
+            "the stroke behind the bake did not come off"
+        );
+    }
+
+    /// A bake on a hidden body is refused for the same reason a stroke on one
+    /// is: the field would change with nothing on screen saying so.
+    #[test]
+    fn undoing_a_bake_on_a_hidden_body_is_refused() {
+        let (mut doc, _, _) = sculpted();
+        let body = doc.active();
+        let moved = doc.volume(body).expect("a body").shifted(glam::IVec3::new(2, 0, 0));
+        let previous = doc.replace_volume(body, moved).expect("the body is in the document");
+
+        let mut history = History::new(DEFAULT_HISTORY_BUDGET);
+        history.push(Entry::new(vec![Change::WholeVolume { body, volume: Box::new(previous) }]));
+        assert_eq!(history.undo(&mut doc, &[false]), UndoOutcome::Refused(body));
     }
 }

--- a/crates/brokkr-gpu/src/overlay.rs
+++ b/crates/brokkr-gpu/src/overlay.rs
@@ -2,10 +2,11 @@
 
 //! Flat coloured geometry drawn over the sculpt.
 //!
-//! Three consumers share this one pipeline: the brush cursor ring, the mirror
-//! planes, and the navigation cube. Building a mechanism each would have been
-//! three places to get depth and blending wrong, which is the part of this that
-//! is actually difficult — the geometry is a handful of circles and quads.
+//! Four consumers share this one pipeline set: the brush cursor ring, the
+//! mirror planes, the navigation cube, and the transform gizmo. Building a
+//! mechanism each would have been four places to get depth and blending wrong,
+//! which is the part of this that is actually difficult — the geometry is a
+//! handful of circles and quads.
 //!
 //! # Where the geometry comes from
 //!
@@ -26,6 +27,13 @@
 //!   drawn after it and self-occlude where it folds.
 //! * Solids — the navigation cube is opaque and convex and must occlude its own
 //!   far faces, so it both tests and writes depth in its own pass.
+//!
+//! **Still three, and the gizmo is why that sentence is worth keeping.** It was
+//! the fourth consumer and it needed a fourth behaviour — always on top, in the
+//! sculpt's own matrix, self-occluding — and it got it by GENERALISING the
+//! third rather than adding to this list: the cube's own pass became
+//! `SculptRenderer::overlay_pass`, which clears depth and draws solids, and the
+//! gizmo is a second caller of it. The next overlay should do the same.
 
 use glam::Mat4;
 
@@ -81,6 +89,19 @@ impl OverlayBatch {
         colour: [f32; 4],
     ) {
         for point in [a, b, c, a, c, d] {
+            self.surfaces.push(OverlayVertex::new(point, colour));
+        }
+    }
+
+    /// One triangle.
+    ///
+    /// **Not a convenience over [`OverlayBatch::push_quad`], and the gizmo is
+    /// why it exists.** An arrowhead cone and a ring segment are triangle fans,
+    /// and faking a fan out of quads by repeating a vertex emits zero-area
+    /// triangles -- which cost vertices, are invisible, and hide a winding
+    /// mistake because nothing is drawn either way.
+    pub fn push_triangle(&mut self, a: glam::Vec3, b: glam::Vec3, c: glam::Vec3, colour: [f32; 4]) {
+        for point in [a, b, c] {
             self.surfaces.push(OverlayVertex::new(point, colour));
         }
     }

--- a/crates/brokkr-gpu/src/renderer.rs
+++ b/crates/brokkr-gpu/src/renderer.rs
@@ -151,6 +151,15 @@ pub struct SculptRenderer {
     /// extra pipeline objects at startup and saves plumbing a slot index through
     /// every call. Nothing here is hot enough for that trade to matter.
     cube: OverlayRenderer,
+    /// A third overlay for the transform gizmo.
+    ///
+    /// A whole instance again, for the reason `cube` gives, and it earns it for
+    /// a second reason: the gizmo is drawn in the SCULPT's matrix but over the
+    /// sculpt's depth, so it can share neither the cube's matrix nor the
+    /// ring's pass. What it does share is the mechanism -- see
+    /// [`SculptRenderer::overlay_pass`], which the cube's own pass was
+    /// generalised into rather than copied.
+    gizmo: OverlayRenderer,
     bind_group: wgpu::BindGroup,
     uniform_buffer: wgpu::Buffer,
     /// The same uniforms with [`Uniforms::mask_inverted`] complemented, and the
@@ -394,6 +403,7 @@ impl SculptRenderer {
             pipeline,
             overlay: OverlayRenderer::new(device, target_format, DEPTH_FORMAT),
             cube: OverlayRenderer::new(device, target_format, DEPTH_FORMAT),
+            gizmo: OverlayRenderer::new(device, target_format, DEPTH_FORMAT),
             bind_group,
             uniform_buffer,
             opposite_uniform_buffer,
@@ -641,7 +651,7 @@ impl SculptRenderer {
 
     /// Overlay vertices drawn last frame, for the debug readout.
     pub fn overlay_vertices(&self) -> usize {
-        self.overlay.vertex_count() + self.cube.vertex_count()
+        self.overlay.vertex_count() + self.cube.vertex_count() + self.gizmo.vertex_count()
     }
 
     /// Replace the navigation cube's geometry and the matrix it is drawn with.
@@ -655,29 +665,64 @@ impl SculptRenderer {
         self.cube.upload(device, queue, batch, view_projection);
     }
 
-    /// Draw the navigation cube into its corner.
+    /// Replace the transform gizmo's geometry.
     ///
-    /// A pass of its own, because the cube has to be depth tested against
-    /// itself and nothing else: it is drawn over the model wherever it sits, and
-    /// the sculpt's depth values in that corner would otherwise clip it.
+    /// The SCULPT's matrix, not one of its own: the gizmo sits on the body it
+    /// moves, in world space, and only its SIZE is held constant on screen --
+    /// which `brokkr-app` does by scaling the geometry it builds, so that the
+    /// draw and the hit test cannot disagree about how big it is.
+    pub fn write_gizmo(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        batch: &OverlayBatch,
+        view_projection: glam::Mat4,
+    ) {
+        self.gizmo.upload(device, queue, batch, view_projection);
+    }
+
+    /// Draw an overlay OVER the sculpt, in a pass with a depth buffer of its
+    /// own.
     ///
-    /// The depth clear covers the whole attachment rather than the scissor rect,
-    /// which is how wgpu defines it. That is a full screen clear for a 92 pixel
-    /// box, and it is still cheaper and far less fragile than the alternatives
-    /// (a second depth texture cannot be used, since every attachment in a pass
-    /// must share the colour attachment's size).
-    pub fn render_cube(
+    /// **The one always-on-top mechanism, and the reason it is one rather than
+    /// two.** All three of `overlay.rs`'s pipelines compare `Less` against the
+    /// sculpt's depth, which is right for a ring lying on a surface and wrong
+    /// for anything that has to be reachable while buried: the navigation cube
+    /// is drawn over whatever is behind it, and a gizmo on a body's centroid is
+    /// *inside* the mesh. Clearing depth and keeping `Less` is what buys both,
+    /// and it buys correct self-occlusion with it -- an arrowhead over its own
+    /// shaft, three rings crossing -- for nothing. A `depth_compare: Always`
+    /// variant would need the geometry sorted back to front on the CPU every
+    /// time the camera moved.
+    ///
+    /// The cube's pass was generalised into this rather than copied for it,
+    /// which is what `overlay.rs`'s "do not add a fourth mechanism for the next
+    /// overlay" asks for: the next overlay uses the third one.
+    ///
+    /// The depth clear covers the whole attachment rather than the scissor
+    /// rect, which is how wgpu defines it. That is a full screen clear for a 92
+    /// pixel box, and it is still cheaper and far less fragile than the
+    /// alternatives (a second depth texture cannot be used, since every
+    /// attachment in a pass must share the colour attachment's size).
+    ///
+    /// **Correct only while nothing depth-tested is scheduled after it.** Two
+    /// of these run per frame now, and a future pass added below them would
+    /// draw against a cleared buffer with no test to catch it.
+    fn overlay_pass(
         &self,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         clip: PixelRect,
+        label: &str,
+        overlay: &OverlayRenderer,
+        solid_surfaces: bool,
     ) {
-        if clip.width == 0 || clip.height == 0 || self.cube.vertex_count() == 0 {
+        if clip.width == 0 || clip.height == 0 || overlay.vertex_count() == 0 {
             return;
         }
 
         let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("brokkr navigation cube pass"),
+            label: Some(label),
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                 view: target,
                 depth_slice: None,
@@ -705,9 +750,33 @@ impl SculptRenderer {
             1.0,
         );
         pass.set_scissor_rect(clip.x, clip.y, clip.width, clip.height);
+        overlay.draw(&mut pass, solid_surfaces);
+    }
+
+    /// Draw the navigation cube into its corner.
+    pub fn render_cube(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        clip: PixelRect,
+    ) {
         // Solid: the cube is opaque and convex, so it must occlude its own far
         // faces rather than blending with them.
-        self.cube.draw(&mut pass, true);
+        self.overlay_pass(encoder, target, clip, "brokkr navigation cube pass", &self.cube, true);
+    }
+
+    /// Draw the transform gizmo over the whole viewport.
+    ///
+    /// Solid for the same reason the cube is: an arrowhead is an opaque cone
+    /// and a ring is an opaque band, and both have to occlude their own far
+    /// side rather than blending through it.
+    pub fn render_gizmo(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        clip: PixelRect,
+    ) {
+        self.overlay_pass(encoder, target, clip, "brokkr gizmo pass", &self.gizmo, true);
     }
 
     /// Make sure the depth buffer matches the render target.

--- a/crates/brokkr-gpu/tests/offscreen.rs
+++ b/crates/brokkr-gpu/tests/offscreen.rs
@@ -116,6 +116,19 @@ impl Harness {
     /// application does too. A frustum that disagreed with the projection would
     /// show up here as missing geometry.
     fn frame(&self, renderer: &SculptRenderer) -> Vec<u8> {
+        self.frame_inner(renderer, false)
+    }
+
+    /// The same, plus the gizmo's own always-on-top pass.
+    ///
+    /// A second entry point rather than a flag on every call site, because the
+    /// gizmo pass is the only thing in the renderer that CLEARS depth and so
+    /// the only thing whose presence changes what a frame means.
+    fn frame_with_gizmo(&self, renderer: &SculptRenderer) -> Vec<u8> {
+        self.frame_inner(renderer, true)
+    }
+
+    fn frame_inner(&self, renderer: &SculptRenderer, gizmo: bool) -> Vec<u8> {
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("offscreen") });
@@ -146,6 +159,14 @@ impl Harness {
             PixelRect { x: 0, y: 0, width: WIDTH, height: HEIGHT },
             &Frustum::from_view_projection(self.view_projection),
         );
+
+        if gizmo {
+            renderer.render_gizmo(
+                &mut encoder,
+                &self.view,
+                PixelRect { x: 0, y: 0, width: WIDTH, height: HEIGHT },
+            );
+        }
 
         encoder.copy_texture_to_buffer(
             wgpu::TexelCopyTextureInfo {
@@ -1992,4 +2013,146 @@ fn read_back(harness: &Harness, texture: &wgpu::Texture) -> Vec<u8> {
     drop(mapped);
     buffer.unmap();
     pixels
+}
+
+/// **The property the transform gizmo exists on, on a real device.**
+///
+/// A gizmo sits on the body it moves, which means its origin is INSIDE the
+/// mesh. Every one of `overlay.rs`'s three pipelines compares `Less` against
+/// the sculpt's depth, so geometry there is buried and unreachable -- correct
+/// for a brush ring lying on a surface, useless for a control the user has to
+/// grab. `SculptRenderer::overlay_pass` clears depth and keeps `Less`, which is
+/// what makes the gizmo visible while still occluding itself.
+///
+/// Both halves are asserted, and the first is what gives the second meaning:
+/// the same geometry through the ordinary overlay has to be hidden, or the test
+/// would pass just as well if the depth clear did nothing.
+#[test]
+fn a_gizmo_inside_the_model_is_drawn_over_it_where_an_overlay_would_be_buried() {
+    let Some(harness) = Harness::new() else {
+        eprintln!("no usable wgpu adapter, skipping the gizmo render test");
+        return;
+    };
+
+    let distance = MODEL_RADIUS * 3.0;
+    let mut renderer = SculptRenderer::new(&harness.device, &harness.queue, TARGET_FORMAT);
+    renderer.resize(&harness.device, WIDTH, HEIGHT);
+    renderer.write_uniforms(&harness.queue, &uniforms(distance));
+
+    let mut volume = Volume::new(VOXEL_SIZE);
+    volume.seed_sphere(Vec3::ZERO, MODEL_RADIUS);
+    upload_all(&mut renderer, &harness.device, &harness.queue, &mut volume);
+
+    let bare = harness.frame(&renderer);
+    let differing = |a: &[u8], b: &[u8]| {
+        a.as_chunks::<4>()
+            .0
+            .iter()
+            .zip(b.as_chunks::<4>().0.iter())
+            .filter(|(x, y)| x[..3] != y[..3])
+            .count()
+    };
+
+    // A quad at the model's CENTRE, buried under 30 mm of sphere.
+    let toward_eye = Vec3::new(0.45, 0.35, 1.0).normalize();
+    let right = toward_eye.cross(Vec3::Y).normalize();
+    let up = right.cross(toward_eye).normalize();
+    let half = 10.0;
+    let mut batch = OverlayBatch::default();
+    batch.push_quad(
+        -right * half - up * half,
+        right * half - up * half,
+        right * half + up * half,
+        -right * half + up * half,
+        [0.94, 0.35, 0.46, 1.0],
+    );
+
+    // Through the ordinary overlay: buried, which is the behaviour the gizmo
+    // could not live with.
+    renderer.write_overlay(&harness.device, &harness.queue, &batch, view_projection(distance));
+    let buried = harness.frame(&renderer);
+    dump("gizmo-through-the-overlay", &buried);
+    let leaked = differing(&bare, &buried);
+
+    // Through the gizmo's own pass: drawn.
+    renderer.write_overlay(
+        &harness.device,
+        &harness.queue,
+        &OverlayBatch::default(),
+        view_projection(distance),
+    );
+    renderer.write_gizmo(&harness.device, &harness.queue, &batch, view_projection(distance));
+    let shown = harness.frame_with_gizmo(&renderer);
+    dump("gizmo-through-its-own-pass", &shown);
+    let drawn = differing(&bare, &shown);
+
+    assert!(drawn > 2_000, "the gizmo pass drew almost nothing over the model: {drawn} pixels");
+    assert!(
+        leaked < drawn / 10,
+        "the ordinary overlay was not buried after all, so this test proves nothing: \
+         {leaked} pixels against the gizmo pass's {drawn}"
+    );
+}
+
+/// The cleared-depth pass still depth-tests WITHIN itself, which is what gives
+/// an arrowhead over its own shaft and three crossing rings for free.
+///
+/// Without it the answer would be draw order, and the alternative -- a
+/// `depth_compare: Always` pipeline -- would need the geometry sorted back to
+/// front on the CPU every time the camera moved.
+#[test]
+fn the_gizmo_pass_occludes_its_own_far_side() {
+    let Some(harness) = Harness::new() else {
+        eprintln!("no usable wgpu adapter, skipping the gizmo occlusion test");
+        return;
+    };
+
+    let distance = MODEL_RADIUS * 3.0;
+    let mut renderer = SculptRenderer::new(&harness.device, &harness.queue, TARGET_FORMAT);
+    renderer.resize(&harness.device, WIDTH, HEIGHT);
+    renderer.write_uniforms(&harness.queue, &uniforms(distance));
+
+    let toward_eye = Vec3::new(0.45, 0.35, 1.0).normalize();
+    let right = toward_eye.cross(Vec3::Y).normalize();
+    let up = right.cross(toward_eye).normalize();
+    let quad = |batch: &mut OverlayBatch, centre: Vec3, half: f32, colour: [f32; 4]| {
+        batch.push_quad(
+            centre - right * half - up * half,
+            centre + right * half - up * half,
+            centre + right * half + up * half,
+            centre - right * half + up * half,
+            colour,
+        );
+    };
+
+    // A big near quad and a small far one directly behind it, submitted FAR
+    // FIRST so that draw order alone would leave the near one on top anyway...
+    let mut near_first = OverlayBatch::default();
+    quad(&mut near_first, toward_eye * 20.0, 14.0, [0.1, 0.9, 0.3, 1.0]);
+    quad(&mut near_first, toward_eye * -20.0, 6.0, [0.9, 0.1, 0.1, 1.0]);
+    renderer.write_gizmo(&harness.device, &harness.queue, &near_first, view_projection(distance));
+    let near_first_frame = harness.frame_with_gizmo(&renderer);
+
+    // ...and the same pair submitted the other way round. If depth is working,
+    // the two frames are identical; if it is draw order, the small red quad
+    // paints over the green one in exactly one of them.
+    let mut far_first = OverlayBatch::default();
+    quad(&mut far_first, toward_eye * -20.0, 6.0, [0.9, 0.1, 0.1, 1.0]);
+    quad(&mut far_first, toward_eye * 20.0, 14.0, [0.1, 0.9, 0.3, 1.0]);
+    renderer.write_gizmo(&harness.device, &harness.queue, &far_first, view_projection(distance));
+    let far_first_frame = harness.frame_with_gizmo(&renderer);
+    dump("gizmo-self-occlusion", &far_first_frame);
+
+    let differing = near_first_frame
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .zip(far_first_frame.as_chunks::<4>().0.iter())
+        .filter(|(a, b)| a[..3] != b[..3])
+        .count();
+    assert_eq!(
+        differing, 0,
+        "the gizmo pass is resolving overlap by draw order rather than by depth: \
+         {differing} pixels changed when the two quads were submitted the other way round"
+    );
 }

--- a/scripts/drive.py
+++ b/scripts/drive.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Drive the running BrokkrSculpt window with a virtual input device.
+
+There is no ydotool, wtype or dotool on this machine and XTEST silently does
+nothing under KWin Wayland, which is why `scripts/shot.sh` says there is no
+input injection here. That was true of the routes tried; it is not true of
+`/dev/uinput`, which is writable by the `input` group and creates a device the
+kernel and the compositor cannot tell from real hardware.
+
+# Two things that are not obvious and cost a session each
+
+**Absolute, never relative.** libinput accelerates relative motion, so a delta
+of 500 does not travel 500 pixels and nothing ever lands where it was aimed.
+The ABS range is set to the logical desktop union, read from `kscreen-doctor`,
+so a coordinate here is a coordinate on screen.
+
+**Coordinates are WINDOW-LOCAL.** The window moves between sessions and the
+desktop is two outputs at an offset, so a desktop coordinate written down today
+aims at nothing tomorrow. The window's position comes from KWin at run time and
+local coordinates are converted against it. Local (0, 0) is the top-left of the
+window, in the same logical pixels the application lays out in -- so a position
+read off a `shot.sh` capture converts by dividing by the capture's scale
+(1.5 on this desktop: a 1024x768 window captures at 1536x1152).
+
+This device deliberately does NOT advertise `ABS_PRESSURE` or `BTN_TOOL_PEN`
+(how the application recognises a tablet) nor all six of `REL_X`..`REL_RZ` (how
+it recognises a SpaceMouse), so the application under test will not adopt it as
+either and the pen and puck paths stay untouched.
+
+Usage
+-----
+    scripts/drive.py <script-file>          # one command per line
+    scripts/drive.py --geometry             # print the window rectangle
+
+Commands, all coordinates window-local:
+
+    move X Y                    click [left|right|middle]
+    down [button]               up [button]
+    drag X1 Y1 X2 Y2 [steps]    mdrag X1 Y1 X2 Y2 [steps]   # middle: orbits
+    key NAME                    keydown NAME / keyup NAME
+    scroll N                    sleep MS
+
+`#` starts a comment. Key names are in KEYS below; `ctrl+z` is
+`keydown ctrl`, `key z`, `keyup ctrl`.
+"""
+import fcntl
+import os
+import re
+import struct
+import subprocess
+import sys
+import time
+
+UINPUT = "/dev/uinput"
+WINDOW_CLASS = "brokkrsculpt"
+
+EV_SYN, EV_KEY, EV_REL, EV_ABS = 0, 1, 2, 3
+SYN_REPORT = 0
+ABS_X, ABS_Y = 0, 1
+REL_WHEEL = 8
+BTN = {"left": 0x110, "right": 0x111, "middle": 0x112}
+KEYS = {
+    "esc": 1, "1": 2, "2": 3, "3": 4, "4": 5, "5": 6, "6": 7, "7": 8,
+    "q": 16, "w": 17, "e": 18, "r": 19, "t": 20, "y": 21, "u": 22,
+    "s": 31, "f": 33, "z": 44, "x": 45, "c": 46, "v": 47, "m": 50,
+    "ctrl": 29, "shift": 42, "alt": 56, "space": 57, "tab": 15, "enter": 28,
+}
+
+
+def _ioc(direction, typ, nr, size):
+    return (direction << 30) | (size << 16) | (typ << 8) | nr
+
+
+UI_SET_EVBIT = _ioc(1, 0x55, 100, 4)
+UI_SET_KEYBIT = _ioc(1, 0x55, 101, 4)
+UI_SET_RELBIT = _ioc(1, 0x55, 102, 4)
+UI_SET_ABSBIT = _ioc(1, 0x55, 103, 4)
+UI_DEV_CREATE = _ioc(0, 0x55, 1, 0)
+UI_DEV_DESTROY = _ioc(0, 0x55, 2, 0)
+
+
+def desktop_union():
+    """The logical rectangle every output sits inside, from `kscreen-doctor`.
+
+    The ABS range maps onto this, so it has to cover both monitors or the far
+    one is unreachable.
+    """
+    try:
+        out = subprocess.run(
+            ["kscreen-doctor", "-o"], capture_output=True, text=True, timeout=15
+        ).stdout
+    except Exception:
+        return 3840, 2160
+    width = height = 0
+    # Geometry lines look like "Geometry:  786,0 1536x864", with colour codes.
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", out)
+    for x, y, w, h in re.findall(r"Geometry:\s*(\d+),(\d+)\s+(\d+)x(\d+)", plain):
+        width = max(width, int(x) + int(w))
+        height = max(height, int(y) + int(h))
+    return (width or 3840), (height or 2160)
+
+
+def kwin_ask(body):
+    """Ask KWin a question and read the answer out of the journal.
+
+    A KWin script has no return channel -- `print` goes to the journal -- so
+    each question carries a unique marker and finds its own answer by it.
+    Reusing one marker reads a previous run's reply. Same device as
+    `scripts/shot.sh`, which explains it at greater length.
+    """
+    marker = f"drive-{os.getpid()}-{time.time_ns() % 100000}"
+    path = f"/tmp/kwin-drive-{marker}.js"
+    with open(path, "w") as handle:
+        handle.write(f'const MARKER = "{marker}";\n{body}\n')
+    name = f"drive-{marker}"
+    try:
+        ident = subprocess.run(
+            ["qdbus6", "org.kde.KWin", "/Scripting",
+             "org.kde.kwin.Scripting.loadScript", path, name],
+            capture_output=True, text=True, timeout=15,
+        ).stdout.strip()
+        subprocess.run(["qdbus6", "org.kde.KWin", f"/Scripting/Script{ident}",
+                        "org.kde.kwin.Script.run"], capture_output=True, timeout=15)
+        subprocess.run(["qdbus6", "org.kde.KWin", "/Scripting",
+                        "org.kde.kwin.Scripting.unloadScript", name],
+                       capture_output=True, timeout=15)
+        time.sleep(0.3)
+        log = subprocess.run(
+            ["journalctl", "--user", "-b", "--since", "-20s"],
+            capture_output=True, text=True, timeout=20,
+        ).stdout
+        hits = [line for line in log.splitlines() if marker in line]
+        if not hits:
+            return ""
+        return hits[-1].split(marker, 1)[1].strip()
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def window_rect():
+    """Where the application's window is, in logical desktop pixels."""
+    answer = kwin_ask(
+        'for (const w of workspace.windowList()) {'
+        f'  const k = (w.resourceClass || "").toString().toLowerCase();'
+        f'  if (k.includes("{WINDOW_CLASS}")) {{'
+        '    print(MARKER + " " + Math.round(w.frameGeometry.x) + " "'
+        '          + Math.round(w.frameGeometry.y) + " "'
+        '          + Math.round(w.frameGeometry.width) + " "'
+        '          + Math.round(w.frameGeometry.height)); break; }'
+        '}'
+    )
+    parts = answer.split()
+    if len(parts) != 4:
+        raise SystemExit(
+            f"could not find a {WINDOW_CLASS} window through KWin (got {answer!r}) -- "
+            "is the application running?"
+        )
+    return tuple(int(p) for p in parts)
+
+
+def activate():
+    """Bring the window forward, and CHECK that it came.
+
+    Activation is a request, not a guarantee. Every key below goes to whatever
+    is focused, so a failed activation types into the user's terminal instead --
+    which is how a screenshot once showed a brush changed and a mirror plane on
+    that no code had touched.
+    """
+    active = ""
+    # Asked up to three times: raising a window is a request to the compositor
+    # and it loses to a window that is still mapping, or to one that takes focus
+    # back. One attempt reads as "the application is not there".
+    for _ in range(3):
+        kwin_ask(
+            'for (const w of workspace.windowList()) {'
+            f'  const k = (w.resourceClass || "").toString().toLowerCase();'
+            f'  if (k.includes("{WINDOW_CLASS}")) {{ workspace.activeWindow = w;'
+            '    print(MARKER + " ok"); break; }}'
+            '}'
+        )
+        time.sleep(0.8)
+        active = kwin_ask('const a = workspace.activeWindow;'
+                          'print(MARKER + " " + (a ? a.resourceClass : "none"));')
+        if WINDOW_CLASS in active.lower():
+            return
+    raise SystemExit(
+        f"refusing to drive: '{active}' has focus, not {WINDOW_CLASS}. "
+        "Every keystroke would land in it."
+    )
+
+
+class Device:
+    def __init__(self, origin):
+        self.ox, self.oy = origin
+        self.width, self.height = desktop_union()
+        self.fd = os.open(UINPUT, os.O_WRONLY | os.O_NONBLOCK)
+        for ev in (EV_KEY, EV_ABS, EV_REL, EV_SYN):
+            fcntl.ioctl(self.fd, UI_SET_EVBIT, ev)
+        for code in list(BTN.values()) + list(KEYS.values()):
+            fcntl.ioctl(self.fd, UI_SET_KEYBIT, code)
+        for axis in (ABS_X, ABS_Y):
+            fcntl.ioctl(self.fd, UI_SET_ABSBIT, axis)
+        fcntl.ioctl(self.fd, UI_SET_RELBIT, REL_WHEEL)
+
+        absmax = [0] * 64
+        absmax[ABS_X], absmax[ABS_Y] = self.width - 1, self.height - 1
+        os.write(self.fd, struct.pack(
+            "80sHHHHi" + "64i" * 4, b"brokkr-drive", 0x03, 0x1234, 0x5678, 1, 0,
+            *absmax, *([0] * 64), *([0] * 64), *([0] * 64),
+        ))
+        fcntl.ioctl(self.fd, UI_DEV_CREATE)
+        # The compositor has to notice the device before it will route to it.
+        time.sleep(0.5)
+
+    def _emit(self, typ, code, value):
+        os.write(self.fd, struct.pack("llHHi", 0, 0, typ, code, value))
+
+    def _syn(self):
+        self._emit(EV_SYN, SYN_REPORT, 0)
+
+    def move(self, lx, ly):
+        x = max(0, min(self.width - 1, int(round(self.ox + lx))))
+        y = max(0, min(self.height - 1, int(round(self.oy + ly))))
+        self._emit(EV_ABS, ABS_X, x)
+        self._emit(EV_ABS, ABS_Y, y)
+        self._syn()
+        time.sleep(0.012)
+
+    def button(self, name, down):
+        self._emit(EV_KEY, BTN[name], 1 if down else 0)
+        self._syn()
+        time.sleep(0.05)
+
+    def key(self, name, down):
+        if name not in KEYS:
+            raise SystemExit(f"no key code for {name!r}; add it to KEYS")
+        self._emit(EV_KEY, KEYS[name], 1 if down else 0)
+        self._syn()
+        time.sleep(0.04)
+
+    def scroll(self, notches):
+        step = 1 if notches > 0 else -1
+        for _ in range(abs(notches)):
+            self._emit(EV_REL, REL_WHEEL, step)
+            self._syn()
+            time.sleep(0.06)
+
+    def drag(self, x1, y1, x2, y2, steps=24, button="left"):
+        # Many small steps and never one jump: an application tells a drag from
+        # a click by travel, and a single leap reads as neither.
+        self.move(x1, y1)
+        time.sleep(0.15)
+        self.button(button, True)
+        time.sleep(0.12)
+        for i in range(1, steps + 1):
+            t = i / steps
+            self.move(x1 + (x2 - x1) * t, y1 + (y2 - y1) * t)
+        time.sleep(0.15)
+        self.button(button, False)
+        time.sleep(0.25)
+
+    def close(self):
+        time.sleep(0.25)
+        fcntl.ioctl(self.fd, UI_DEV_DESTROY)
+        os.close(self.fd)
+
+
+def run(path):
+    activate()
+    x, y, w, h = window_rect()
+    print(f"window at {x},{y} size {w}x{h}", flush=True)
+    dev = Device((x, y))
+    try:
+        for raw in open(path).read().splitlines():
+            line = raw.split("#")[0].strip()
+            if not line:
+                continue
+            cmd, *args = line.split()
+            if cmd == "move":
+                dev.move(float(args[0]), float(args[1]))
+            elif cmd == "down":
+                dev.button(args[0] if args else "left", True)
+            elif cmd == "up":
+                dev.button(args[0] if args else "left", False)
+            elif cmd == "click":
+                name = args[0] if args else "left"
+                dev.button(name, True)
+                dev.button(name, False)
+            elif cmd in ("drag", "mdrag"):
+                steps = int(args[4]) if len(args) > 4 else 24
+                dev.drag(*[float(a) for a in args[:4]], steps=steps,
+                         button="middle" if cmd == "mdrag" else "left")
+            elif cmd == "key":
+                dev.key(args[0], True)
+                dev.key(args[0], False)
+            elif cmd == "keydown":
+                dev.key(args[0], True)
+            elif cmd == "keyup":
+                dev.key(args[0], False)
+            elif cmd == "scroll":
+                dev.scroll(int(args[0]))
+            elif cmd == "sleep":
+                time.sleep(float(args[0]) / 1000.0)
+            else:
+                raise SystemExit(f"unknown command: {cmd}")
+            print(f"ok: {line}", flush=True)
+    finally:
+        dev.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    if sys.argv[1] == "--geometry":
+        print("%d %d %d %d" % window_rect())
+    else:
+        run(sys.argv[1])


### PR DESCRIPTION
Eight commits: the four that were already on this branch, plus four from a
hardening pass over them.

## Speed

Measured on the largest body `arm_gizmo` will accept (470 MB at 0.07 mm), which
is the release-time bake every gizmo gesture pays for:

| | before | after |
|---|---|---|
| warp | 637 ms | **159 ms** |
| redistance | 20,676 ms | **1,348 ms** |
| **warp + repair** | **21,313 ms** | **1,509 ms — 14.1×** |
| drift after the repair | 0.334–0.364 | **0.054–0.060** |
| resident reclaimed | 2–16% | **25–38%** |

The drift column is the important one: `redistance` declines any body already
within `GRADIENT_TOLERANCE` (0.1) and was leaving every one of these at three to
four times that. It ran, reported success, and left the field outside its own
bar — and at a squash of 0.9 it made the field *worse* than it found it. The
seed was measuring distance along a coordinate axis rather than to the surface.

## Stability

Eighteen defects, four of which were reachable only through a compositor and so
invisible to the suite — this project has shipped a green-but-dead interaction
twice. Among them: undo removed a body from the document and left it drawn;
adding a body with the Transform tool up claimed it was hidden and dropped the
user back to Sculpt; toggling a mirror left its plane a toggle behind; and the
per-axis scale handle pointed 8.49 mm away from where the squash actually went.

## Tests

1,273 → **1,293**. Every fix was checked by disabling it and confirming the new
test goes red — that caught six tests of mine that would otherwise have passed
either way, including one aimed at the single axis a turn leaves fixed and one
that measured a quantity equal by construction.

Two of the audit's own recommendations were **declined** on evidence, both where
a code comment recorded an observed failure the change would have reintroduced,
and four of its claims did not survive testing.

## Not done

The mesh-pool watermark on multi-body documents — a growth curve rather than a
defect met in ordinary work. Full detail, including what was refused and why, is
in the working plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)