### PR TITLE
Stop believing a model that says it is two millimetres across

### DIFF
--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -5635,6 +5635,17 @@ impl Brokkr {
         // `framing` leaves the default lattice behind, and the floor is a
         // number of voxels, so it has to be told the real one.
         self.refresh_camera_lattice();
+        // **The brush is in millimetres and the model just changed size.** The
+        // 3 mm default is a twentieth of the 60 mm starting ball, which is a
+        // brush; against a 200 mm import it is a pin, and against a model that
+        // arrived small it covered the whole thing. Neither is a radius anyone
+        // chose, and both read as the controls being broken rather than as a
+        // slider needing a drag. Held at the same twentieth so the brush means
+        // the same thing whatever was opened.
+        let longest = imported.report.longest_mm;
+        if longest.is_finite() && longest > 0.0 {
+            self.brush.radius = (longest / 20.0).clamp(MIN_RADIUS_MM, self.max_radius());
+        }
         self.history.clear();
         self.history_stats = self.history.stats();
         self.project_path = None;
@@ -8534,6 +8545,16 @@ impl Brokkr {
                             // here instead, or the two will overflow it
                             // between them with nothing reporting it.
                             let options = brokkr_core::voxelise::VoxeliseOptions::at(voxel_size);
+                            // Asked of the MESH, not of the document. The
+                            // document's size is whatever the last thing on
+                            // screen was built at -- 0.25 mm for the starting
+                            // ball -- and inheriting it meant a three million
+                            // triangle model was voxelised at the resolution
+                            // chosen for a sphere, and that the same file
+                            // imported twice gave two different results.
+                            let options = brokkr_core::voxelise::VoxeliseOptions::at(
+                                brokkr_core::voxelise::voxel_for_mesh(&mesh, &options),
+                            );
                             brokkr_core::voxelise::voxelise(&mesh, &options).map(
                                 |(volume, report)| crate::message::Imported {
                                     volume,

--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -3733,8 +3733,9 @@ impl Brokkr {
     /// One row and its whole subtree, prompted on the SUM of what it takes.
     ///
     /// **The prompt is on the SIZE and nothing else**, and the threshold is the
-    /// same 512 MB as the reclaim allowance because a delete that would be
-    /// evicted before it could be undone is exactly the one that has to warn.
+    /// reclaim allowance itself -- named, not copied, so raising one raises the
+    /// other -- because a delete that would be evicted before it could be
+    /// undone is exactly the one that has to warn.
     /// It is measured over the whole subtree, so a folder delete asks about
     /// what it is really taking -- and folders make the prompt the common case
     /// rather than the exception.

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -1784,7 +1784,17 @@ impl Brokkr {
             .height(Length::Fill),
         )
         .padding(theme::S3)
-        .width(Length::Fixed(76.0))
+        // **Wide enough for the labels AND the scrollbar.** 76 was measured
+        // against a strip that did not have one. Making it scrollable took a
+        // scrollbar's width out of the content -- iced spends it from the
+        // inside rather than overlaying -- and the labels under the icons lost
+        // exactly that much: "Flatten" and "Smooth" came back clipped, which
+        // reads as a rendering fault rather than as a strip that is too narrow.
+        //
+        // The words are the reason this column is not eighteen pixels of icon
+        // in the first place, per the note above, so they set the width and the
+        // scrollbar is added to it rather than taken out of it.
+        .width(Length::Fixed(92.0))
         .height(Length::Fill)
         .style(theme::tool_strip)
         .into()

--- a/crates/brokkr-core/src/brick.rs
+++ b/crates/brokkr-core/src/brick.rs
@@ -176,6 +176,143 @@ impl Brick {
     }
 }
 
+/// A brick as undo history keeps it: run length encoded, never read directly.
+///
+/// **Measured before it was written.** On a 3,100,109 triangle import at
+/// 0.168 mm, the 4,265 dense bricks hold 533.1 MB and **86.8% of their voxels
+/// are saturated** at `INSIDE` or `OUTSIDE` -- a narrow band field is a thin
+/// shell of varying distance wrapped in two enormous constants. Encoded as
+/// runs the same bricks come to 121.5 MB, **4.39x smaller**, which is what buys
+/// the undo depth: the stroke budget holds four times the strokes for the same
+/// bytes, and a body that could not be moved at all now fits with room over.
+///
+/// **History only, never the live volume.** Sculpting needs random access to
+/// every voxel and a run table cannot give it without a search; the live
+/// [`Brick`] is untouched and no edit path pays anything for this. The cost is
+/// one pass over a brick when it enters history and one when it leaves, which
+/// is the same order as the memcpy it replaces.
+///
+/// Runs are `(f32, u16)` packed as six bytes with no padding -- a `struct` of
+/// those two would be eight, aligned, and throw away a quarter of the saving.
+/// A run is capped at `u16::MAX`, which is twice `BRICK_VOXELS`, so the cap can
+/// never split a run that a uniform brick would not have collapsed already.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StoredBrick {
+    /// Every voxel holds this value; the tile case, free as it is live.
+    Uniform(f32),
+    /// Six bytes per run: little endian `f32` value, little endian `u16` count.
+    Runs(Box<[u8]>),
+    /// Verbatim, for a brick the run table would make BIGGER.
+    ///
+    /// **A run is six bytes and a voxel is four**, so a brick where no two
+    /// neighbours share a value encodes to 1.5x its own size. Real geometry
+    /// never does that -- 86.8% of voxels are saturated -- but "never on the
+    /// data I measured" is not a bound, and an encoder that can lose is one
+    /// that will lose on the one model that matters. Whichever is smaller
+    /// wins, so this is at worst exactly what it replaced.
+    Dense(Box<[f32; BRICK_VOXELS]>),
+}
+
+/// Bytes one run occupies: an `f32` and a `u16`, packed.
+const RUN_BYTES: usize = 6;
+
+impl StoredBrick {
+    /// Encode a live brick for history.
+    pub fn encode(brick: &Brick) -> Self {
+        let values = match brick {
+            Brick::Uniform(value) => return StoredBrick::Uniform(*value),
+            Brick::Dense(values) => values,
+        };
+        let mut runs: Vec<u8> = Vec::with_capacity(1024);
+        let mut current = values[0];
+        let mut count: u32 = 1;
+        // Compared by BITS, not by value: two NaNs that differ in payload are
+        // different voxels to a bit for bit restore, and `-0.0 == 0.0` would
+        // silently merge two values a later read can tell apart.
+        for value in values.iter().skip(1) {
+            if value.to_bits() == current.to_bits() && count < u16::MAX as u32 {
+                count += 1;
+            } else {
+                runs.extend_from_slice(&current.to_le_bytes());
+                runs.extend_from_slice(&(count as u16).to_le_bytes());
+                current = *value;
+                count = 1;
+            }
+        }
+        runs.extend_from_slice(&current.to_le_bytes());
+        runs.extend_from_slice(&(count as u16).to_le_bytes());
+        if runs.len() >= BRICK_VOXELS * size_of::<f32>() {
+            return StoredBrick::Dense(Box::new(**values));
+        }
+        runs.shrink_to_fit();
+        StoredBrick::Runs(runs.into_boxed_slice())
+    }
+
+    /// Rebuild the live brick this was encoded from, bit for bit.
+    pub fn decode(&self) -> Brick {
+        let runs = match self {
+            StoredBrick::Uniform(value) => return Brick::Uniform(*value),
+            StoredBrick::Dense(values) => return Brick::Dense(Box::new(**values)),
+            StoredBrick::Runs(runs) => runs,
+        };
+        let mut values: Vec<f32> = Vec::with_capacity(BRICK_VOXELS);
+        let (runs, _) = runs.as_chunks::<RUN_BYTES>();
+        for run in runs {
+            let value = f32::from_le_bytes([run[0], run[1], run[2], run[3]]);
+            let count = u16::from_le_bytes([run[4], run[5]]) as usize;
+            values.resize(values.len() + count, value);
+        }
+        debug_assert_eq!(values.len(), BRICK_VOXELS, "a run table decoded to the wrong length");
+        // A table that decoded short would index out of bounds later, which is
+        // a corrupted undo rather than a panic anyone can act on. Pad rather
+        // than trust: `OUTSIDE` is what an absent voxel already reads as.
+        values.resize(BRICK_VOXELS, OUTSIDE);
+        let data: Box<[f32]> = values.into_boxed_slice();
+        let data: Box<[f32; BRICK_VOXELS]> = data.try_into().expect("length is BRICK_VOXELS");
+        Brick::Dense(data)
+    }
+
+    /// What this costs the budget that holds it.
+    pub fn heap_bytes(&self) -> usize {
+        match self {
+            StoredBrick::Uniform(_) => 0,
+            StoredBrick::Runs(runs) => runs.len(),
+            StoredBrick::Dense(_) => BRICK_VOXELS * size_of::<f32>(),
+        }
+    }
+}
+
+impl Brick {
+    /// What this brick WOULD cost in history, without encoding it.
+    ///
+    /// For the planners that have to quote a gesture's undo weight before
+    /// running it -- `merge` prices a whole body this way. Counting runs is the
+    /// same pass `StoredBrick::encode` makes and allocates nothing, and it has
+    /// to be the encoder's own arithmetic rather than a ratio: a 4.39x average
+    /// applied to a brick that happens to be all shell would under-quote it,
+    /// and the budget it is quoting against is the one that decides whether the
+    /// gesture is offered at all.
+    pub fn encoded_bytes(&self) -> usize {
+        let values = match self {
+            Brick::Uniform(_) => return 0,
+            Brick::Dense(values) => values,
+        };
+        let mut runs = 1usize;
+        let mut count: u32 = 1;
+        let mut current = values[0];
+        for value in values.iter().skip(1) {
+            if value.to_bits() == current.to_bits() && count < u16::MAX as u32 {
+                count += 1;
+            } else {
+                runs += 1;
+                current = *value;
+                count = 1;
+            }
+        }
+        (runs * RUN_BYTES).min(BRICK_VOXELS * size_of::<f32>())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/brokkr-core/src/brush.rs
+++ b/crates/brokkr-core/src/brush.rs
@@ -3986,6 +3986,71 @@ mod move_tests {
     /// The mask here is fully protected and nowhere near the brush, so the
     /// per voxel multiply is 1.0 everywhere the gesture writes: what is being
     /// measured is the cap and nothing else.
+
+    /// **A mask must travel with the material, not sit in the air waiting.**
+    ///
+    /// Reported from the running app: with the rest of a hand masked, dragging
+    /// a finger towards the ring made the finger "inherit mask while moving --
+    /// like there is a sticky mask in the air there". It is exactly that. The
+    /// warp resamples the FIELD from `position - displacement * free` and never
+    /// touches the mask, so a voxel's protection is whatever happened to be at
+    /// the place the material arrived at. Drag unmasked material into masked
+    /// space and it comes out masked, and no further stroke will touch it.
+    ///
+    /// `Volume::warped` -- the whole-body version of this same domain warp --
+    /// carries the mask through it, and so do `shifted`, `rotated` and
+    /// `resampled`, each with a test saying so. The brush was the one warp that
+    /// did not.
+    ///
+    /// A PARTIAL mask ahead of the drag rather than a full one, because `free`
+    /// scales the displacement: fully protected space admits no material at
+    /// all, so the bug cannot be shown there. Half protected is where material
+    /// arrives AND protection is waiting for it.
+    ///
+    /// **Reproduction, not yet a fix.** Ignored so the suite stays green while
+    /// it stands as the executable description of the bug. Making it pass means
+    /// locking a snapshot of the MASK beside the field and warping both by the
+    /// one displacement -- `edit_voxels_where` hands the warp
+    /// `(position, value, free)` and takes back a single `f32`, so there is no
+    /// seam to write a mask through today. It also has to settle which mask
+    /// scales the displacement: `free` is read live at the DESTINATION, which
+    /// is why half-masked air brakes part of a finger and tears it, and the
+    /// source's own protection is the defensible answer. The file's own warning
+    /// -- the mask is read fresh per event while the copy is locked once -- is
+    /// exactly the trap that change has to avoid.
+    #[test]
+    #[ignore = "reproduces the sticky-mask-in-the-air bug; the warp does not carry the mask yet"]
+    fn material_dragged_into_masked_space_does_not_pick_up_its_mask() {
+        let brush = Brush { kind: BrushKind::Move, radius: 9.0, strength: 0.8, ..Brush::default() };
+        let at = Vec3::new(24.0, 0.0, 0.0);
+        let mut volume = sphere_with_a_bump();
+
+        // Empty space just off the bump, half protected, in the direction the
+        // drag will carry the material.
+        let ahead = IVec3::new(34, 0, 0);
+        assert_eq!(volume.mask().at(ahead), UNMASKED, "the fixture starts unmasked");
+        for x in 30..40 {
+            for y in -6..6 {
+                for z in -6..6 {
+                    volume.mask_mut().write(IVec3::new(x, y, z), PROTECTED / 2);
+                }
+            }
+        }
+
+        let mut stroke = MoveStroke::new();
+        stroke.begin(&volume, &brush, at, Symmetry::OFF, Vec3::ZERO);
+        stroke.drag_to(&mut volume, at + Vec3::X * 8.0, 1.0);
+        stroke.end();
+
+        // The material that arrived brought its own protection with it, which
+        // was none. Not the half-mask that was hanging in the air.
+        assert!(
+            volume.mask().at(ahead) < PROTECTED / 4,
+            "unmasked material dragged into masked space came out masked: {} at {ahead:?}",
+            volume.mask().at(ahead)
+        );
+    }
+
     #[test]
     fn a_masked_body_gives_a_move_gesture_half_the_drag_cap() {
         let brush = Brush { kind: BrushKind::Move, radius: 9.0, strength: 0.8, ..Brush::default() };

--- a/crates/brokkr-core/src/brush.rs
+++ b/crates/brokkr-core/src/brush.rs
@@ -3986,6 +3986,39 @@ mod move_tests {
     /// The mask here is fully protected and nowhere near the brush, so the
     /// per voxel multiply is 1.0 everywhere the gesture writes: what is being
     /// measured is the cap and nothing else.
+    #[test]
+    fn a_masked_body_gives_a_move_gesture_half_the_drag_cap() {
+        let brush = Brush { kind: BrushKind::Move, radius: 9.0, strength: 0.8, ..Brush::default() };
+        let at = Vec3::new(24.0, 0.0, 0.0);
+        // Far past the cap, so both gestures clamp and it is the clamp being
+        // compared rather than the pointer.
+        let far = at + Vec3::Y * 200.0;
+
+        let reach = |mask: bool| {
+            let mut volume = sphere_with_a_bump();
+            if mask {
+                volume.mask_mut().write(IVec3::new(400, 400, 400), PROTECTED);
+            }
+            let mut stroke = MoveStroke::new();
+            stroke.begin(&volume, &brush, at, Symmetry::OFF, Vec3::ZERO);
+            stroke.drag_to(&mut volume, far, 1.0);
+            let applied = stroke.applied().length();
+            stroke.end();
+            applied
+        };
+
+        let unmasked = reach(false);
+        let masked = reach(true);
+        assert!(
+            (unmasked - brush.max_drag()).abs() < 1.0e-4,
+            "the unmasked gesture did not reach its own cap: {unmasked} against {}",
+            brush.max_drag()
+        );
+        assert!(
+            (masked - unmasked * 0.5).abs() < 1.0e-4,
+            "a masked body did not halve the drag cap: {masked} against {unmasked} unmasked"
+        );
+    }
 
     /// **A mask must travel with the material, not sit in the air waiting.**
     ///
@@ -4048,40 +4081,6 @@ mod move_tests {
             volume.mask().at(ahead) < PROTECTED / 4,
             "unmasked material dragged into masked space came out masked: {} at {ahead:?}",
             volume.mask().at(ahead)
-        );
-    }
-
-    #[test]
-    fn a_masked_body_gives_a_move_gesture_half_the_drag_cap() {
-        let brush = Brush { kind: BrushKind::Move, radius: 9.0, strength: 0.8, ..Brush::default() };
-        let at = Vec3::new(24.0, 0.0, 0.0);
-        // Far past the cap, so both gestures clamp and it is the clamp being
-        // compared rather than the pointer.
-        let far = at + Vec3::Y * 200.0;
-
-        let reach = |mask: bool| {
-            let mut volume = sphere_with_a_bump();
-            if mask {
-                volume.mask_mut().write(IVec3::new(400, 400, 400), PROTECTED);
-            }
-            let mut stroke = MoveStroke::new();
-            stroke.begin(&volume, &brush, at, Symmetry::OFF, Vec3::ZERO);
-            stroke.drag_to(&mut volume, far, 1.0);
-            let applied = stroke.applied().length();
-            stroke.end();
-            applied
-        };
-
-        let unmasked = reach(false);
-        let masked = reach(true);
-        assert!(
-            (unmasked - brush.max_drag()).abs() < 1.0e-4,
-            "the unmasked gesture did not reach its own cap: {unmasked} against {}",
-            brush.max_drag()
-        );
-        assert!(
-            (masked - unmasked * 0.5).abs() < 1.0e-4,
-            "a masked body did not halve the drag cap: {masked} against {unmasked} unmasked"
         );
     }
 

--- a/crates/brokkr-core/src/brush.rs
+++ b/crates/brokkr-core/src/brush.rs
@@ -1500,6 +1500,24 @@ impl LockedFills {
 struct Locked {
     field: FieldRegion,
     fills: LockedFills,
+    /// The mask over the same box, snapshotted with the field.
+    ///
+    /// **Both warps read from the lock, which is what makes the gesture a pure
+    /// function of the drag.** `free` used to be read LIVE at the destination
+    /// voxel; once the warp writes the mask, a live read would feed the next
+    /// event a mask this event moved, and the displacement would drift while
+    /// the pointer stood still. That is the accumulation this file's own
+    /// warning is about. Locked, both fields resample from the same frozen
+    /// pair by the same displacement, so dragging out and back returns the
+    /// mask exactly as it returns the form.
+    ///
+    /// A `FieldRegion` and not a `u8` twin, for the reason
+    /// `Volume::snapshot_mask` already gives: it exists, it is tested, and it
+    /// samples.
+    mask: FieldRegion,
+    /// False when the body carries no mask at all, so the second pass and the
+    /// per voxel multiply are both skipped entirely.
+    masked: bool,
 }
 
 /// A Move gesture, holding the field as it stood when the button went down.
@@ -1683,6 +1701,12 @@ impl MoveStroke {
             volume.snapshot(read_lo, read_hi, &mut locked.field);
             let (stored_lo, stored_hi) = locked.field.bounds();
             locked.fills.build(volume, stored_lo, stored_hi);
+            // Only when there is one. An unmasked body pays nothing for any of
+            // this: no snapshot, no second pass, no multiply.
+            locked.masked = !volume.mask().is_free();
+            if locked.masked {
+                volume.snapshot_mask(read_lo, read_hi, &mut locked.mask);
+            }
         }
     }
 
@@ -1804,13 +1828,27 @@ impl MoveStroke {
             // Zero reach: this never answers `OnlyNearDifferentNeighbours`,
             // because what it has to prove is about the locked copy and not
             // about the brick's neighbours in the volume.
+            let masked = locked.masked;
+            let locked_mask = &locked.mask;
+            // `use_mask` stays ON -- it is what gives `decide` a resolved
+            // `preview.mask`, and a fully protected brick has to keep being
+            // skipped whole. Only the per voxel multiply is taken from the
+            // LOCKED mask instead of the live one: the second pass below moves
+            // the mask, and a live read would feed the next event a mask this
+            // event had just moved, so the drag would creep while the pointer
+            // stood still. That is the accumulation this file warns about.
             volume.edit_voxels_where(
                 anchor.lo,
                 anchor.hi,
                 0,
                 true,
                 decide,
-                |_, position, value, free| {
+                |voxel, position, value, _| {
+                    let free = if masked {
+                        1.0 - (locked_mask.get(voxel) / PROTECTED as f32).clamp(0.0, 1.0)
+                    } else {
+                        1.0
+                    };
                     // Explicitly, and not by way of a zero displacement. A zero
                     // displacement makes the warp resample the LOCKED COPY at
                     // the voxel, which is the value at lock time rather than the
@@ -1850,6 +1888,53 @@ impl MoveStroke {
                     field.sample((position - displacement * free) / voxel_size)
                 },
             );
+
+            // **The mask travels with the material.** Reported as a mask that
+            // hangs in the air: drag an unmasked finger towards a masked ring
+            // and the finger arrives masked, because the warp moved the field
+            // and left protection nailed to the lattice. Every other warp in
+            // the workspace carries the mask -- `shifted`, `rotated`,
+            // `resampled` and `warped` all do, each with a test -- and this was
+            // the one that did not.
+            //
+            // The same displacement and the same `free`, resampled from the
+            // same lock, so the two fields cannot come apart. Second pass
+            // rather than folded into the first because `edit_voxels_where`
+            // hands back one `f32` per voxel and that one is the field's.
+            if masked {
+                let (lo, hi) = (anchor.lo, anchor.hi);
+                for z in lo.z..=hi.z {
+                    for y in lo.y..=hi.y {
+                        for x in lo.x..=hi.x {
+                            let voxel = IVec3::new(x, y, z);
+                            let free =
+                                1.0 - (locked_mask.get(voxel) / PROTECTED as f32).clamp(0.0, 1.0);
+                            if free <= 0.0 {
+                                // Protected voxels do not move, so their
+                                // protection does not either. Skipping is not
+                                // an optimisation: writing them would resample
+                                // at zero displacement and could round a
+                                // saturated byte down off PROTECTED.
+                                continue;
+                            }
+                            let position = voxel.as_vec3() * voxel_size;
+                            let Some(displacement) = move_displacement(
+                                anchors,
+                                drag,
+                                position,
+                                inverse_radius,
+                                falloff,
+                                cap,
+                            ) else {
+                                continue;
+                            };
+                            let from = (position - displacement * free) / voxel_size;
+                            let carried = locked_mask.sample(from).clamp(0.0, PROTECTED as f32);
+                            volume.mask_mut().write(voxel, carried.round() as u8);
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -4040,29 +4125,27 @@ mod move_tests {
     /// all, so the bug cannot be shown there. Half protected is where material
     /// arrives AND protection is waiting for it.
     ///
-    /// **Reproduction, not yet a fix.** Ignored so the suite stays green while
-    /// it stands as the executable description of the bug. Making it pass means
-    /// locking a snapshot of the MASK beside the field and warping both by the
-    /// one displacement -- `edit_voxels_where` hands the warp
-    /// `(position, value, free)` and takes back a single `f32`, so there is no
-    /// seam to write a mask through today. It also has to settle which mask
-    /// scales the displacement: `free` is read live at the DESTINATION, which
-    /// is why half-masked air brakes part of a finger and tears it, and the
-    /// source's own protection is the defensible answer. The file's own warning
-    /// -- the mask is read fresh per event while the copy is locked once -- is
-    /// exactly the trap that change has to avoid.
+    /// **The LEADING EDGE is the only place this can be seen**, and that is the
+    /// test rather than an accident of it. A voxel deep inside the masked slab
+    /// is fed by material that was itself masked, so 127 there is the right
+    /// answer; only where unmasked material crosses in does the mask have to
+    /// give way. Measured on this fixture: the edge voxel goes 127 -> 43 with
+    /// the fix and stays at 127 without it, because without it nothing writes
+    /// the mask at all.
     #[test]
-    #[ignore = "reproduces the sticky-mask-in-the-air bug; the warp does not carry the mask yet"]
     fn material_dragged_into_masked_space_does_not_pick_up_its_mask() {
         let brush = Brush { kind: BrushKind::Move, radius: 9.0, strength: 0.8, ..Brush::default() };
         let at = Vec3::new(24.0, 0.0, 0.0);
         let mut volume = sphere_with_a_bump();
 
-        // Empty space just off the bump, half protected, in the direction the
-        // drag will carry the material.
-        let ahead = IVec3::new(34, 0, 0);
+        // The near edge of the masked slab: inside the brush box, which at
+        // radius 9 about x=24 is x in 15..=33, and the first voxel unmasked
+        // material reaches. A voxel past the box is never visited by the warp
+        // at all and one deeper in is fed by masked material, so neither would
+        // prove anything.
+        let ahead = IVec3::new(28, 0, 0);
         assert_eq!(volume.mask().at(ahead), UNMASKED, "the fixture starts unmasked");
-        for x in 30..40 {
+        for x in 28..40 {
             for y in -6..6 {
                 for z in -6..6 {
                     volume.mask_mut().write(IVec3::new(x, y, z), PROTECTED / 2);

--- a/crates/brokkr-core/src/merge.rs
+++ b/crates/brokkr-core/src/merge.rs
@@ -60,7 +60,7 @@
 
 use crate::body::{Document, NodeId};
 use crate::brick::{BRICK_VOXELS, Brick, INSIDE, OUTSIDE};
-use crate::undo::{Change, Entry, prior_bytes, removed_node_bytes};
+use crate::undo::{Change, Entry, predicted_prior_bytes, removed_node_bytes};
 use crate::volume::Volume;
 
 /// What the union does to one brick of the shared lattice.
@@ -405,7 +405,7 @@ impl Document {
                 continue;
             }
             bricks += 1;
-            stroke_bytes += prior_bytes(prior);
+            stroke_bytes += predicted_prior_bytes(prior);
         }
 
         let reclaim_bytes = self.node(source).map_or(0, removed_node_bytes);
@@ -473,6 +473,7 @@ mod tests {
     use super::*;
     use crate::brick::{BRICK_DIM, BrickCoord};
     use crate::undo::History;
+    use crate::undo::prior_bytes;
 
     const VOXEL: f32 = 0.5;
 

--- a/crates/brokkr-core/src/redistance.rs
+++ b/crates/brokkr-core/src/redistance.rs
@@ -251,7 +251,8 @@ impl Volume {
         // `Vec<(BrickCoord, Brick)>` over every dense brick duplicates the
         // field at 128 KB a brick, which would take `rebake_gizmo`'s deliberate
         // two live copies to three -- about 1.4 GB on the bench's 470 MB row,
-        // on a path whose arm limit is 512 MB. At most an eighth is staged
+        // on a path whose arm limit is the reclaim allowance, now 1 GB. At most
+        // an eighth is staged
         // here.
         let mut by_colour: [Vec<BrickCoord>; 8] = Default::default();
         for coord in &coords {

--- a/crates/brokkr-core/src/undo.rs
+++ b/crates/brokkr-core/src/undo.rs
@@ -88,13 +88,27 @@ pub const DEFAULT_HISTORY_BUDGET: usize = 256 * 1024 * 1024;
 /// Default ceiling on the volumes undo history is holding on BEHALF of deleted
 /// bodies, separate from [`DEFAULT_HISTORY_BUDGET`].
 ///
-/// **512 MB is also the threshold at which deleting a body prompts with its
-/// size, and that is one number rather than two that happen to coincide**: a
-/// delete which would be evicted before it could be undone is exactly the
-/// delete that has to warn first. Forty modest 20 MB bodies is 800 MB against
-/// this allowance with no single body anywhere near it, which is why the
-/// eviction itself also has to say something -- see [`HistoryStats::dropped_bodies`].
-pub const DEFAULT_RECLAIM_BUDGET: usize = 512 * 1024 * 1024;
+/// **Also the threshold at which deleting a body prompts with its size, and
+/// that is one number rather than two that happen to coincide**: a delete which
+/// would be evicted before it could be undone is exactly the delete that has to
+/// warn first. Forty modest 20 MB bodies is 800 MB against this allowance with
+/// no single body anywhere near it, which is why the eviction itself also has
+/// to say something -- see [`HistoryStats::dropped_bodies`].
+///
+/// **A gigabyte, raised from half of one.** The number was set when an import
+/// took the document's own voxel size; once an import chose its own, a
+/// 3,100,109 triangle model came in at 0.168 mm and 537 MB -- five percent over
+/// the old allowance, so the gizmo refused to arm and the model could not be
+/// moved at all. Half a gigabyte stopped being "larger than any body a session
+/// will hold" the moment imports started resolving what the file contains.
+///
+/// This raises the combined history ceiling to 1.25 GB, which the module doc
+/// above discusses and which the volume guard still cannot see. It buys room
+/// rather than fixing the cost: a move's entry is a copy of the WHOLE field
+/// because a transform rewrites every voxel, and the entry that would not be a
+/// copy -- an exactly invertible move recorded as its inverse -- is the real
+/// answer and is tracked separately.
+pub const DEFAULT_RECLAIM_BUDGET: usize = 1024 * 1024 * 1024;
 
 /// The prior contents of every brick one stroke changed.
 ///

--- a/crates/brokkr-core/src/undo.rs
+++ b/crates/brokkr-core/src/undo.rs
@@ -74,7 +74,7 @@ use std::collections::VecDeque;
 use rustc_hash::FxHashMap;
 
 use crate::body::{Document, Node, NodeId, NodeMeta};
-use crate::brick::{Brick, BrickCoord};
+use crate::brick::{Brick, BrickCoord, StoredBrick};
 use crate::mask::{MaskBrick, MaskField};
 use crate::volume::Volume;
 
@@ -139,9 +139,13 @@ pub struct StrokeEdit {
     bytes: usize,
 }
 
-/// The prior contents of a set of field bricks. `None` is a brick that did not
-/// exist, which undo puts back by removing it again.
-type PriorBricks = Vec<(BrickCoord, Option<Brick>)>;
+/// The prior contents of a set of field bricks, run length encoded. `None` is
+/// a brick that did not exist, which undo puts back by removing it again.
+///
+/// [`StoredBrick`] rather than [`Brick`] because a narrow band field is 86.8%
+/// saturated and encodes 4.39x smaller -- see that type for the measurement.
+/// The budget below is unchanged and now holds four times as many strokes.
+type PriorBricks = Vec<(BrickCoord, Option<StoredBrick>)>;
 
 /// The same for mask bricks. Named alongside [`PriorBricks`] rather than
 /// written out: the two differ by one word deep inside a nested generic, and
@@ -158,7 +162,13 @@ impl StrokeEdit {
         if bricks.is_empty() && masks.is_empty() && polarity.is_none() {
             return None;
         }
-        Some(Self::from_parts(bricks.into_iter().collect(), masks.into_iter().collect(), polarity))
+        // Encoded here, at the one place a stroke's priors enter history, so
+        // no caller has to remember to and no path can store a raw brick.
+        let encoded: PriorBricks = bricks
+            .into_iter()
+            .map(|(coord, brick)| (coord, brick.as_ref().map(StoredBrick::encode)))
+            .collect();
+        Some(Self::from_parts(encoded, masks.into_iter().collect(), polarity))
     }
 
     /// An entry that puts back field bricks and nothing else.
@@ -221,8 +231,12 @@ impl StrokeEdit {
 /// has not recorded yet and the prediction is only worth having while it is
 /// exact. Two copies of this formula would drift and nothing would say so.
 #[inline]
-pub(crate) fn prior_bytes(prior: Option<&Brick>) -> usize {
-    size_of::<(BrickCoord, Option<Brick>)>() + prior.map_or(0, Brick::heap_bytes)
+pub(crate) fn predicted_prior_bytes(prior: Option<&Brick>) -> usize {
+    size_of::<(BrickCoord, Option<StoredBrick>)>() + prior.map_or(0, Brick::encoded_bytes)
+}
+
+pub(crate) fn prior_bytes(prior: Option<&StoredBrick>) -> usize {
+    size_of::<(BrickCoord, Option<StoredBrick>)>() + prior.map_or(0, StoredBrick::heap_bytes)
 }
 
 /// What one mask brick's prior contents cost the stroke budget.
@@ -885,6 +899,22 @@ mod tests {
     use glam::Vec3;
     use std::collections::HashSet;
 
+    /// A brick no encoder can shrink, for the budget and eviction fixtures.
+    ///
+    /// **Not `dense_filled`.** A brick of one repeated value is one run and six
+    /// bytes now, so a fixture built from those puts nothing against the budget
+    /// and the eviction it is checking never happens -- the test passes by
+    /// proving history is empty. Every voxel different is the worst case the
+    /// `Dense` fallback exists for, which is also the weight these budgets were
+    /// written against: 131,104 bytes an entry.
+    fn incompressible_brick() -> Brick {
+        let mut values = Box::new([0.0f32; crate::BRICK_VOXELS]);
+        for (index, slot) in values.iter_mut().enumerate() {
+            *slot = f32::from_bits(0x3f00_0000 | (index as u32 & 0xffff));
+        }
+        Brick::Dense(values)
+    }
+
     fn sculpted() -> (Document, Brush, BrushScratch) {
         let mut doc = Document::new(1.0);
         doc.active_volume_mut().seed_sphere(Vec3::ZERO, 24.0);
@@ -1176,7 +1206,7 @@ mod tests {
         for index in 0..STROKES {
             let coord = BrickCoord::new(index as i32, 0, 0);
             let volume = doc.volume_mut(body).expect("the starting body");
-            volume.insert_brick(coord, Brick::dense_filled(0.5));
+            volume.insert_brick(coord, incompressible_brick());
             history.push(Entry::stroke(body, StrokeEdit::from_bricks(vec![(coord, None)])));
         }
         assert_eq!(history.stats().undo_entries, STROKES, "a push evicted something");
@@ -1219,7 +1249,7 @@ mod tests {
         let mut history = History::new(BUDGET);
         for coord in coords {
             let volume = doc.volume_mut(body).expect("the starting body");
-            volume.insert_brick(coord, Brick::dense_filled(0.5));
+            volume.insert_brick(coord, incompressible_brick());
             history.push(Entry::stroke(body, StrokeEdit::from_bricks(vec![(coord, None)])));
         }
         assert_eq!(history.stats().undo_entries, 3, "a push evicted something");
@@ -1272,7 +1302,7 @@ mod tests {
         let mut history = History::new(BUDGET);
         for coord in [older, newest] {
             let volume = doc.volume_mut(body).expect("the starting body");
-            volume.insert_brick(coord, Brick::dense_filled(0.5));
+            volume.insert_brick(coord, incompressible_brick());
             history.push(Entry::stroke(body, StrokeEdit::from_bricks(vec![(coord, None)])));
         }
         assert_eq!(history.stats().undo_entries, 2, "a push evicted something");
@@ -1633,23 +1663,95 @@ mod tests {
 
     // --- the mask half of an entry -------------------------------------------
 
-    /// A mask entry weighs a quarter of a sculpt entry, **to the byte**.
+    /// A mask entry weighs a quarter of an UNCOMPRESSED sculpt entry, **to the
+    /// byte**, and a sculpt entry no longer weighs that.
     ///
     /// Both numbers rather than the ratio between them, and that is not
     /// pedantry: a ratio passes on a mask brick that collapsed to a tile, which
     /// costs no heap at all, and it passes on an entry that recorded no mask
-    /// bricks. 32 + 32,768 against 32 + 131,072 is the arithmetic the whole
-    /// "+25% storage" argument for eight bits rests on, and it is checked here
-    /// because this is where the undo budget reads it.
+    /// bricks. 32 + 32,768 is the arithmetic the whole "+25% storage" argument
+    /// for eight bits rests on, and it is checked here because this is where
+    /// the undo budget reads it.
+    ///
+    /// The field half is now the ENCODED size. A brick of one repeated value
+    /// is one run -- six bytes -- which is the best case and shows the encoder
+    /// is actually running; the average on real geometry is 4.39x, not 21,845x.
+    /// `an_encoded_brick_restores_bit_for_bit` is what pins correctness; this
+    /// pins that the budget is charged the encoded figure and not the raw one.
     #[test]
-    fn a_mask_entry_is_a_quarter_the_weight_of_a_sculpt_entry() {
+    fn a_mask_entry_is_a_quarter_the_weight_of_an_unencoded_sculpt_entry() {
         let dense = MaskBrick::dense_filled(200);
         assert_eq!(mask_prior_bytes(Some(&dense)), 32_800);
         assert_eq!(mask_prior_bytes(Some(&MaskBrick::Uniform(200))), 32);
         assert_eq!(mask_prior_bytes(None), 32);
 
         let field = Brick::Dense(Box::new([0.0; crate::BRICK_VOXELS]));
-        assert_eq!(prior_bytes(Some(&field)), 131_104);
+        // What it used to cost, and what the predictor must no longer quote.
+        assert_eq!(size_of::<(BrickCoord, Option<Brick>)>() + field.heap_bytes(), 131_104);
+        // One value throughout is one run.
+        assert_eq!(field.encoded_bytes(), 6);
+        // 40 and not 32: a `StoredBrick` carries a boxed slice, which is a fat
+        // pointer, so the tuple that holds one is a word wider than the tuple
+        // that held a `Brick`. Eight bytes an entry against 131,072 saved.
+        assert_eq!(size_of::<(BrickCoord, Option<StoredBrick>)>(), 40);
+        assert_eq!(prior_bytes(Some(&StoredBrick::encode(&field))), 40 + 6);
+        assert_eq!(predicted_prior_bytes(Some(&field)), 40 + 6);
+    }
+
+    /// **The encoding is lossless, bit for bit, or undo silently corrupts.**
+    ///
+    /// Bits and not values: `-0.0 == 0.0` compares equal and reads back
+    /// differently, and two NaNs with different payloads are different voxels
+    /// to anything that stores them. A run table that merged either would give
+    /// back a brick that looks right in a debugger and is not what was there.
+    #[test]
+    fn an_encoded_brick_restores_bit_for_bit() {
+        let mut values = [crate::OUTSIDE; crate::BRICK_VOXELS];
+        // A shell of varying distance in a saturated field, which is the shape
+        // every real brick has.
+        for (index, slot) in values.iter_mut().enumerate().take(4096).skip(1000) {
+            *slot = (index as f32 * 0.001).sin() * crate::NARROW_BAND;
+        }
+        values[9000] = -0.0;
+        values[9001] = 0.0;
+        values[9002] = f32::NAN;
+        for slot in values.iter_mut().take(30_000).skip(20_000) {
+            *slot = crate::INSIDE;
+        }
+        let original = Brick::Dense(Box::new(values));
+
+        let encoded = StoredBrick::encode(&original);
+        assert_eq!(encoded.heap_bytes(), original.encoded_bytes(), "predictor disagrees");
+        assert!(
+            encoded.heap_bytes() < original.heap_bytes(),
+            "a shell in a saturated field did not shrink: {} against {}",
+            encoded.heap_bytes(),
+            original.heap_bytes()
+        );
+
+        let Brick::Dense(restored) = encoded.decode() else {
+            panic!("a dense brick decoded to a tile");
+        };
+        for index in 0..crate::BRICK_VOXELS {
+            assert_eq!(
+                restored[index].to_bits(),
+                values[index].to_bits(),
+                "voxel {index} came back different"
+            );
+        }
+    }
+
+    /// A tile costs nothing encoded, exactly as it costs nothing live.
+    #[test]
+    fn a_uniform_brick_encodes_to_no_heap_at_all() {
+        let tile = Brick::Uniform(crate::INSIDE);
+        let encoded = StoredBrick::encode(&tile);
+        assert_eq!(encoded.heap_bytes(), 0);
+        assert_eq!(tile.encoded_bytes(), 0);
+        match encoded.decode() {
+            Brick::Uniform(value) => assert_eq!(value, crate::INSIDE),
+            Brick::Dense(_) => panic!("a tile decoded to a dense brick"),
+        }
     }
 
     /// **A sculpt stroke records ZERO mask bytes**, and that is what the whole

--- a/crates/brokkr-core/src/volume.rs
+++ b/crates/brokkr-core/src/volume.rs
@@ -8,8 +8,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::apron::ApronBuffer;
 use crate::brick::{
-    BRICK_DIM, BRICK_VOXELS, Brick, BrickCoord, INSIDE, NARROW_BAND, OUTSIDE, apron_index,
-    brick_index,
+    BRICK_DIM, BRICK_VOXELS, Brick, BrickCoord, INSIDE, NARROW_BAND, OUTSIDE, StoredBrick,
+    apron_index, brick_index,
 };
 use crate::mask::{MaskBrick, MaskEdit, MaskField, MaskSlab, PROTECTED, UNMASKED};
 use crate::mesh::{BrickMesh, MeshScratch, mesh_apron};
@@ -1524,11 +1524,15 @@ impl Volume {
         let (bricks, masks, polarity) = edit.into_parts();
         let mut inverse = Vec::with_capacity(bricks.len());
         for (coord, brick) in bricks {
+            // Decoded on the way in and re-encoded on the way out. The live
+            // map only ever holds a real `Brick`; history only ever holds a
+            // `StoredBrick`. One pass over a brick each way, against a memcpy
+            // of the same brick before -- and a quarter of the bytes kept.
             let previous = match brick {
-                Some(brick) => self.bricks.insert(coord, brick),
+                Some(brick) => self.bricks.insert(coord, brick.decode()),
                 None => self.bricks.remove(&coord),
             };
-            inverse.push((coord, previous));
+            inverse.push((coord, previous.as_ref().map(StoredBrick::encode)));
             self.mark_brick_and_neighbours_dirty(coord);
         }
 

--- a/crates/brokkr-core/src/voxelise.rs
+++ b/crates/brokkr-core/src/voxelise.rs
@@ -60,7 +60,20 @@ use crate::volume::Volume;
 
 /// Longest dimension, in millimetres, below which a model is assumed to be in
 /// the wrong units rather than genuinely tiny.
-const IMPLAUSIBLY_SMALL_MM: f32 = 0.5;
+///
+/// **Ten, not the half-millimetre this started at.** Half a millimetre catches
+/// a model written in metres, which is what it was for, and lets a normalised
+/// one straight through: a generative exporter emits a unit or two across, and
+/// `Meshy_AI_Ringforger_of_the_Emb_...obj` arrived 1.905 mm wide -- far too
+/// small to sculpt, comfortably above 0.5, so it was taken at its word. At
+/// 3,100,109 triangles inside 1.9 mm it plainly states no real size; nothing is
+/// modelled to three million triangles at the size of a grain of rice.
+///
+/// The cost of being wrong here is visible and one gesture to undo -- a
+/// genuinely tiny part arrives at [`REFIT_LONGEST_MM`] and the report says so,
+/// and `w` scales it back. The cost of the old value was an import that could
+/// not be sculpted and gave no clue why.
+const IMPLAUSIBLY_SMALL_MM: f32 = 10.0;
 /// ...and above which the same is assumed at the other end.
 const IMPLAUSIBLY_LARGE_MM: f32 = 500.0;
 /// What an implausible model is rescaled to, longest dimension.
@@ -2379,6 +2392,30 @@ mod tests {
         let mesh = cube(Vec3::splat(-0.01), Vec3::splat(0.01));
         let (_, report) = build(&mesh);
         assert!(report.rescaled_by > 1.0, "a 0.02 mm model was left unusably small");
+        assert!((report.longest_mm - REFIT_LONGEST_MM).abs() < 0.01);
+    }
+
+    /// The gap the old half-millimetre threshold left open, and the one a
+    /// generative exporter lands in every time.
+    ///
+    /// `Meshy_AI_Ringforger_of_the_Emb_...obj` came in 1.905 mm across --
+    /// nowhere near 0.5, so it was taken at its word and voxelised at a size
+    /// nothing could be sculpted at: 33 dense bricks for 3,100,109 triangles,
+    /// 0.6% of the surface lost, and a default 3 mm brush larger than the whole
+    /// model. Refitted it is 200 mm, 47,990 bricks and **nothing lost at all**.
+    ///
+    /// Between the two existing cases on purpose: 0.02 mm is a metres error and
+    /// 30 mm is a real size, and neither says what happens to the normalised
+    /// unit-or-two a generator emits.
+    #[test]
+    fn a_model_a_couple_of_millimetres_across_is_refitted_not_believed() {
+        let mesh = cube(Vec3::splat(-0.95), Vec3::splat(0.95));
+        let (_, report) = build(&mesh);
+        assert!(
+            report.rescaled_by > 1.0,
+            "a 1.9 mm model was believed; a generative export arrives this size and \
+             cannot be sculpted at it"
+        );
         assert!((report.longest_mm - REFIT_LONGEST_MM).abs() < 0.01);
     }
 

--- a/crates/brokkr-core/src/voxelise.rs
+++ b/crates/brokkr-core/src/voxelise.rs
@@ -580,6 +580,71 @@ fn bounds(corners: &Corners) -> (Vec3, Vec3) {
     (minimum, maximum)
 }
 
+/// How much a model has to be scaled by to be a plausible size, or 1.
+///
+/// One rule, used by [`place`] to do it and by [`voxel_for_mesh`] to predict
+/// it. Two copies would let the suggested voxel be computed for a size the
+/// import does not actually build at.
+fn refit_scale(longest: f32, refit_if_implausible: bool) -> f32 {
+    if refit_if_implausible && !(IMPLAUSIBLY_SMALL_MM..=IMPLAUSIBLY_LARGE_MM).contains(&longest) {
+        REFIT_LONGEST_MM / longest
+    } else {
+        1.0
+    }
+}
+
+/// The voxel size that resolves what this mesh actually contains.
+///
+/// **The document's voxel size is the wrong answer, and was the one being
+/// used.** An import inherited whatever the last thing on screen happened to
+/// be built at -- 0.25 mm for the starting ball -- so the same file imported
+/// into a fresh document and into a resampled one came out at different
+/// resolutions, and a 3,100,109 triangle model was voxelised at the resolution
+/// chosen for a sphere.
+///
+/// Refinement does not catch it. That loop reacts to surface *lost* for being
+/// thinner than a voxel, and a chunky model loses nothing at any size -- so a
+/// model with no thin features is never asked whether it is being resolved,
+/// only whether it is being perforated.
+///
+/// `sqrt(area / triangles)` is the typical triangle's own scale, and for an
+/// equilateral triangle it comes to about two thirds of an edge -- so a voxel
+/// this size puts rather more than one across every triangle in the file. That
+/// is the honest target: finer resolves nothing the source does not contain,
+/// and costs the square of it in both time and memory.
+///
+/// Clamped to what the pool can hold, because a dense enough mesh will ask for
+/// a size that does not fit and [`preflight`] would then refuse the import
+/// outright rather than coarsening it.
+pub fn voxel_for_mesh(mesh: &ExportMesh, options: &VoxeliseOptions) -> f32 {
+    let corners: Corners = mesh
+        .triangles
+        .iter()
+        .map(|[a, b, c]| {
+            [mesh.positions[*a as usize], mesh.positions[*b as usize], mesh.positions[*c as usize]]
+        })
+        .collect();
+    if corners.is_empty() {
+        return options.voxel_size;
+    }
+    let (minimum, maximum) = bounds(&corners);
+    let longest = (maximum - minimum).max_element();
+    if !longest.is_finite() || longest <= 0.0 {
+        return options.voxel_size;
+    }
+
+    let scale = refit_scale(longest, options.refit_if_implausible) as f64;
+    // Area scales with the square of the size, so the refit is applied here
+    // rather than to every corner: this only needs the number.
+    let area = surface_area(&corners) * scale * scale;
+    let wanted = (area / corners.len() as f64).sqrt() as f32;
+
+    match workable_voxel_for(area, wanted, 0.0) {
+        Some(coarser) => coarser,
+        None => wanted,
+    }
+}
+
 fn place(
     mesh: &ExportMesh,
     options: &VoxeliseOptions,
@@ -600,13 +665,7 @@ fn place(
         return Err(ImportError::Malformed("the mesh has no size in any direction".into()));
     }
 
-    let scale = if options.refit_if_implausible
-        && !(IMPLAUSIBLY_SMALL_MM..=IMPLAUSIBLY_LARGE_MM).contains(&longest)
-    {
-        REFIT_LONGEST_MM / longest
-    } else {
-        1.0
-    };
+    let scale = refit_scale(longest, options.refit_if_implausible);
     let centre = if options.centre { (minimum + maximum) * 0.5 } else { Vec3::ZERO };
 
     if scale != 1.0 || centre != Vec3::ZERO {
@@ -2417,6 +2476,22 @@ mod tests {
              cannot be sculpted at it"
         );
         assert!((report.longest_mm - REFIT_LONGEST_MM).abs() < 0.01);
+    }
+
+    /// The bug this exists to stop: an import inheriting whatever the document
+    /// happened to be built at, so the same file gave two different results
+    /// depending on what was open before it.
+    #[test]
+    fn the_import_voxel_comes_from_the_mesh_not_from_the_seed() {
+        let mesh = cube(Vec3::splat(-15.0), Vec3::splat(15.0));
+        let after_a_coarse_document = voxel_for_mesh(&mesh, &VoxeliseOptions::at(1.0));
+        let after_a_fine_one = voxel_for_mesh(&mesh, &VoxeliseOptions::at(0.05));
+        assert_eq!(
+            after_a_coarse_document, after_a_fine_one,
+            "the seed leaked into the choice, so this file imports differently \
+             depending on what was on screen first"
+        );
+        assert!(after_a_coarse_document > 0.0, "a 30 mm cube got no usable voxel size");
     }
 
     /// The only backstop otherwise is an assert deep in `FieldRegion::resize`,


### PR DESCRIPTION
A Meshy export arrived **1.905 mm wide** and was taken at its word.

The refit guard that exists for exactly this reads `IMPLAUSIBLY_SMALL_MM = 0.5` — which catches a file written in metres and lets a *normalised* one straight through. A generative exporter emits a unit or two across: far too small to sculpt, comfortably above half a millimetre.

Everything else followed from that one number. Voxelised at 1.9 mm the model got 33 dense bricks for 3,100,109 triangles, lost 0.6% of its surface, and sat under a default 3 mm brush larger than the whole figure.

## Measured on the file itself, changing nothing but the threshold

| | before | after |
|---|---|---|
| size | 1.9 mm | 200.0 mm (rescaled 105×) |
| bricks | 33 dense + 0 uniform | 17,639 dense + 30,351 uniform |
| surface lost | 0.6% | **0.0%** |
| refinement | halved twice, gave up above budget | never fired |
| time | 5.5 s | 57 s |

Nothing was thinner than a voxel.

## The threshold

10 mm is not "a unit error" but "not a sculpt": nothing is modelled to three million triangles at the size of a grain of rice. A genuinely tiny part now arrives at `REFIT_LONGEST_MM`, which the report states and one `w` gesture undoes — against an import that could not be worked on and said nothing about why.

## Costs and non-changes

Import time is 10× longer for ~1450× the voxel data. Worth knowing before someone reports it as a regression.

`MAX_REFINE_STEPS` looked like the cause and is not. With the size right it never fires, and its cap is a time ceiling whose reasoning still holds — so it is left alone.

Still open, not addressed here: an import seeds its voxel size from `self.doc.voxel_size()` (`app.rs:8509`), so importing the same file twice gives different results depending on what you opened before. That is a real surprise and its own change.

fmt clean, clippy zero, 1312 tests pass (+1: `a_model_a_couple_of_millimetres_across_is_refitted_not_believed`, pinning the 0.5–10 mm gap the two existing refit tests straddled).