### PR TITLE
Read the pen on Windows, through Raw Input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,8 +165,17 @@ jobs:
 
           - **macOS** will say *"BrokkrSculpt.app is damaged and can't be opened."*
             It is not damaged; that is what Gatekeeper says about any unsigned app
-            from the internet. Run `xattr -dr com.apple.quarantine /Applications/BrokkrSculpt.app`
-            after moving it to Applications, then open it normally.
+            from the internet. Move it to Applications, then in Terminal run
+            `xattr -dr com.apple.quarantine /Applications/BrokkrSculpt.app` and
+            open it normally.
+
+            Not Control+click then Open -- Sequoia removed that. The supported
+            route is System Settings > Privacy & Security > **Open Anyway** after
+            a failed launch, but it wants an admin password, only offers the
+            button for about an hour afterwards, and an app with no signature at
+            all may not appear there to be excused at all. The quarantine flag is
+            the one path that does not depend on any of that, and it turns off
+            nothing system wide.
           - **Windows** will show *"Windows protected your PC"* from SmartScreen.
             Click **More info**, then **Run anyway**.
           - **Linux** has nothing to say about it. Untar and run `./brokkrsculpt`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "brokkr-core",
  "brokkr-gpu",
  "bytemuck",
+ "core-foundation 0.10.1",
  "env_logger",
  "evdev",
  "glam 0.33.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "serde_json",
  "ureq",
  "wgpu",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,12 @@ windows-sys = { version = "0.61", features = [
   "Win32_UI_WindowsAndMessaging",
   "Win32_Devices_HumanInterfaceDevice",
 ] }
+# Core Foundation, for the macOS HID reader. **Already in the graph on that
+# target** via winit, so this pins what is compiled rather than adding to it.
+# IOKit itself is ten `extern` declarations in `raw_hid` and no crate: the
+# same trade the nonce made, where a dependency has to be doing something hard
+# to be worth it, and retain/release is hard while ten signatures are not.
+core-foundation = "0.10"
 glam = { version = "0.33", features = ["bytemuck"] }
 iced = "0.14"
 iced_wgpu = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,16 @@ brokkr-gpu = { path = "crates/brokkr-gpu" }
 
 bytemuck = { version = "1", features = ["derive"] }
 fast-surface-nets = "0.2"
+# Raw Input and the HID parsers, for the Windows stylus. **Already in the graph
+# on that target** -- winit pulls this same version -- so the cost here is the
+# extra feature surface being compiled, not a new crate. Linux and macOS never
+# see it.
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_UI_Input",
+  "Win32_UI_WindowsAndMessaging",
+  "Win32_Devices_HumanInterfaceDevice",
+] }
 glam = { version = "0.33", features = ["bytemuck"] }
 iced = "0.14"
 iced_wgpu = "0.14"

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ should have to discover for themselves.
 |---|---|---|---|
 | Sculpting, import, export, printing | yes | yes | yes |
 | Masking **display** | yes | yes | **wrong — see below** |
-| Stylus pressure and tilt | yes | untested | no |
-| SpaceMouse | yes | no | no |
+| Stylus pressure and tilt | yes | untested | untested |
+| SpaceMouse | yes | untested | untested |
 | Installer the OS trusts | n/a | no | no |
 
 - **macOS masking renders wrong.** The tint spreads past the mask and a seam
@@ -282,20 +282,42 @@ should have to discover for themselves.
   unaffected, and so is anything you export — but you cannot trust the blue to
   tell you where it is. A difference in how the Metal backend reads a vertex
   attribute; it is being chased, and Linux and Windows are unaffected.
-- **Stylus on Windows is written but has never met a tablet.** The PEN panel
-  says which state it is in: *"Listening for a pen through Raw Input; none has
-  reported yet"* against *"Reading the pen through Raw Input."* If it never
-  leaves the first, strokes run at full pressure exactly as a mouse does — so
-  it degrades rather than breaks. A screenshot of that panel is the single most
-  useful bug report a Windows user with a tablet can send.
-- **No stylus or SpaceMouse on macOS.** Both are read straight from the Linux
-  kernel today and the macOS equivalents are not written yet.
+- **Stylus and SpaceMouse on Windows and macOS are written but have never met
+  the hardware.** Windows reads them through Raw Input, macOS through IOKit,
+  and both compile on their own platform — but nobody involved owns a tablet or
+  a puck on either, so "it works" is not a claim being made. Both panels say
+  which state they are in rather than leaving you guessing:
+
+  > *"Listening for a pen through Raw Input; none has reported yet"* — against —
+  > *"Reading the pen through Raw Input."*
+
+  If it never leaves the first, strokes run at full pressure exactly as a mouse
+  does, so it degrades rather than breaks. **A screenshot of that panel is the
+  single most useful bug report a Windows or macOS user with a tablet can
+  send.** On macOS, silence most often means Input Monitoring has not been
+  granted in System Settings → Privacy & Security.
 - **Neither installer is signed**, because the certificates cost money this
-  project does not have yet. macOS will tell you the app *"is damaged and can't
-  be opened"* — it is not; that is what Gatekeeper says about any unsigned
-  download, and `xattr -dr com.apple.quarantine` on the app clears it. Windows
-  shows SmartScreen's *"Windows protected your PC"*, which needs **More info**
-  then **Run anyway**.
+  project does not have yet.
+
+  **macOS** will say the app *"is damaged and can't be opened."* It is not
+  damaged — that is what Gatekeeper says about any unsigned download. Move it
+  to Applications, then in Terminal:
+
+  ```
+  xattr -dr com.apple.quarantine /Applications/BrokkrSculpt.app
+  ```
+
+  The Terminal command rather than the usual advice, deliberately. Control+click
+  → Open **no longer works**: Sequoia removed it. The supported route is now
+  System Settings → Privacy & Security → **Open Anyway** after a failed launch,
+  which needs an admin password and only offers the button for about an hour
+  afterwards — and an app with no signature at all may not appear there to be
+  excused. Removing the quarantine flag is the one path that does not depend on
+  any of that. It turns off nothing system-wide; it marks this one download as
+  one you chose.
+
+  **Windows** shows SmartScreen's *"Windows protected your PC"*, which needs
+  **More info** then **Run anyway**.
 
 **The honest limits**, both of which you will meet in ordinary use rather than
 in exotic corner cases:

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ canvas paths costs 6.
 ## Checking it
 
 ```fish
-cargo test --workspace     # 610 tests
+cargo test --workspace     # 1316 tests
 cargo bench -p brokkr-core # budget gate; exits non-zero when one is blown
 ```
 

--- a/crates/brokkr-app/Cargo.toml
+++ b/crates/brokkr-app/Cargo.toml
@@ -63,6 +63,9 @@ wgpu.workspace = true
 # and it works with any tablet the kernel has a driver for rather than a list of
 # vendors. Nothing else in the stack can supply it: iced 0.14 drops winit's
 # force field, and winit 0.30 only ever had it for touch.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys.workspace = true
+
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev.workspace = true
 

--- a/crates/brokkr-app/Cargo.toml
+++ b/crates/brokkr-app/Cargo.toml
@@ -63,6 +63,9 @@ wgpu.workspace = true
 # and it works with any tablet the kernel has a driver for rather than a list of
 # vendors. Nothing else in the stack can supply it: iced 0.14 drops winit's
 # force field, and winit 0.30 only ever had it for touch.
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation.workspace = true
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys.workspace = true
 

--- a/crates/brokkr-app/src/main.rs
+++ b/crates/brokkr-app/src/main.rs
@@ -21,6 +21,10 @@ mod message;
 mod navcube;
 mod paths;
 mod printer;
+// Reading HID devices on Windows, the way `input_watch` reads them on Linux.
+// Both the pen and the puck come through it.
+#[cfg(target_os = "windows")]
+mod raw_input;
 mod recent;
 mod report;
 mod slicer;

--- a/crates/brokkr-app/src/main.rs
+++ b/crates/brokkr-app/src/main.rs
@@ -21,8 +21,10 @@ mod message;
 mod navcube;
 mod paths;
 mod printer;
-// Reading HID devices on Windows, the way `input_watch` reads them on Linux.
-// Both the pen and the puck come through it.
+// Reading HID devices on macOS and on Windows, the way `input_watch` reads
+// them on Linux. Both the pen and the puck come through whichever applies.
+#[cfg(target_os = "macos")]
+mod raw_hid;
 #[cfg(target_os = "windows")]
 mod raw_input;
 mod recent;

--- a/crates/brokkr-app/src/raw_hid.rs
+++ b/crates/brokkr-app/src/raw_hid.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Reading a HID device on macOS, the way `raw_input` reads one on Windows and
+//! `input_watch` reads one on Linux.
+//!
+//! Both the stylus and the puck arrive here, and for the same reason they do on
+//! the other two: iced 0.14 drops winit's `force` field and winit has no
+//! desktop pen pressure at all, so the pen has to be read below the toolkit.
+//!
+//! # IOKit directly, and no crate for it
+//!
+//! `io-kit-sys` exists and is not in this graph. Ten `extern` declarations are,
+//! and this is the same trade the nonce made in `account`: a dependency is
+//! worth it when it does something hard, and declaring the handful of functions
+//! a caller actually uses is not hard. `core-foundation` IS used, because it is
+//! already in the graph via winit and because hand-rolling retain and release
+//! is exactly the kind of hard that earns a crate.
+//!
+//! # Elements, not reports
+//!
+//! This is the one place where macOS is simpler than Windows. Raw Input hands
+//! over a report and leaves the parsing to `HidP_*`; IOKit has already split it
+//! and calls back per ELEMENT, with the usage and the logical range attached.
+//! So there is no report layout to reason about here at all -- the callback is
+//! handed "this usage, on this page, is now this value, out of this range".
+//!
+//! # One run loop per device kind
+//!
+//! Same argument as Windows: matching costs nothing once registered, so each
+//! backend owns a manager and a run loop rather than sharing one and needing a
+//! protocol to add matchers to it. A `CFRunLoopRun` thread is a blocked thread.
+
+use std::ffi::c_void;
+
+use core_foundation::base::{CFRelease, TCFType};
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::number::CFNumber;
+use core_foundation::runloop::{CFRunLoop, kCFRunLoopDefaultMode};
+use core_foundation::string::CFString;
+
+/// HID usage pages this application reads from. The numbers are the HID
+/// specification's own and match `raw_input`'s, which is not a coincidence
+/// worth hiding: it is the same table underneath both platforms.
+pub const PAGE_GENERIC: u32 = 0x01;
+pub const PAGE_DIGITIZER: u32 = 0x0D;
+pub const PAGE_BUTTON: u32 = 0x09;
+
+type IOHIDManagerRef = *mut c_void;
+type IOHIDValueRef = *mut c_void;
+type IOHIDElementRef = *mut c_void;
+
+/// What IOKit hands back for one element that changed.
+pub struct Sample {
+    pub page: u32,
+    pub usage: u32,
+    pub value: i64,
+    /// The logical range the element declares, for normalising against.
+    pub minimum: i64,
+    pub maximum: i64,
+}
+
+#[link(name = "IOKit", kind = "framework")]
+unsafe extern "C" {
+    fn IOHIDManagerCreate(allocator: *const c_void, options: u32) -> IOHIDManagerRef;
+    fn IOHIDManagerSetDeviceMatching(manager: IOHIDManagerRef, matching: *const c_void);
+    fn IOHIDManagerRegisterInputValueCallback(
+        manager: IOHIDManagerRef,
+        callback: extern "C" fn(*mut c_void, i32, *mut c_void, IOHIDValueRef),
+        context: *mut c_void,
+    );
+    fn IOHIDManagerScheduleWithRunLoop(
+        manager: IOHIDManagerRef,
+        run_loop: *mut c_void,
+        mode: *const c_void,
+    );
+    fn IOHIDManagerOpen(manager: IOHIDManagerRef, options: u32) -> i32;
+    fn IOHIDValueGetElement(value: IOHIDValueRef) -> IOHIDElementRef;
+    fn IOHIDValueGetIntegerValue(value: IOHIDValueRef) -> isize;
+    fn IOHIDElementGetUsagePage(element: IOHIDElementRef) -> u32;
+    fn IOHIDElementGetUsage(element: IOHIDElementRef) -> u32;
+    fn IOHIDElementGetLogicalMin(element: IOHIDElementRef) -> isize;
+    fn IOHIDElementGetLogicalMax(element: IOHIDElementRef) -> isize;
+}
+
+/// Everything the callback needs, kept alive for the life of the run loop.
+///
+/// Leaked on purpose. The run loop below never returns, so this lives until the
+/// process ends and there is no drop to arrange; boxing it and reclaiming it
+/// would mean proving IOKit holds no pointer to it after a return that does not
+/// happen.
+struct Sink {
+    on_sample: Box<dyn Fn(Sample)>,
+}
+
+/// Read one kind of device until the process ends, handing every changed
+/// element to `on_sample`.
+///
+/// Returns only on failure, and silently, for the reason the other two
+/// backends do: a device that cannot be read must never stop the application
+/// starting. Each caller says the difference between "matching" and
+/// "receiving" in its own panel instead.
+pub fn pump(usage_page: u32, usage: u32, on_sample: impl Fn(Sample) + 'static) {
+    let manager = unsafe { IOHIDManagerCreate(std::ptr::null(), 0) };
+    if manager.is_null() {
+        return;
+    }
+
+    // The matching dictionary is by DEVICE usage, not element usage: it selects
+    // which devices to open, and every element on them is then delivered.
+    let matching = CFDictionary::from_CFType_pairs(&[
+        (
+            CFString::new("DeviceUsagePage").as_CFType(),
+            CFNumber::from(usage_page as i32).as_CFType(),
+        ),
+        (CFString::new("DeviceUsage").as_CFType(), CFNumber::from(usage as i32).as_CFType()),
+    ]);
+    unsafe { IOHIDManagerSetDeviceMatching(manager, matching.as_CFTypeRef() as *const c_void) };
+
+    let sink = Box::into_raw(Box::new(Sink { on_sample: Box::new(on_sample) }));
+    unsafe {
+        IOHIDManagerRegisterInputValueCallback(manager, on_value, sink as *mut c_void);
+        IOHIDManagerScheduleWithRunLoop(
+            manager,
+            CFRunLoop::get_current().as_CFTypeRef() as *mut c_void,
+            kCFRunLoopDefaultMode as *const c_void,
+        );
+    }
+    // kIOHIDOptionsTypeNone. A non-zero return is a device this process is not
+    // allowed to open, which on a Mac means Input Monitoring has not been
+    // granted -- silent here, and visible in the panel as "none has reported".
+    if unsafe { IOHIDManagerOpen(manager, 0) } != 0 {
+        unsafe { CFRelease(manager as *const c_void) };
+        return;
+    }
+
+    CFRunLoop::run_current();
+}
+
+/// IOKit's callback, once per element that changed.
+extern "C" fn on_value(
+    context: *mut c_void,
+    _result: i32,
+    _sender: *mut c_void,
+    value: IOHIDValueRef,
+) {
+    if context.is_null() || value.is_null() {
+        return;
+    }
+    let element = unsafe { IOHIDValueGetElement(value) };
+    if element.is_null() {
+        return;
+    }
+    let sample = Sample {
+        page: unsafe { IOHIDElementGetUsagePage(element) },
+        usage: unsafe { IOHIDElementGetUsage(element) },
+        value: unsafe { IOHIDValueGetIntegerValue(value) } as i64,
+        minimum: unsafe { IOHIDElementGetLogicalMin(element) } as i64,
+        maximum: unsafe { IOHIDElementGetLogicalMax(element) } as i64,
+    };
+    let sink = unsafe { &*(context as *const Sink) };
+    (sink.on_sample)(sample);
+}

--- a/crates/brokkr-app/src/raw_input.rs
+++ b/crates/brokkr-app/src/raw_input.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Reading a HID device on Windows, the way `input_watch` reads one on Linux.
+//!
+//! Both the stylus and the puck arrive here. Neither goes through the window
+//! system: iced 0.14 drops winit's `force` field and winit has no pen pressure
+//! on the desktop at all, so the pen has to be read below the toolkit -- and
+//! once one device is being read that way the other may as well be, rather
+//! than having two unrelated input paths to reason about.
+//!
+//! # Why this shares helpers and not a thread
+//!
+//! `input_watch` on Linux is shared because SCANNING is expensive: thirty
+//! event nodes, reopened twice a second, is real work and doing it twice would
+//! be twice the work. Raw Input has no scan. The OS pushes reports at a window
+//! and a blocked `GetMessageW` costs a thread and nothing else, so each backend
+//! owns its own window and pump and there is no shared mutable state, no
+//! registration protocol and no ordering between them. What is shared is the
+//! part that is genuinely identical: creating the sink, and asking Windows what
+//! a report says.
+//!
+//! # Why `HidP_*` and not a report descriptor parser
+//!
+//! HID reports are vendor specific and the descriptor that explains them is a
+//! small language. Windows has already parsed it. Asking by usage --
+//! [`value`], [`button`] -- means a tablet and a puck are read by the same four
+//! functions, and a device with an unusual report layout is the OS's problem
+//! rather than ours.
+
+use windows_sys::Win32::Devices::HumanInterfaceDevice::{
+    HIDP_STATUS_SUCCESS, HIDP_VALUE_CAPS, HidP_GetUsageValue, HidP_GetUsages, HidP_GetValueCaps,
+    HidP_Input, PHIDP_PREPARSED_DATA,
+};
+use windows_sys::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows_sys::Win32::UI::Input::{
+    GetRawInputData, GetRawInputDeviceInfoW, HRAWINPUT, RAWINPUT, RAWINPUTDEVICE, RAWINPUTHEADER,
+    RID_INPUT, RIDEV_INPUTSINK, RIDI_PREPARSEDDATA, RegisterRawInputDevices,
+};
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, HWND_MESSAGE, MSG,
+    RegisterClassW, WM_INPUT, WNDCLASSW,
+};
+
+/// HID usage pages this application reads from.
+pub const PAGE_GENERIC: u16 = 0x01;
+pub const PAGE_DIGITIZER: u16 = 0x0D;
+
+/// Read one kind of device until the process ends, handing every report to
+/// `on_report` along with the parsed descriptor it should be read against.
+///
+/// Returns only on failure, and silently: a device that cannot be read must
+/// never stop the application starting. Both callers report the difference
+/// between "set up" and "receiving" in their own panel instead, which is the
+/// thing a user can actually act on.
+///
+/// `class` must be unique per caller. Registering a window class twice fails,
+/// and two devices read on two threads need two windows.
+pub fn pump(
+    class: &str,
+    usage_page: u16,
+    usage: u16,
+    on_report: impl Fn(PHIDP_PREPARSED_DATA, &[u8]),
+) {
+    let class_name: Vec<u16> = class.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut descriptor: WNDCLASSW = unsafe { std::mem::zeroed() };
+    descriptor.lpfnWndProc = Some(wndproc);
+    descriptor.lpszClassName = class_name.as_ptr();
+    unsafe { RegisterClassW(&descriptor) };
+
+    // `HWND_MESSAGE` is a window that is never shown, never focused and never
+    // in the taskbar. It exists only to be something Raw Input can deliver to.
+    let window = unsafe {
+        CreateWindowExW(
+            0,
+            class_name.as_ptr(),
+            class_name.as_ptr(),
+            0,
+            0,
+            0,
+            0,
+            0,
+            HWND_MESSAGE,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null(),
+        )
+    };
+    if window.is_null() {
+        return;
+    }
+
+    let device = RAWINPUTDEVICE {
+        usUsagePage: usage_page,
+        usUsage: usage,
+        // Delivered even unfocused, which this window always is: without this
+        // flag a message-only window receives nothing at all.
+        dwFlags: RIDEV_INPUTSINK,
+        hwndTarget: window,
+    };
+    if unsafe { RegisterRawInputDevices(&device, 1, size_of::<RAWINPUTDEVICE>() as u32) } == 0 {
+        return;
+    }
+
+    let mut message: MSG = unsafe { std::mem::zeroed() };
+    // Returns -1 on error, 0 on WM_QUIT, positive otherwise -- so `> 0` is the
+    // only correct test, and `!= 0` would spin forever on an error.
+    while unsafe { GetMessageW(&mut message, std::ptr::null_mut(), 0, 0) } > 0 {
+        if message.message == WM_INPUT {
+            deliver(message.lParam as isize as HRAWINPUT, &on_report);
+        }
+        unsafe { DispatchMessageW(&message) };
+    }
+}
+
+/// Nothing to do: `WM_INPUT` is taken from the message loop rather than from
+/// the procedure, so there is no state to keep between them.
+unsafe extern "system" fn wndproc(window: HWND, message: u32, w: WPARAM, l: LPARAM) -> LRESULT {
+    unsafe { DefWindowProcW(window, message, w, l) }
+}
+
+/// Pull one `WM_INPUT` apart and hand each report inside it to the caller.
+///
+/// A single message can carry several reports -- `dwCount` above one is a
+/// device that batched them -- and dropping the tail would quietly lose input
+/// under exactly the fast movement that produces batching.
+fn deliver(handle: HRAWINPUT, on_report: &impl Fn(PHIDP_PREPARSED_DATA, &[u8])) {
+    let header = size_of::<RAWINPUTHEADER>() as u32;
+    let mut size = 0u32;
+    if unsafe { GetRawInputData(handle, RID_INPUT, std::ptr::null_mut(), &mut size, header) } != 0
+        || size == 0
+    {
+        return;
+    }
+    let mut buffer = vec![0u8; size as usize];
+    let read = unsafe {
+        GetRawInputData(handle, RID_INPUT, buffer.as_mut_ptr().cast(), &mut size, header)
+    };
+    if read != size {
+        return;
+    }
+
+    let raw = buffer.as_ptr() as *const RAWINPUT;
+    let hid = unsafe { &(*raw).data.hid };
+    let (count, stride) = (hid.dwCount as usize, hid.dwSizeHid as usize);
+    if count == 0 || stride == 0 {
+        return;
+    }
+
+    let Some(preparsed) = preparsed_data(unsafe { (*raw).header.hDevice }) else {
+        return;
+    };
+    let data = preparsed.as_ptr() as PHIDP_PREPARSED_DATA;
+    let reports = hid.bRawData.as_ptr();
+    for index in 0..count {
+        let report = unsafe { std::slice::from_raw_parts(reports.add(index * stride), stride) };
+        on_report(data, report);
+    }
+}
+
+/// The device's parsed report descriptor, which Windows keeps for us.
+fn preparsed_data(device: *mut core::ffi::c_void) -> Option<Vec<u8>> {
+    let mut size = 0u32;
+    unsafe { GetRawInputDeviceInfoW(device, RIDI_PREPARSEDDATA, std::ptr::null_mut(), &mut size) };
+    if size == 0 {
+        return None;
+    }
+    let mut buffer = vec![0u8; size as usize];
+    let read = unsafe {
+        GetRawInputDeviceInfoW(device, RIDI_PREPARSEDDATA, buffer.as_mut_ptr().cast(), &mut size)
+    };
+    // The bytes written, or -1 as a `u32` when the buffer was short.
+    if read == u32::MAX || read == 0 { None } else { Some(buffer) }
+}
+
+/// The raw value of a usage in this report, if the device carries it.
+pub fn value(
+    data: PHIDP_PREPARSED_DATA,
+    report: &[u8],
+    usage_page: u16,
+    usage: u16,
+) -> Option<i32> {
+    let mut out = 0u32;
+    let status = unsafe {
+        HidP_GetUsageValue(
+            HidP_Input,
+            usage_page,
+            0,
+            usage,
+            &mut out,
+            data,
+            report.as_ptr() as *mut u8,
+            report.len() as u32,
+        )
+    };
+    (status == HIDP_STATUS_SUCCESS).then_some(out as i32)
+}
+
+/// Whether a button usage is asserted in this report.
+///
+/// `HidP_GetUsages` fills the usages that are ON, so one the device has but is
+/// not asserting comes back absent. `None` is "this call failed", not "up".
+pub fn button(
+    data: PHIDP_PREPARSED_DATA,
+    report: &[u8],
+    usage_page: u16,
+    usage: u16,
+) -> Option<bool> {
+    Some(pressed(data, report, usage_page)?.contains(&usage))
+}
+
+/// Every button usage asserted in this report, for a caller that wants them
+/// all rather than asking one at a time.
+pub fn pressed(data: PHIDP_PREPARSED_DATA, report: &[u8], usage_page: u16) -> Option<Vec<u16>> {
+    // Thirty-two is past any puck's button count and costs a third of a cache
+    // line; a device with more simply has its extras ignored rather than
+    // overflowing anything.
+    let mut list = [0u16; 32];
+    let mut length = list.len() as u32;
+    let status = unsafe {
+        HidP_GetUsages(
+            HidP_Input,
+            usage_page,
+            0,
+            list.as_mut_ptr(),
+            &mut length,
+            data,
+            report.as_ptr() as *mut u8,
+            report.len() as u32,
+        )
+    };
+    (status == HIDP_STATUS_SUCCESS).then(|| list[..length as usize].to_vec())
+}
+
+/// The logical range the device declares for a usage.
+///
+/// Read rather than assumed: a tablet reporting 0..8191 and one reporting
+/// 0..1023 are both ordinary, and assuming either would give the other eight
+/// times the pressure or an eighth of it.
+pub fn range(data: PHIDP_PREPARSED_DATA, usage_page: u16, usage: u16) -> Option<(i32, i32)> {
+    let mut count = 0u16;
+    // The count first, from a null buffer: the caps array is per device, and a
+    // fixed guess would either truncate a rich device or waste a page on a
+    // plain one.
+    unsafe { HidP_GetValueCaps(HidP_Input, std::ptr::null_mut(), &mut count, data) };
+    if count == 0 {
+        return None;
+    }
+    let mut caps: Vec<HIDP_VALUE_CAPS> = vec![unsafe { std::mem::zeroed() }; count as usize];
+    let status = unsafe { HidP_GetValueCaps(HidP_Input, caps.as_mut_ptr(), &mut count, data) };
+    if status != HIDP_STATUS_SUCCESS {
+        return None;
+    }
+    caps[..count as usize].iter().find_map(|cap| {
+        let matches = cap.UsagePage == usage_page
+            && !cap.IsRange
+            && unsafe { cap.Anonymous.NotRange.Usage } == usage;
+        matches.then_some((cap.LogicalMin, cap.LogicalMax))
+    })
+}

--- a/crates/brokkr-app/src/spacemouse.rs
+++ b/crates/brokkr-app/src/spacemouse.rs
@@ -1042,7 +1042,128 @@ mod backend {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+/// Windows: the puck comes from Raw Input, on the generic desktop page.
+///
+/// **The same capability rule as Linux, expressed in HID.** A puck is usage
+/// 0x08, Multi-axis Controller, and the six axes are usages 0x30 through 0x35
+/// in exactly the order [`Axis::ALL`] wants them. Matching on that rather than
+/// on a vendor id is the same argument the module header makes: a mouse has X
+/// and Y and a wheel, and only a six axis device has six axes.
+///
+/// **One thing is simpler here than on Linux.** The kernel drops zero valued
+/// relative events, so evdev has to read silence as "the cap came back to
+/// centre" -- see [`Shared::clear_axes`] and the timeout around it. A HID
+/// report carries all six axes every time, zeros included, so the centre
+/// arrives as data and there is nothing to infer.
+#[cfg(target_os = "windows")]
+mod backend {
+    use super::{Axis, Shared};
+    use crate::raw_input::{self, PAGE_GENERIC};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use windows_sys::Win32::Devices::HumanInterfaceDevice::PHIDP_PREPARSED_DATA;
+
+    pub const SUPPORTED: bool = true;
+
+    /// Usage 0x08 on the generic desktop page is a multi-axis controller.
+    const USAGE_MULTI_AXIS: u16 = 0x08;
+    /// The usage each axis is reported under, paired with the axis itself
+    /// rather than left to line up by index. `Axis::ALL` and this list are
+    /// already in the same order; zipping them says so to the compiler instead
+    /// of to a reader, so reordering either one cannot silently swap two axes.
+    const USAGE_AXES: [(Axis, u16); 6] = [
+        (Axis::Tx, 0x30),
+        (Axis::Ty, 0x31),
+        (Axis::Tz, 0x32),
+        (Axis::Rx, 0x33),
+        (Axis::Ry, 0x34),
+        (Axis::Rz, 0x35),
+    ];
+    /// The button page, which is its own page rather than a usage on this one.
+    const PAGE_BUTTON: u16 = 0x09;
+
+    static SAW_A_REPORT: AtomicBool = AtomicBool::new(false);
+
+    pub fn report() -> String {
+        if SAW_A_REPORT.load(Ordering::Relaxed) {
+            "Reading the puck through Raw Input.".to_string()
+        } else {
+            "Listening for a six axis device through Raw Input; none has reported yet.".to_string()
+        }
+    }
+
+    pub fn spawn(shared: Arc<Shared>) {
+        std::thread::Builder::new()
+            .name("brokkr-puck".to_string())
+            .spawn(move || {
+                raw_input::pump(
+                    "BrokkrPuckSink",
+                    PAGE_GENERIC,
+                    USAGE_MULTI_AXIS,
+                    |data, report| {
+                        decode(&shared, data, report);
+                    },
+                );
+            })
+            .ok();
+    }
+
+    fn decode(shared: &Arc<Shared>, data: PHIDP_PREPARSED_DATA, report: &[u8]) {
+        // A puck usually splits translation and rotation across two report
+        // ids, so a report carrying only three of the six is normal and the
+        // other three must be left alone rather than zeroed -- zeroing them
+        // would make every translation cancel the rotation before it.
+        let mut saw_an_axis = false;
+        for (axis, usage) in USAGE_AXES {
+            if let Some(raw) = raw_input::value(data, report, PAGE_GENERIC, usage) {
+                shared.set_axis(axis as usize, sign_extend(data, raw, usage));
+                saw_an_axis = true;
+            }
+        }
+
+        // Buttons live on their own page and are numbered from one, while
+        // `press` counts from zero.
+        if let Some(down) = raw_input::pressed(data, report, PAGE_BUTTON) {
+            for usage in down {
+                if usage >= 1 {
+                    shared.press(usage as usize - 1);
+                }
+            }
+        }
+
+        if saw_an_axis {
+            SAW_A_REPORT.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Put the sign back on an axis Windows handed over as unsigned.
+    ///
+    /// **`HidP_GetUsageValue` does not sign extend.** A puck's axes are
+    /// centred on zero and swing both ways, so a device declaring -350..350
+    /// reports -1 as 0xFFFF and reading it raw gives 65535 -- the cap pushed
+    /// gently one way would come back as a violent shove the other. The
+    /// declared range is what says how wide the field is and whether it is
+    /// signed at all; `HidP_GetUsageValueArray` and friends have the same
+    /// property, so this is the correction and not a workaround.
+    fn sign_extend(data: PHIDP_PREPARSED_DATA, raw: i32, usage: u16) -> i32 {
+        let Some((minimum, maximum)) = raw_input::range(data, PAGE_GENERIC, usage) else {
+            return raw;
+        };
+        if minimum >= 0 {
+            return raw;
+        }
+        // The smallest power of two that holds the declared span, which is the
+        // field width the device actually reports in.
+        let span = (maximum - minimum) as u32;
+        let bits = u32::BITS - span.leading_zeros();
+        let half = 1i64 << (bits - 1);
+        let wrap = 1i64 << bits;
+        let value = raw as i64;
+        (if value >= half { value - wrap } else { value }) as i32
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 mod backend {
     use super::Shared;
     use std::sync::Arc;
@@ -1055,7 +1176,7 @@ mod backend {
     pub fn spawn(_shared: Arc<Shared>) {}
 
     pub fn report() -> String {
-        "The SpaceMouse is implemented for Linux only so far.".to_string()
+        "The SpaceMouse is implemented for Linux and Windows so far.".to_string()
     }
 }
 

--- a/crates/brokkr-app/src/spacemouse.rs
+++ b/crates/brokkr-app/src/spacemouse.rs
@@ -1593,12 +1593,15 @@ mod tests {
         let sample = puck.motion();
         assert!(!sample.live);
         assert_eq!(sample.axes, [0.0; 6]);
-        // Off Linux there is no backend to find a device with, so the honest
-        // answer is `Unsupported` rather than "looked and found none" -- see
-        // `backend::SUPPORTED`. The centring above is what this test is for and
-        // holds everywhere; only the reason for the silence differs.
+        // Keyed on `backend::SUPPORTED` and NOT on a list of platforms. Where
+        // there is a backend the honest answer is "looked and found none";
+        // where there is not it is "unsupported", and `diagnosis` decides that
+        // on exactly this flag. A platform list was right when Linux was the
+        // only backend and went stale the moment Windows grew one -- this
+        // cannot. The centring above is what the test is for and holds
+        // everywhere; only the reason for the silence differs.
         let expected =
-            if cfg!(target_os = "linux") { Diagnosis::NoDevice } else { Diagnosis::Unsupported };
+            if backend::SUPPORTED { Diagnosis::NoDevice } else { Diagnosis::Unsupported };
         assert_eq!(puck.diagnosis(), expected);
     }
 

--- a/crates/brokkr-app/src/spacemouse.rs
+++ b/crates/brokkr-app/src/spacemouse.rs
@@ -1163,7 +1163,83 @@ mod backend {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+/// macOS: the puck comes from IOKit, matched on the multi axis controller.
+///
+/// Same capability rule as the other two, in the same HID numbers: usage 0x08
+/// on the generic desktop page, axes 0x30 through 0x35.
+///
+/// **No sign extension here, unlike Windows.** `IOHIDValueGetIntegerValue`
+/// returns a `CFIndex`, which is signed, and IOKit has already applied the
+/// element's own sign -- so a value that Raw Input would have handed over as
+/// 0xFFFF arrives as -1. Doing the Windows correction here would turn every
+/// negative axis back into a large positive one.
+#[cfg(target_os = "macos")]
+mod backend {
+    use super::{Axis, Shared};
+    use crate::raw_hid::{self, PAGE_BUTTON, PAGE_GENERIC, Sample};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    pub const SUPPORTED: bool = true;
+
+    const USAGE_MULTI_AXIS: u32 = 0x08;
+    /// Paired with the axis rather than lined up by index, for the reason the
+    /// Windows backend gives: reordering either must not silently swap two.
+    const USAGE_AXES: [(Axis, u32); 6] = [
+        (Axis::Tx, 0x30),
+        (Axis::Ty, 0x31),
+        (Axis::Tz, 0x32),
+        (Axis::Rx, 0x33),
+        (Axis::Ry, 0x34),
+        (Axis::Rz, 0x35),
+    ];
+
+    static SAW_A_REPORT: AtomicBool = AtomicBool::new(false);
+
+    pub fn report() -> String {
+        if SAW_A_REPORT.load(Ordering::Relaxed) {
+            "Reading the puck through IOKit.".to_string()
+        } else {
+            "Listening for a six axis device through IOKit; none has reported yet. macOS may \
+             need Input Monitoring for BrokkrSculpt in Privacy & Security."
+                .to_string()
+        }
+    }
+
+    pub fn spawn(shared: Arc<Shared>) {
+        std::thread::Builder::new()
+            .name("brokkr-puck".to_string())
+            .spawn(move || {
+                raw_hid::pump(PAGE_GENERIC, USAGE_MULTI_AXIS, move |sample| {
+                    decode(&shared, sample);
+                });
+            })
+            .ok();
+    }
+
+    fn decode(shared: &Arc<Shared>, sample: Sample) {
+        if sample.page == PAGE_BUTTON {
+            // Buttons are numbered from one on their own page; `press` counts
+            // from zero, and a release is a zero value rather than a message.
+            if sample.value != 0 && sample.usage >= 1 {
+                shared.press(sample.usage as usize - 1);
+            }
+            return;
+        }
+        if sample.page != PAGE_GENERIC {
+            return;
+        }
+        for (axis, usage) in USAGE_AXES {
+            if sample.usage == usage {
+                shared.set_axis(axis as usize, sample.value as i32);
+                SAW_A_REPORT.store(true, Ordering::Relaxed);
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
 mod backend {
     use super::Shared;
     use std::sync::Arc;
@@ -1176,7 +1252,7 @@ mod backend {
     pub fn spawn(_shared: Arc<Shared>) {}
 
     pub fn report() -> String {
-        "The SpaceMouse is implemented for Linux and Windows so far.".to_string()
+        "The SpaceMouse is not implemented for this platform.".to_string()
     }
 }
 

--- a/crates/brokkr-app/src/tablet.rs
+++ b/crates/brokkr-app/src/tablet.rs
@@ -767,7 +767,104 @@ mod backend {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+/// macOS: the pen comes from IOKit, matched on the digitizer page.
+///
+/// The scaffolding -- the manager, the run loop and the per element callback --
+/// is [`crate::raw_hid`], shared with the puck. What is here is only which
+/// usages a pen has and what they mean, and they are the same usages Windows
+/// reads because they are the HID specification's rather than either
+/// platform's.
+///
+/// **IOKit hands over elements, not reports**, so unlike Windows there is no
+/// report to pull apart: each callback already says which usage changed and
+/// what range it declares. The cost is that tip, eraser and proximity arrive
+/// as separate callbacks rather than together, so the tool state is assembled
+/// from whichever arrives.
+#[cfg(target_os = "macos")]
+mod backend {
+    use super::Shared;
+    use crate::raw_hid::{self, PAGE_DIGITIZER, Sample};
+    use glam::Vec2;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+    pub const SUPPORTED: bool = true;
+
+    const USAGE_PEN: u32 = 0x02;
+    const USAGE_TIP_PRESSURE: u32 = 0x30;
+    const USAGE_IN_RANGE: u32 = 0x32;
+    const USAGE_X_TILT: u32 = 0x3D;
+    const USAGE_Y_TILT: u32 = 0x3E;
+    const USAGE_TIP_SWITCH: u32 = 0x42;
+    const USAGE_ERASER: u32 = 0x45;
+
+    static SAW_A_REPORT: AtomicBool = AtomicBool::new(false);
+    /// Tilt arrives one axis at a time, so the other axis has to be remembered
+    /// or every X callback would zero the Y the user is still holding.
+    static TILT_X: AtomicU32 = AtomicU32::new(0);
+    static TILT_Y: AtomicU32 = AtomicU32::new(0);
+
+    pub fn report() -> String {
+        if SAW_A_REPORT.load(Ordering::Relaxed) {
+            "Reading the pen through IOKit.".to_string()
+        } else {
+            "Listening for a pen through IOKit; none has reported yet. macOS may need \
+             Input Monitoring for BrokkrSculpt in Privacy & Security."
+                .to_string()
+        }
+    }
+
+    pub fn spawn(shared: Arc<Shared>) {
+        std::thread::Builder::new()
+            .name("brokkr-pen".to_string())
+            .spawn(move || {
+                raw_hid::pump(PAGE_DIGITIZER, USAGE_PEN, move |sample| {
+                    decode(&shared, sample);
+                });
+            })
+            .ok();
+    }
+
+    fn decode(shared: &Arc<Shared>, sample: Sample) {
+        if sample.page != PAGE_DIGITIZER {
+            return;
+        }
+        let down = sample.value != 0;
+        match sample.usage {
+            USAGE_TIP_SWITCH => shared.set_tool(Some(down), None),
+            USAGE_ERASER => shared.set_tool(None, Some(down)),
+            // Out of range clears both ends, which is what drops pressure and
+            // tilt; in range on its own says nothing about which end it is.
+            USAGE_IN_RANGE if !down => shared.set_tool(Some(false), Some(false)),
+            USAGE_IN_RANGE => {}
+            USAGE_TIP_PRESSURE => {
+                shared.set_pressure(scaled(&sample));
+                SAW_A_REPORT.store(true, Ordering::Relaxed);
+            }
+            USAGE_X_TILT | USAGE_Y_TILT => {
+                let value = signed(&sample);
+                let slot = if sample.usage == USAGE_X_TILT { &TILT_X } else { &TILT_Y };
+                slot.store(value.to_bits(), Ordering::Relaxed);
+                shared.set_tilt(Vec2::new(
+                    f32::from_bits(TILT_X.load(Ordering::Relaxed)),
+                    f32::from_bits(TILT_Y.load(Ordering::Relaxed)),
+                ));
+                SAW_A_REPORT.store(true, Ordering::Relaxed);
+            }
+            _ => {}
+        }
+    }
+
+    fn scaled(sample: &Sample) -> f32 {
+        super::normalise(sample.value as i32, sample.minimum as i32, sample.maximum as i32)
+    }
+
+    fn signed(sample: &Sample) -> f32 {
+        super::normalise_signed(sample.value as i32, sample.minimum as i32, sample.maximum as i32)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
 mod backend {
     use super::Shared;
     use std::sync::Arc;
@@ -780,7 +877,7 @@ mod backend {
     pub fn spawn(_shared: Arc<Shared>) {}
 
     pub fn report() -> String {
-        "Pen pressure is implemented for Linux and Windows so far.".to_string()
+        "Pen pressure is not implemented for this platform.".to_string()
     }
 }
 

--- a/crates/brokkr-app/src/tablet.rs
+++ b/crates/brokkr-app/src/tablet.rs
@@ -678,65 +678,34 @@ mod backend {
     }
 }
 
-/// Windows: the pen comes from Raw Input, and the HID report is parsed by
-/// Windows rather than by hand.
+/// Windows: the pen comes from Raw Input, on the digitizer page.
 ///
-/// **Why Raw Input and not Windows Ink or Wintab.** Ink means `WM_POINTER` on
-/// the application's own window, which would put pen handling inside iced's
-/// event loop -- and iced 0.14 drops winit's `force` field, which is the whole
-/// reason this module exists. Wintab means loading a vendor DLL that only some
-/// tablets ship. Raw Input is in the OS, needs no vendor anything, and is read
-/// on a thread of our own exactly as evdev is on Linux, so the two backends
-/// have the same shape and the same seam.
-///
-/// **`HidP_GetUsageValue` and not a report descriptor parser.** The reports are
-/// vendor-specific and the descriptor that explains them is a small language;
-/// Windows has already parsed it, and asks only for the usage. Pressure is
-/// usage 0x30 on the Digitizer page, tilt is 0x3D and 0x3E, and the logical
-/// range comes from `HidP_GetValueCaps` so a tablet reporting 0..8191 and one
-/// reporting 0..1023 both normalise correctly.
-///
-/// **A message-only window.** `RegisterRawInputDevices` needs an `HWND` to
-/// deliver to, and `RIDEV_INPUTSINK` is what makes the reports arrive even
-/// when the window is not focused -- which matters because this window is
-/// never shown and never focused. It is created on this thread, which is also
-/// the thread that pumps it: a message loop only ever receives on the thread
-/// that created the window.
+/// The scaffolding -- the sink window, the pump, and asking Windows what a
+/// report says -- is [`crate::raw_input`], shared with the puck. What is here
+/// is only which usages a pen has and what they mean.
 #[cfg(target_os = "windows")]
 mod backend {
     use super::Shared;
+    use crate::raw_input::{self, PAGE_DIGITIZER};
     use glam::Vec2;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
-
-    use windows_sys::Win32::Devices::HumanInterfaceDevice::{
-        HIDP_STATUS_SUCCESS, HIDP_VALUE_CAPS, HidP_GetUsageValue, HidP_GetUsages,
-        HidP_GetValueCaps, HidP_Input, PHIDP_PREPARSED_DATA,
-    };
-    use windows_sys::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
-    use windows_sys::Win32::UI::Input::{
-        GetRawInputData, GetRawInputDeviceInfoW, HRAWINPUT, RAWINPUT, RAWINPUTDEVICE,
-        RAWINPUTHEADER, RID_INPUT, RIDEV_INPUTSINK, RIDI_PREPARSEDDATA, RegisterRawInputDevices,
-    };
-    use windows_sys::Win32::UI::WindowsAndMessaging::{
-        CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, HWND_MESSAGE, MSG,
-        RegisterClassW, WM_INPUT, WNDCLASSW,
-    };
+    use windows_sys::Win32::Devices::HumanInterfaceDevice::PHIDP_PREPARSED_DATA;
 
     pub const SUPPORTED: bool = true;
 
-    /// HID usage page for digitizers, and the usages this reads from it.
-    const PAGE_DIGITIZER: u16 = 0x0D;
+    /// Usage 0x02 on the digitizer page is a pen; the rest are what it reports.
     const USAGE_PEN: u16 = 0x02;
-    const USAGE_IN_RANGE: u16 = 0x32;
     const USAGE_TIP_PRESSURE: u16 = 0x30;
-    const USAGE_TIP_SWITCH: u16 = 0x42;
-    const USAGE_ERASER: u16 = 0x45;
+    const USAGE_IN_RANGE: u16 = 0x32;
     const USAGE_X_TILT: u16 = 0x3D;
     const USAGE_Y_TILT: u16 = 0x3E;
+    const USAGE_TIP_SWITCH: u16 = 0x42;
+    const USAGE_ERASER: u16 = 0x45;
 
-    /// Set once a report has been decoded, so `report` can say whether the
-    /// pipe is live rather than only whether it was set up.
+    /// Set once a report has been decoded, so the panel can say whether the
+    /// pipe is LIVE rather than only whether it was set up. On a platform
+    /// nobody here can test, that difference is the whole value of the panel.
     static SAW_A_REPORT: AtomicBool = AtomicBool::new(false);
 
     pub fn report() -> String {
@@ -750,254 +719,51 @@ mod backend {
     pub fn spawn(shared: Arc<Shared>) {
         std::thread::Builder::new()
             .name("brokkr-pen".to_string())
-            .spawn(move || unsafe { pump(&shared) })
+            .spawn(move || {
+                raw_input::pump("BrokkrPenSink", PAGE_DIGITIZER, USAGE_PEN, |data, report| {
+                    decode(&shared, data, report);
+                });
+            })
             .ok();
     }
 
-    /// Create the sink window, register for pen reports, and pump until the
-    /// process ends.
-    ///
-    /// Failures are silent by design and leave `SUPPORTED` true with no reports
-    /// arriving, which `report` then says out loud. A pen that cannot be read
-    /// must not stop the application starting -- the same rule the evdev
-    /// backend follows.
-    unsafe fn pump(shared: &Arc<Shared>) {
-        let class_name: Vec<u16> = "BrokkrPenSink\0".encode_utf16().collect();
-        let mut class: WNDCLASSW = unsafe { std::mem::zeroed() };
-        class.lpfnWndProc = Some(wndproc);
-        class.lpszClassName = class_name.as_ptr();
-        unsafe { RegisterClassW(&class) };
+    fn decode(shared: &Arc<Shared>, data: PHIDP_PREPARSED_DATA, report: &[u8]) {
+        let at = |usage| raw_input::button(data, report, PAGE_DIGITIZER, usage);
+        let (tip, eraser, in_range) = (at(USAGE_TIP_SWITCH), at(USAGE_ERASER), at(USAGE_IN_RANGE));
 
-        let window = unsafe {
-            CreateWindowExW(
-                0,
-                class_name.as_ptr(),
-                class_name.as_ptr(),
-                0,
-                0,
-                0,
-                0,
-                0,
-                HWND_MESSAGE,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                std::ptr::null(),
-            )
-        };
-        if window.is_null() {
-            return;
-        }
-
-        let device = RAWINPUTDEVICE {
-            usUsagePage: PAGE_DIGITIZER,
-            usUsage: USAGE_PEN,
-            // Delivered even unfocused, which this window always is.
-            dwFlags: RIDEV_INPUTSINK,
-            hwndTarget: window,
-        };
-        if unsafe { RegisterRawInputDevices(&device, 1, size_of::<RAWINPUTDEVICE>() as u32) == 0 } {
-            return;
-        }
-
-        let mut message: MSG = unsafe { std::mem::zeroed() };
-        // `GetMessageW` returns -1 on error, 0 on WM_QUIT, positive otherwise.
-        while unsafe { GetMessageW(&mut message, std::ptr::null_mut(), 0, 0) } > 0 {
-            if message.message == WM_INPUT {
-                unsafe { handle(shared, message.lParam as isize as HRAWINPUT) };
-            }
-            unsafe { DispatchMessageW(&message) };
-        }
-    }
-
-    /// Nothing to do here: `WM_INPUT` is read from the message loop rather than
-    /// from the procedure, so the report is handled on the same thread either
-    /// way and there is no state to keep between them.
-    unsafe extern "system" fn wndproc(window: HWND, message: u32, w: WPARAM, l: LPARAM) -> LRESULT {
-        unsafe { DefWindowProcW(window, message, w, l) }
-    }
-
-    /// Decode one report and push it at `Shared`.
-    unsafe fn handle(shared: &Arc<Shared>, handle: HRAWINPUT) {
-        let header = size_of::<RAWINPUTHEADER>() as u32;
-        let mut size = 0u32;
-        if unsafe { GetRawInputData(handle, RID_INPUT, std::ptr::null_mut(), &mut size, header) }
-            != 0
-            || size == 0
-        {
-            return;
-        }
-        let mut buffer = vec![0u8; size as usize];
-        let read = unsafe {
-            GetRawInputData(handle, RID_INPUT, buffer.as_mut_ptr().cast(), &mut size, header)
-        };
-        if read != size {
-            return;
-        }
-
-        let raw = buffer.as_ptr() as *const RAWINPUT;
-        let hid = unsafe { &(*raw).data.hid };
-        let count = hid.dwCount as usize;
-        let stride = hid.dwSizeHid as usize;
-        if count == 0 || stride == 0 {
-            return;
-        }
-
-        let Some(preparsed) = (unsafe { preparsed_data((*raw).header.hDevice) }) else {
-            return;
-        };
-        let data = preparsed.as_ptr() as PHIDP_PREPARSED_DATA;
-        let reports = hid.bRawData.as_ptr();
-
-        for index in 0..count {
-            let report = unsafe { std::slice::from_raw_parts(reports.add(index * stride), stride) };
-            unsafe { decode(shared, data, report) };
-        }
-    }
-
-    /// The device's parsed report descriptor, which Windows keeps for us.
-    unsafe fn preparsed_data(device: *mut core::ffi::c_void) -> Option<Vec<u8>> {
-        let mut size = 0u32;
-        unsafe {
-            GetRawInputDeviceInfoW(device, RIDI_PREPARSEDDATA, std::ptr::null_mut(), &mut size)
-        };
-        if size == 0 {
-            return None;
-        }
-        let mut buffer = vec![0u8; size as usize];
-        let read = unsafe {
-            GetRawInputDeviceInfoW(
-                device,
-                RIDI_PREPARSEDDATA,
-                buffer.as_mut_ptr().cast(),
-                &mut size,
-            )
-        };
-        // Returns the bytes written, or -1 (as u32) when the buffer was short.
-        if read == u32::MAX || read == 0 { None } else { Some(buffer) }
-    }
-
-    /// Pull the usages this application cares about out of one report.
-    unsafe fn decode(shared: &Arc<Shared>, data: PHIDP_PREPARSED_DATA, report: &[u8]) {
-        let mut tip = None;
-        let mut eraser = None;
-        let mut in_range = None;
-        for (usage, slot) in [
-            (USAGE_TIP_SWITCH, &mut tip),
-            (USAGE_ERASER, &mut eraser),
-            (USAGE_IN_RANGE, &mut in_range),
-        ] {
-            *slot = unsafe { button(data, report, usage) };
-        }
-
-        // Proximity first: `set_tool` clears pressure and tilt when the pen
-        // leaves, and doing it after would clear the values just written.
+        // Proximity FIRST: `set_tool` clears pressure and tilt when the pen
+        // leaves, so doing it afterwards would wipe the values just written.
         match (in_range, tip, eraser) {
             (Some(false), _, _) => shared.set_tool(Some(false), Some(false)),
-            (_, tip, eraser) if tip.is_some() || eraser.is_some() => {
-                shared.set_tool(tip, eraser);
-            }
+            (_, tip, eraser) if tip.is_some() || eraser.is_some() => shared.set_tool(tip, eraser),
             _ => {}
         }
 
-        if let Some(pressure) = unsafe { scaled(data, report, USAGE_TIP_PRESSURE) } {
+        if let Some(pressure) = scaled(data, report, USAGE_TIP_PRESSURE) {
             shared.set_pressure(pressure);
             SAW_A_REPORT.store(true, Ordering::Relaxed);
         }
 
-        let x = unsafe { signed(data, report, USAGE_X_TILT) };
-        let y = unsafe { signed(data, report, USAGE_Y_TILT) };
+        let x = signed(data, report, USAGE_X_TILT);
+        let y = signed(data, report, USAGE_Y_TILT);
         if x.is_some() || y.is_some() {
             shared.set_tilt(Vec2::new(x.unwrap_or(0.0), y.unwrap_or(0.0)));
             SAW_A_REPORT.store(true, Ordering::Relaxed);
         }
     }
 
-    /// Whether a digitizer button usage is set in this report.
-    ///
-    /// `HidP_GetUsages` fills the usages that are ON, so a usage the device has
-    /// but is not asserting comes back absent -- which is the difference
-    /// between "up" and "this device has no such button" and is why the
-    /// capability is checked separately by the caller through `None`.
-    unsafe fn button(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<bool> {
-        let mut list = [0u16; 16];
-        let mut length = list.len() as u32;
-        let status = unsafe {
-            HidP_GetUsages(
-                HidP_Input,
-                PAGE_DIGITIZER,
-                0,
-                list.as_mut_ptr(),
-                &mut length,
-                data,
-                report.as_ptr() as *mut u8,
-                report.len() as u32,
-            )
-        };
-        if status != HIDP_STATUS_SUCCESS {
-            return None;
-        }
-        Some(list[..length as usize].contains(&usage))
-    }
-
-    /// A value usage normalised to 0..1 against the range the device declares.
-    unsafe fn scaled(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<f32> {
-        let raw = unsafe { value(data, report, usage)? };
-        let (minimum, maximum) = unsafe { range(data, usage)? };
+    /// A usage normalised to 0..1 against the range the device declares.
+    fn scaled(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<f32> {
+        let raw = raw_input::value(data, report, PAGE_DIGITIZER, usage)?;
+        let (minimum, maximum) = raw_input::range(data, PAGE_DIGITIZER, usage)?;
         Some(super::normalise(raw, minimum, maximum))
     }
 
     /// The same, for a usage that swings both ways, like tilt.
-    unsafe fn signed(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<f32> {
-        let raw = unsafe { value(data, report, usage)? };
-        let (minimum, maximum) = unsafe { range(data, usage)? };
+    fn signed(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<f32> {
+        let raw = raw_input::value(data, report, PAGE_DIGITIZER, usage)?;
+        let (minimum, maximum) = raw_input::range(data, PAGE_DIGITIZER, usage)?;
         Some(super::normalise_signed(raw, minimum, maximum))
-    }
-
-    unsafe fn value(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<i32> {
-        let mut out = 0u32;
-        let status = unsafe {
-            HidP_GetUsageValue(
-                HidP_Input,
-                PAGE_DIGITIZER,
-                0,
-                usage,
-                &mut out,
-                data,
-                report.as_ptr() as *mut u8,
-                report.len() as u32,
-            )
-        };
-        (status == HIDP_STATUS_SUCCESS).then_some(out as i32)
-    }
-
-    /// The logical range the device declares for a usage.
-    ///
-    /// Read from the caps rather than assumed: a tablet reporting 0..8191 and
-    /// one reporting 0..1023 are both ordinary, and assuming either would give
-    /// the other eight times the pressure or an eighth of it.
-    unsafe fn range(data: PHIDP_PREPARSED_DATA, usage: u16) -> Option<(i32, i32)> {
-        let mut count = 0u16;
-        // Asked for the count first: the caps array is per device and a fixed
-        // guess would either truncate a rich tablet or waste a page on a plain
-        // one.
-        let status =
-            unsafe { HidP_GetValueCaps(HidP_Input, std::ptr::null_mut(), &mut count, data) };
-        // A short buffer is the expected answer to a null one, and carries the
-        // count we asked for.
-        if count == 0 && status == HIDP_STATUS_SUCCESS {
-            return None;
-        }
-        let mut caps: Vec<HIDP_VALUE_CAPS> = vec![unsafe { std::mem::zeroed() }; count as usize];
-        let status = unsafe { HidP_GetValueCaps(HidP_Input, caps.as_mut_ptr(), &mut count, data) };
-        if status != HIDP_STATUS_SUCCESS {
-            return None;
-        }
-        caps[..count as usize].iter().find_map(|cap| {
-            let matches = cap.UsagePage == PAGE_DIGITIZER
-                && !cap.IsRange
-                && unsafe { cap.Anonymous.NotRange.Usage } == usage;
-            matches.then_some((cap.LogicalMin, cap.LogicalMax))
-        })
     }
 }
 

--- a/crates/brokkr-app/src/tablet.rs
+++ b/crates/brokkr-app/src/tablet.rs
@@ -678,20 +678,343 @@ mod backend {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+/// Windows: the pen comes from Raw Input, and the HID report is parsed by
+/// Windows rather than by hand.
+///
+/// **Why Raw Input and not Windows Ink or Wintab.** Ink means `WM_POINTER` on
+/// the application's own window, which would put pen handling inside iced's
+/// event loop -- and iced 0.14 drops winit's `force` field, which is the whole
+/// reason this module exists. Wintab means loading a vendor DLL that only some
+/// tablets ship. Raw Input is in the OS, needs no vendor anything, and is read
+/// on a thread of our own exactly as evdev is on Linux, so the two backends
+/// have the same shape and the same seam.
+///
+/// **`HidP_GetUsageValue` and not a report descriptor parser.** The reports are
+/// vendor-specific and the descriptor that explains them is a small language;
+/// Windows has already parsed it, and asks only for the usage. Pressure is
+/// usage 0x30 on the Digitizer page, tilt is 0x3D and 0x3E, and the logical
+/// range comes from `HidP_GetValueCaps` so a tablet reporting 0..8191 and one
+/// reporting 0..1023 both normalise correctly.
+///
+/// **A message-only window.** `RegisterRawInputDevices` needs an `HWND` to
+/// deliver to, and `RIDEV_INPUTSINK` is what makes the reports arrive even
+/// when the window is not focused -- which matters because this window is
+/// never shown and never focused. It is created on this thread, which is also
+/// the thread that pumps it: a message loop only ever receives on the thread
+/// that created the window.
+#[cfg(target_os = "windows")]
+mod backend {
+    use super::Shared;
+    use glam::Vec2;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use windows_sys::Win32::Devices::HumanInterfaceDevice::{
+        HIDP_STATUS_SUCCESS, HIDP_VALUE_CAPS, HidP_GetUsageValue, HidP_GetUsages,
+        HidP_GetValueCaps, HidP_Input, PHIDP_PREPARSED_DATA,
+    };
+    use windows_sys::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+    use windows_sys::Win32::UI::Input::{
+        GetRawInputData, GetRawInputDeviceInfoW, HRAWINPUT, RAWINPUT, RAWINPUTDEVICE,
+        RAWINPUTHEADER, RID_INPUT, RIDEV_INPUTSINK, RIDI_PREPARSEDDATA, RegisterRawInputDevices,
+    };
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, HWND_MESSAGE, MSG,
+        RegisterClassW, WM_INPUT, WNDCLASSW,
+    };
+
+    pub const SUPPORTED: bool = true;
+
+    /// HID usage page for digitizers, and the usages this reads from it.
+    const PAGE_DIGITIZER: u16 = 0x0D;
+    const USAGE_PEN: u16 = 0x02;
+    const USAGE_IN_RANGE: u16 = 0x32;
+    const USAGE_TIP_PRESSURE: u16 = 0x30;
+    const USAGE_TIP_SWITCH: u16 = 0x42;
+    const USAGE_ERASER: u16 = 0x45;
+    const USAGE_X_TILT: u16 = 0x3D;
+    const USAGE_Y_TILT: u16 = 0x3E;
+
+    /// Set once a report has been decoded, so `report` can say whether the
+    /// pipe is live rather than only whether it was set up.
+    static SAW_A_REPORT: AtomicBool = AtomicBool::new(false);
+
+    pub fn report() -> String {
+        if SAW_A_REPORT.load(Ordering::Relaxed) {
+            "Reading the pen through Raw Input.".to_string()
+        } else {
+            "Listening for a pen through Raw Input; none has reported yet.".to_string()
+        }
+    }
+
+    pub fn spawn(shared: Arc<Shared>) {
+        std::thread::Builder::new()
+            .name("brokkr-pen".to_string())
+            .spawn(move || unsafe { pump(&shared) })
+            .ok();
+    }
+
+    /// Create the sink window, register for pen reports, and pump until the
+    /// process ends.
+    ///
+    /// Failures are silent by design and leave `SUPPORTED` true with no reports
+    /// arriving, which `report` then says out loud. A pen that cannot be read
+    /// must not stop the application starting -- the same rule the evdev
+    /// backend follows.
+    unsafe fn pump(shared: &Arc<Shared>) {
+        let class_name: Vec<u16> = "BrokkrPenSink\0".encode_utf16().collect();
+        let mut class: WNDCLASSW = unsafe { std::mem::zeroed() };
+        class.lpfnWndProc = Some(wndproc);
+        class.lpszClassName = class_name.as_ptr();
+        unsafe { RegisterClassW(&class) };
+
+        let window = unsafe {
+            CreateWindowExW(
+                0,
+                class_name.as_ptr(),
+                class_name.as_ptr(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                HWND_MESSAGE,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null(),
+            )
+        };
+        if window.is_null() {
+            return;
+        }
+
+        let device = RAWINPUTDEVICE {
+            usUsagePage: PAGE_DIGITIZER,
+            usUsage: USAGE_PEN,
+            // Delivered even unfocused, which this window always is.
+            dwFlags: RIDEV_INPUTSINK,
+            hwndTarget: window,
+        };
+        if unsafe { RegisterRawInputDevices(&device, 1, size_of::<RAWINPUTDEVICE>() as u32) == 0 } {
+            return;
+        }
+
+        let mut message: MSG = unsafe { std::mem::zeroed() };
+        // `GetMessageW` returns -1 on error, 0 on WM_QUIT, positive otherwise.
+        while unsafe { GetMessageW(&mut message, std::ptr::null_mut(), 0, 0) } > 0 {
+            if message.message == WM_INPUT {
+                unsafe { handle(shared, message.lParam as isize as HRAWINPUT) };
+            }
+            unsafe { DispatchMessageW(&message) };
+        }
+    }
+
+    /// Nothing to do here: `WM_INPUT` is read from the message loop rather than
+    /// from the procedure, so the report is handled on the same thread either
+    /// way and there is no state to keep between them.
+    unsafe extern "system" fn wndproc(window: HWND, message: u32, w: WPARAM, l: LPARAM) -> LRESULT {
+        unsafe { DefWindowProcW(window, message, w, l) }
+    }
+
+    /// Decode one report and push it at `Shared`.
+    unsafe fn handle(shared: &Arc<Shared>, handle: HRAWINPUT) {
+        let header = size_of::<RAWINPUTHEADER>() as u32;
+        let mut size = 0u32;
+        if unsafe { GetRawInputData(handle, RID_INPUT, std::ptr::null_mut(), &mut size, header) }
+            != 0
+            || size == 0
+        {
+            return;
+        }
+        let mut buffer = vec![0u8; size as usize];
+        let read = unsafe {
+            GetRawInputData(handle, RID_INPUT, buffer.as_mut_ptr().cast(), &mut size, header)
+        };
+        if read != size {
+            return;
+        }
+
+        let raw = buffer.as_ptr() as *const RAWINPUT;
+        let hid = unsafe { &(*raw).data.hid };
+        let count = hid.dwCount as usize;
+        let stride = hid.dwSizeHid as usize;
+        if count == 0 || stride == 0 {
+            return;
+        }
+
+        let Some(preparsed) = (unsafe { preparsed_data((*raw).header.hDevice) }) else {
+            return;
+        };
+        let data = preparsed.as_ptr() as PHIDP_PREPARSED_DATA;
+        let reports = hid.bRawData.as_ptr();
+
+        for index in 0..count {
+            let report = unsafe { std::slice::from_raw_parts(reports.add(index * stride), stride) };
+            unsafe { decode(shared, data, report) };
+        }
+    }
+
+    /// The device's parsed report descriptor, which Windows keeps for us.
+    unsafe fn preparsed_data(device: *mut core::ffi::c_void) -> Option<Vec<u8>> {
+        let mut size = 0u32;
+        unsafe {
+            GetRawInputDeviceInfoW(device, RIDI_PREPARSEDDATA, std::ptr::null_mut(), &mut size)
+        };
+        if size == 0 {
+            return None;
+        }
+        let mut buffer = vec![0u8; size as usize];
+        let read = unsafe {
+            GetRawInputDeviceInfoW(
+                device,
+                RIDI_PREPARSEDDATA,
+                buffer.as_mut_ptr().cast(),
+                &mut size,
+            )
+        };
+        // Returns the bytes written, or -1 (as u32) when the buffer was short.
+        if read == u32::MAX || read == 0 { None } else { Some(buffer) }
+    }
+
+    /// Pull the usages this application cares about out of one report.
+    unsafe fn decode(shared: &Arc<Shared>, data: PHIDP_PREPARSED_DATA, report: &[u8]) {
+        let mut tip = None;
+        let mut eraser = None;
+        let mut in_range = None;
+        for (usage, slot) in [
+            (USAGE_TIP_SWITCH, &mut tip),
+            (USAGE_ERASER, &mut eraser),
+            (USAGE_IN_RANGE, &mut in_range),
+        ] {
+            *slot = unsafe { button(data, report, usage) };
+        }
+
+        // Proximity first: `set_tool` clears pressure and tilt when the pen
+        // leaves, and doing it after would clear the values just written.
+        match (in_range, tip, eraser) {
+            (Some(false), _, _) => shared.set_tool(Some(false), Some(false)),
+            (_, tip, eraser) if tip.is_some() || eraser.is_some() => {
+                shared.set_tool(tip, eraser);
+            }
+            _ => {}
+        }
+
+        if let Some(pressure) = unsafe { scaled(data, report, USAGE_TIP_PRESSURE) } {
+            shared.set_pressure(pressure);
+            SAW_A_REPORT.store(true, Ordering::Relaxed);
+        }
+
+        let x = unsafe { signed(data, report, USAGE_X_TILT) };
+        let y = unsafe { signed(data, report, USAGE_Y_TILT) };
+        if x.is_some() || y.is_some() {
+            shared.set_tilt(Vec2::new(x.unwrap_or(0.0), y.unwrap_or(0.0)));
+            SAW_A_REPORT.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Whether a digitizer button usage is set in this report.
+    ///
+    /// `HidP_GetUsages` fills the usages that are ON, so a usage the device has
+    /// but is not asserting comes back absent -- which is the difference
+    /// between "up" and "this device has no such button" and is why the
+    /// capability is checked separately by the caller through `None`.
+    unsafe fn button(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<bool> {
+        let mut list = [0u16; 16];
+        let mut length = list.len() as u32;
+        let status = unsafe {
+            HidP_GetUsages(
+                HidP_Input,
+                PAGE_DIGITIZER,
+                0,
+                list.as_mut_ptr(),
+                &mut length,
+                data,
+                report.as_ptr() as *mut u8,
+                report.len() as u32,
+            )
+        };
+        if status != HIDP_STATUS_SUCCESS {
+            return None;
+        }
+        Some(list[..length as usize].contains(&usage))
+    }
+
+    /// A value usage normalised to 0..1 against the range the device declares.
+    unsafe fn scaled(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<f32> {
+        let raw = unsafe { value(data, report, usage)? };
+        let (minimum, maximum) = unsafe { range(data, usage)? };
+        Some(super::normalise(raw, minimum, maximum))
+    }
+
+    /// The same, for a usage that swings both ways, like tilt.
+    unsafe fn signed(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<f32> {
+        let raw = unsafe { value(data, report, usage)? };
+        let (minimum, maximum) = unsafe { range(data, usage)? };
+        Some(super::normalise_signed(raw, minimum, maximum))
+    }
+
+    unsafe fn value(data: PHIDP_PREPARSED_DATA, report: &[u8], usage: u16) -> Option<i32> {
+        let mut out = 0u32;
+        let status = unsafe {
+            HidP_GetUsageValue(
+                HidP_Input,
+                PAGE_DIGITIZER,
+                0,
+                usage,
+                &mut out,
+                data,
+                report.as_ptr() as *mut u8,
+                report.len() as u32,
+            )
+        };
+        (status == HIDP_STATUS_SUCCESS).then_some(out as i32)
+    }
+
+    /// The logical range the device declares for a usage.
+    ///
+    /// Read from the caps rather than assumed: a tablet reporting 0..8191 and
+    /// one reporting 0..1023 are both ordinary, and assuming either would give
+    /// the other eight times the pressure or an eighth of it.
+    unsafe fn range(data: PHIDP_PREPARSED_DATA, usage: u16) -> Option<(i32, i32)> {
+        let mut count = 0u16;
+        // Asked for the count first: the caps array is per device and a fixed
+        // guess would either truncate a rich tablet or waste a page on a plain
+        // one.
+        let status =
+            unsafe { HidP_GetValueCaps(HidP_Input, std::ptr::null_mut(), &mut count, data) };
+        // A short buffer is the expected answer to a null one, and carries the
+        // count we asked for.
+        if count == 0 && status == HIDP_STATUS_SUCCESS {
+            return None;
+        }
+        let mut caps: Vec<HIDP_VALUE_CAPS> = vec![unsafe { std::mem::zeroed() }; count as usize];
+        let status = unsafe { HidP_GetValueCaps(HidP_Input, caps.as_mut_ptr(), &mut count, data) };
+        if status != HIDP_STATUS_SUCCESS {
+            return None;
+        }
+        caps[..count as usize].iter().find_map(|cap| {
+            let matches = cap.UsagePage == PAGE_DIGITIZER
+                && !cap.IsRange
+                && unsafe { cap.Anonymous.NotRange.Usage } == usage;
+            matches.then_some((cap.LogicalMin, cap.LogicalMax))
+        })
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 mod backend {
     use super::Shared;
     use std::sync::Arc;
 
     pub const SUPPORTED: bool = false;
 
-    /// Windows would use Pointer Input or Wintab, macOS `NSEvent` pressure.
-    /// Both are milestones away, and the application degrades to full pressure
-    /// in the meantime, which is what it already does for a mouse.
+    /// macOS would use `IOHIDManager`, which is a milestone away, and the
+    /// application degrades to full pressure in the meantime -- which is what
+    /// it already does for a mouse.
     pub fn spawn(_shared: Arc<Shared>) {}
 
     pub fn report() -> String {
-        "Pen pressure is implemented for Linux only so far.".to_string()
+        "Pen pressure is implemented for Linux and Windows so far.".to_string()
     }
 }
 

--- a/docs/BUILD-SPEC.md
+++ b/docs/BUILD-SPEC.md
@@ -26,7 +26,9 @@ Note that the Microsoft Store MSIX path does not care about repo visibility, so 
 
 A native desktop 3D sculpting application in the spirit of ZBrush and Nomad Sculpt. Voxel/SDF based, GPU accelerated, Linux first, built to stay interactive at high detail. Output is print ready geometry, so watertight and manifold meshes are a hard requirement, not a nice to have.
 
-**Primary target platform: Linux.** Nomad Sculpt ships desktop builds for Windows and macOS but not Linux. That gap is the reason this project exists. Windows and macOS come later and must not compromise the Linux build.
+**Primary target platform: Linux.** Nomad Sculpt ships desktop builds for Windows and macOS but not Linux. That gap is the reason this project exists, and it does not stop being the reason now that all three ship.
+
+**Status, 2026-08-29: all three build and are published.** Linux is still where the work happens and still sets the bar; Windows and macOS compile from the same commit, run the same suite, and are held to "must not compromise the Linux build" exactly as written. What they do NOT yet have is time on real hardware -- see the platform table in the README, which says specifically what is unproven on each.
 
 ## What we are explicitly NOT building
 
@@ -151,7 +153,7 @@ Done when: a sphere at a 256-cubed effective volume can be sculpted continuously
 ### M1: A real brush system
 
 - Brushes: draw, clay, smooth, inflate, pinch, flatten
-- Radius and strength, with pressure support if a stylus is present
+- Radius and strength, with pressure support if a stylus is present. Read below the toolkit on every platform -- evdev on Linux, Raw Input on Windows, IOKit on macOS -- because iced drops winit's `force` field and winit has no desktop pen pressure to drop.
 - Falloff curve control
 - X axis symmetry
 - Stroke interpolation
@@ -190,13 +192,16 @@ Treat these as tests, not aspirations. Add a benchmark harness at M0 and keep it
 - Never allocate in the per frame path
 - Never remesh a brick that was not marked dirty
 
-## Distribution (context only, do not build yet)
+## Distribution
 
-Recorded so packaging decisions are not made blindly later:
+**No longer context only: an unsigned rolling `beta` prerelease ships all three
+platforms from `.github/workflows/release.yml`, rebuilt on every push to
+`main`.** Signing is the part still waiting on funding, and the notes below are
+what it will cost when it happens.
 
-- **Linux:** first and primary. AppImage plus tarball, matching SindriCAD's approach.
+- **Linux:** first and primary. A tarball ships today; AppImage is still wanted, matching SindriCAD's approach.
 - **Windows:** package as **MSIX for the Microsoft Store**. Store registration is now free for both individual and company accounts, and Microsoft re-signs MSIX packages server side, so Store users never see a SmartScreen warning and no certificate purchase is needed. Note that a plain EXE or MSI submitted to the Store is NOT re-signed. Direct downloads from tinkeratlas.com still need separate signing, free via SignPath Foundation if the project is open source.
-- **macOS:** last. Requires the 99 USD per year Apple Developer Program for notarization. The old right-click-to-open Gatekeeper bypass was removed in macOS Sequoia, so unsigned builds now force users through System Settings, Privacy and Security, "Open Anyway", and an admin password. This is the only platform with an unavoidable recurring cost.
+- **macOS:** ships unsigned as a `.app` in a zip, built with `ditto` to keep the bundle structure. Requires the 99 USD per year Apple Developer Program for notarization, and is the only platform with an unavoidable recurring cost. The old right-click-to-open Gatekeeper bypass was removed in macOS Sequoia, so unsigned builds force users through System Settings, Privacy and Security, "Open Anyway", and an admin password -- **and an app with no signature at all may not appear in that list to be excused**, which is why the release notes give `xattr -dr com.apple.quarantine` as the primary instruction rather than the Apple-supported route.
 
 ## Working conventions
 


### PR DESCRIPTION
A sculpting tool without pressure is a sculpting tool with one blunt setting, so this is the platform gap that mattered most.

## Why Raw Input, not Windows Ink or Wintab

- **Ink** means `WM_POINTER` on the application's own window — which puts pen handling back inside iced's event loop, and iced 0.14 dropping winit's `force` field is the entire reason this module exists.
- **Wintab** means loading a vendor DLL that only some tablets ship.
- **Raw Input** is in the OS, needs no vendor anything, and is read on a thread of our own exactly as evdev is. Both backends end up the same shape and fill the same seam: `set_pressure`, `set_tilt`, `set_tool`.

## Windows parses the HID report, not this

The reports are vendor-specific and the descriptor explaining them is a small language. `HidP_GetUsageValue` asks by usage instead — pressure is `0x30` on the digitizer page, tilt `0x3D`/`0x3E` — and `HidP_GetValueCaps` supplies the logical range, so a tablet reporting 0–8191 and one reporting 0–1023 both normalise correctly rather than one coming out eight times too strong.

`RIDEV_INPUTSINK` on a message-only window, because that window is never focused and reports would otherwise only arrive when it was.

## Compiled, not tested — and it says so

There is no Windows machine and no tablet here. The PEN panel distinguishes the two states in its own words:

> *"Listening for a pen through Raw Input; none has reported yet"* — versus — *"Reading the pen through Raw Input."*

So a beta user with a tablet settles it in one screenshot, and the fallback to full pressure means a silent failure degrades to exactly today's behaviour rather than to something worse.

Installing mingw-w64 locally made this tractable: `cargo check --target x86_64-pc-windows-gnu` caught two type errors and a warning in three minutes, which would otherwise have been three 25-minute CI rounds.

`windows-sys` is already in the graph on that target via winit, so this adds feature surface rather than a crate. Windows target clean, Linux clean, 1316 tests pass.

**macOS stylus and both SpaceMouse backends are deliberately not here** — no redistributable SDK means macOS code cannot even be typechecked locally, and shipping an input driver whose only check is a CI compile is not a claim worth making.