### PR TITLE
Cut with a shape you draw, not just a line across everything

### DIFF
--- a/crates/brokkr-app/src/app.rs
+++ b/crates/brokkr-app/src/app.rs
@@ -19,6 +19,8 @@ use iced::{Subscription, Task};
 
 use crate::camera::OrbitCamera;
 use crate::cursor;
+use crate::cut;
+use crate::cut_preview;
 use crate::gizmo;
 use crate::message::{
     ConfirmChoice, ExportFormat, MaskGenerator, Message, PanelSection, PointerButton, PointerEvent,
@@ -228,6 +230,30 @@ const FRAME_HISTORY: usize = 60;
 /// and a small deliberate orbit opens a menu over the model. Four pixels and a
 /// quarter second are a starting point to tune by feel, which is why both are
 /// named.
+/// The narrowest a cut region may be, in voxels, before it is refused.
+///
+/// Two, because one is not enough: a region exactly one voxel across lands on a
+/// row of voxel centres or falls between two rows depending on where the
+/// lattice sits under it, so it removes material in some places and not others
+/// for reasons the user cannot see. Two guarantees at least one centre across
+/// the narrow direction wherever the region happens to fall.
+const MIN_CUT_WIDTH_VOXELS: f32 = 2.0;
+
+/// Bricks a cut may walk looking for loose pieces before it gives up.
+///
+/// **Sized from a time budget rather than from a memory one.**
+/// `Document::split_plan` measures 13 to 17 microseconds per brick -- 423
+/// bricks in 7.2 ms, 7,665 in 103 ms, close to linear -- so a brick ceiling IS
+/// a time ceiling once the slope is known. At 14 us a brick, 1,200 bricks is
+/// about one 16 ms frame, which is the right order for something appended to a
+/// status line.
+///
+/// The number this replaced was 24,000, chosen to sound like "a large model".
+/// At the measured slope that is roughly 320 milliseconds -- twenty frames --
+/// spent deciding whether to add five words to a sentence, on top of a cut that
+/// costs five.
+const MOST_BRICKS_TO_WALK: usize = 1_200;
+
 const CLICK_SLOP_PX: f32 = 4.0;
 const CLICK_MS: u128 = 250;
 
@@ -466,6 +492,19 @@ pub struct Brokkr {
     /// Stamp centres produced by the current pointer event. Reused so a stroke
     /// does not allocate.
     stamp_centres: Vec<Vec3>,
+    /// The whole path the pointer has taken during a live cut, in widget
+    /// pixels.
+    ///
+    /// **The whole path and not just its ends**, because the shape is inferred
+    /// from what was drawn and the ends of a lasso are the same two points as
+    /// the ends of a click.
+    ///
+    /// It lives here rather than in [`Drag`] because `Drag` is `Copy` and is
+    /// read by value at every pointer event; a `Vec` in it would be cloned
+    /// several times per motion, which is exactly the allocation a per-event
+    /// path most needs to avoid. Cleared at the press and drained at the
+    /// release, so it holds nothing between gestures.
+    cut_path: Vec<Vec2>,
     /// Bricks waiting to be remeshed, each tagged with the body it belongs to.
     ///
     /// One list across the whole document rather than one per body, because
@@ -1897,6 +1936,7 @@ impl Brokkr {
             move_grab: None,
             move_stroke: MoveStroke::new(),
             stamp_centres: Vec::new(),
+            cut_path: Vec::new(),
             dirty: Vec::new(),
             shown: Vec::new(),
             hidden_bodies: Vec::new(),
@@ -4516,8 +4556,81 @@ impl Brokkr {
             ),
             self.model_radius,
         );
+        self.add_cut_preview(&mut batch);
         self.shared.swap_overlay(&mut batch);
         self.overlay = batch;
+    }
+
+    /// Add the live cut's outline to the overlay, if a cut is being drawn.
+    ///
+    /// Appended after the ring rather than instead of it, because the batch is
+    /// shared -- and the ring is already gone by the time this runs, taken away
+    /// by `refresh_hover`'s `Tool::Cut` arm.
+    ///
+    /// The projection puts the shape on the plane through the camera's target,
+    /// facing the camera. That is where the model being looked at is, and it is
+    /// the one depth at which a screen-space region is honest about its size.
+    fn add_cut_preview(&self, batch: &mut brokkr_gpu::OverlayBatch) {
+        if self.tool != Tool::Cut || self.cut_path.is_empty() {
+            return;
+        }
+        let Some(gesture) = cut::read_stroke(&self.cut_path, CLICK_SLOP_PX) else {
+            return;
+        };
+        let eye = self.camera.eye();
+        let focus = self.camera.target;
+        let Some(facing) = (focus - eye).try_normalize() else {
+            return;
+        };
+        // **In FRONT of the model, not at its centre.** The preview is a
+        // projection of screen points along the view rays, so sliding it toward
+        // the camera changes its world size and not one pixel of where it
+        // appears -- it is screen-exact at every depth. What it does change is
+        // whether the depth test keeps it: drawn on the plane through the
+        // camera's target, the outline of a loop over the model sits INSIDE the
+        // model and is occluded by the very surface it is describing. The line
+        // cut hid this for a while, because its shaded band reaches three model
+        // radii out and the part beyond the silhouette has nothing in front of
+        // it -- so the band appeared over the background and vanished over the
+        // model, which reads as a rendering quirk rather than as the bug it is.
+        //
+        // Just clear of the bounding sphere, and never closer than twice the
+        // near plane, so it cannot be clipped away instead.
+        let depth =
+            ((focus - eye).length() - self.model_radius * 1.05).max(self.camera.near() * 2.0);
+        let plane_at = eye + facing * depth;
+        // Taken from the planes the cut is ACTUALLY about to use, so the shaded
+        // side and the removed side cannot disagree. `cutter_from_hull` is the
+        // one place the sign is settled, and asking it again here is cheaper
+        // than a second derivation that could be wrong on its own.
+        let doomed =
+            self.cutter_from_hull(&gesture.hull).and_then(|planes| match planes.as_slice() {
+                [only] => Some(only.normal),
+                _ => None,
+            });
+        cut_preview::build(
+            batch,
+            &gesture.hull,
+            gesture.shape,
+            self.model_radius,
+            doomed,
+            // A straight drag is infinite whatever shift says, so it is always
+            // the denser shading; a shaped cut is bounded unless shift asks
+            // otherwise.
+            self.shift || gesture.shape == cut::CutShape::Line,
+            |pixel| {
+                let (origin, ray) = self.ray_through(pixel);
+                // Where the ray crosses the plane through the target. The dot
+                // product cannot be zero for a ray inside the frustum, but a
+                // fallback costs nothing and a division by it would put a
+                // vertex at infinity.
+                let denominator = ray.dot(facing);
+                if denominator.abs() < 1.0e-6 {
+                    return origin + ray * depth;
+                }
+                origin + ray * ((plane_at - origin).dot(facing) / denominator)
+            },
+        );
     }
 
     /// Where the pointer meets the surface, and on which body, remembered for
@@ -4564,7 +4677,14 @@ impl Brokkr {
         // thing -- it grabs a handle, or it chooses a body. Drawing one would
         // be the same lie the live-stroke case below exists to stop, told about
         // a different gesture.
-        if self.tool == Tool::Transform {
+        //
+        // **The cut takes it away too, and for exactly the same reason.** With
+        // the cut armed a press does not carve, it draws a line -- and a ring
+        // saying "a press here would remove this much of that surface" is the
+        // same lie told about a different gesture. It is worse here than under
+        // the gizmo, because a cut IS destructive and the ring is what a user
+        // reads to decide whether it is safe to press.
+        if self.tool == Tool::Transform || self.tool == Tool::Cut {
             self.hover = None;
             self.hover_body = None;
             return;
@@ -4796,10 +4916,25 @@ impl Brokkr {
         match (self.tool, self.shift) {
             (Tool::Mask, true) => "MASK — BLUR".to_string(),
             (Tool::Mask, false) => "MASK".to_string(),
-            (Tool::Cut, _) => "PLANE CUT".to_string(),
+            // Shape-aware, through the same live substitution the mask's BLUR
+            // uses: the tool card has to say what the gesture in progress is
+            // going to do, and "PLANE CUT" over a lasso is a lie about which
+            // material is about to go. Before a drag starts there is no shape
+            // yet and it says what an unqualified cut is.
+            (Tool::Cut, _) => self.live_cut_shape().label().to_string(),
             (Tool::Transform, _) => "MOVE".to_string(),
             (Tool::Sculpt, _) => self.effective_brush().kind.label().to_uppercase(),
         }
+    }
+
+    /// How the path drawn so far would be read, for the label and the preview.
+    ///
+    /// [`cut::CutShape::Line`] before anything is drawn, which is both the safe
+    /// default and the true one: a cut that has not been dragged yet is the cut
+    /// this application has always had.
+    fn live_cut_shape(&self) -> cut::CutShape {
+        cut::read_stroke(&self.cut_path, CLICK_SLOP_PX)
+            .map_or(cut::CutShape::Line, |gesture| gesture.shape)
     }
 
     /// Put the live strength away and bring out the one the incoming tool or
@@ -5246,7 +5381,354 @@ impl Brokkr {
         direction * (magnitude * MAX_TILT)
     }
 
-    /// Turn the dragged line into a plane and cut with it.
+    /// The narrowest width of a screen-space hull, in voxels, at the depth the
+    /// camera is focused on.
+    ///
+    /// The narrowest and not the average: a long thin lens is wide in one
+    /// direction and vanishing in the other, and it is the vanishing one that
+    /// decides whether the cut lands on any voxel centres at all.
+    ///
+    /// Found by rotating-callipers over the hull's edges -- for a convex
+    /// polygon the minimum width is always across some edge, so the furthest
+    /// vertex from each edge in turn is the whole search. At most sixteen edges
+    /// by sixteen vertices, once per gesture.
+    fn hull_width_in_voxels(&self, hull: &[Vec2]) -> f32 {
+        let voxel_size = self.doc.voxel_size();
+        if hull.len() < 3 || voxel_size <= 0.0 {
+            return f32::INFINITY;
+        }
+        // Millimetres per pixel where the camera is looking, which is where the
+        // preview is drawn and where the user believes the shape is.
+        let target = self.camera.target;
+        let scale = {
+            let centre = self.viewport_size * 0.5;
+            let (_, straight) = self.ray_through(centre);
+            let (_, offset) = self.ray_through(centre + Vec2::X);
+            let depth = (target - self.camera.eye()).length();
+            (straight * depth).distance(offset * depth)
+        };
+
+        let mut narrowest = f32::INFINITY;
+        for index in 0..hull.len() {
+            let from = hull[index];
+            let to = hull[(index + 1) % hull.len()];
+            let Some(along) = (to - from).try_normalize() else {
+                continue;
+            };
+            // Perpendicular distance from the edge to the furthest vertex.
+            let across = hull
+                .iter()
+                .map(|point| ((*point - from).x * along.y - (*point - from).y * along.x).abs())
+                .fold(0.0, f32::max);
+            narrowest = narrowest.min(across);
+        }
+        narrowest * scale / voxel_size
+    }
+
+    /// A far cap for the cutter, so it stops behind what it is cutting off
+    /// instead of carrying on through the model.
+    ///
+    /// **This is the request, in one function.** "Something that makes it
+    /// easier to cut off things that are sticking out of the main body" is
+    /// unanswerable with an unbounded cutter: circling a spur on the near side
+    /// of a scan also takes whatever is behind it, and the only defence is a
+    /// hand-painted mask on the far side -- which is the workaround every
+    /// comparable tool ships and the one this is meant to remove.
+    ///
+    /// Returns `None` when there should be no cap, which is a real outcome
+    /// rather than a failure. Three ways to get it, and they are not the same:
+    ///
+    /// * A straight drag. One plane is an infinite half-space by definition;
+    ///   that is what the plane cut has always been and what
+    ///   `a_cut_passes_through_the_whole_model` asserts of it.
+    /// * Nothing was hit, so there is no depth to measure from.
+    /// * There is nothing behind worth sparing -- and `report` is set, so the
+    ///   status can say so rather than let the tool look clever.
+    ///
+    /// # Why the cap is clamped against the NEXT surface
+    ///
+    /// Placing it one band past the deepest exit is the obvious rule and it is
+    /// wrong. At a 0.25 mm voxel a band is 0.75 mm, so a wall half a millimetre
+    /// behind a spur is thinned from the front by a quarter of a millimetre
+    /// with a sharp step -- and `is_printable` returns true for the result,
+    /// because it counts holes and winding and has no thickness term at all.
+    /// So the cap is pulled back to stay a full band clear of whatever is
+    /// behind, and where there is not room for both it declines and says so. A
+    /// tool that quietly thins the wall behind is worse than one that admits it
+    /// cannot help.
+    fn depth_cap(
+        &self,
+        hull: &[Vec2],
+        report: &mut Option<&'static str>,
+    ) -> Option<(brokkr_core::ClipPlane, f32)> {
+        if hull.len() < 3 {
+            return None;
+        }
+        let eye = self.camera.eye();
+        let facing = (self.camera.target - eye).try_normalize()?;
+        let reach = self.camera.far();
+
+        // Points known to be inside a CONVEX hull: its centroid, and points on
+        // the way from the centroid to each vertex. Deliberately not a bounding
+        // box grid, which would put rays outside a hull that is not square, and
+        // deliberately not the centroid alone -- one ray down the middle is a
+        // sample of one, and on a long thin loop it can miss the spur entirely.
+        let centroid = hull.iter().copied().sum::<Vec2>() / hull.len() as f32;
+        let mut probes = vec![centroid];
+        for vertex in hull {
+            for fraction in [0.45_f32, 0.8] {
+                probes.push(centroid.lerp(*vertex, fraction));
+            }
+        }
+
+        let bodies = self.drawn_bodies();
+        let mut deepest_exit = f32::NEG_INFINITY;
+        let mut shallowest_enter = f32::INFINITY;
+        let mut nearest_behind = f32::INFINITY;
+        for pixel in probes {
+            let (origin, ray) = self.ray_through(pixel);
+            // Distances come back along each ray from its own origin on the
+            // near plane, so they are converted to DEPTH along the view
+            // direction before being compared between rays. Without this a ray
+            // at the edge of a wide hull reports a longer distance for the same
+            // depth and drags the cap backwards -- which is the same class of
+            // mistake as measuring the cutter's apex from the near plane.
+            let scale = ray.dot(facing);
+            if scale <= 0.0 {
+                continue;
+            }
+            let base = (origin - eye).dot(facing);
+            for body in &bodies {
+                let Some(volume) = self.doc.volume(*body) else {
+                    continue;
+                };
+                let spans = brokkr_core::first_solid_spans(volume, origin, ray, reach);
+                if let Some(span) = spans.first {
+                    deepest_exit = deepest_exit.max(base + span.exit * scale);
+                    shallowest_enter = shallowest_enter.min(base + span.enter * scale);
+                }
+                if let Some(next) = spans.next_enter {
+                    nearest_behind = nearest_behind.min(base + next * scale);
+                }
+            }
+        }
+
+        if deepest_exit == f32::NEG_INFINITY {
+            // Every ray missed. There is no depth here, and the existing "the
+            // cut missed the model" outcome is the one that applies.
+            return None;
+        }
+
+        let margin = brokkr_core::NARROW_BAND * self.doc.voxel_size();
+        let want = deepest_exit + margin;
+        if nearest_behind.is_finite() {
+            if nearest_behind - deepest_exit < 2.0 * margin {
+                *report = Some("nothing behind it to spare — the cut went through");
+                return None;
+            }
+            let limit = nearest_behind - margin;
+            let at = want.min(limit);
+            return brokkr_core::ClipPlane::new(eye + facing * at, -facing)
+                .map(|plane| (plane, at - shallowest_enter));
+        }
+        brokkr_core::ClipPlane::new(eye + facing * want, -facing)
+            .map(|plane| (plane, want - shallowest_enter))
+    }
+
+    /// How many loose pieces the cut left behind, as a phrase to append to the
+    /// status, or nothing.
+    ///
+    /// **A cut that severs a body leaves two shells inside one `Volume` with
+    /// nothing anywhere saying so.** The user gets a model that looks right,
+    /// exports as one object, and arrives at the slicer in two pieces -- which
+    /// is precisely the failure the research identified in the tools this one
+    /// is meant to beat.
+    ///
+    /// `Document::split_plan` is read-only, parallel and already tested, so
+    /// this is a report and not a second connectivity walk. It is specifically
+    /// NOT a brick-level walk: `split.rs` measures one finding a single
+    /// component on the reference dragon where the voxel walk finds 29, 47, 85
+    /// and 182 at four voxel sizes, and fusing parts of a real four-part model.
+    ///
+    /// # It is expensive, so it is bounded three ways
+    ///
+    /// `split_plan` is a per-voxel union-find and costs roughly 13 to 17
+    /// microseconds per brick -- more, on the bench fixture, than the entire
+    /// cut that preceded it. Left unbounded this one status-line suffix is the
+    /// most expensive thing on the commit path by a wide margin. So:
+    ///
+    /// 1. **Only bodies the cut actually changed.** They come from the outcome
+    ///    rather than from asking each body whether anything is dirty, which
+    ///    would be reading an answer off a set that merely has not been drained
+    ///    yet. Walking a body the cutter never reached costs full price and can
+    ///    only ever find what was already there before the gesture.
+    /// 2. **One budget across all of them**, not one each: eight small bodies
+    ///    are eight walks, and a per-body gate lets them through.
+    /// 3. **A budget sized in bricks from a time target.** See
+    ///    [`MOST_BRICKS_TO_WALK`].
+    ///
+    /// Going over budget stops and reports what was found so far rather than
+    /// reporting nothing: pieces already counted are true, and throwing them
+    /// away because a later body was large would hide a real severance behind
+    /// an unrelated body's size.
+    fn loose_pieces_note(&self, changed: &[NodeId]) -> String {
+        let mut pieces = 0usize;
+        let mut walked = 0usize;
+        for body in changed {
+            let Some(volume) = self.doc.volume(*body) else {
+                continue;
+            };
+            // `brick_count` and not `brick_coords().count()`: the second walks
+            // the map to answer a question the map already knows.
+            walked += volume.brick_count();
+            if walked > MOST_BRICKS_TO_WALK {
+                break;
+            }
+            let Some(plan) = self.doc.split_plan(*body) else {
+                continue;
+            };
+            // One part is the body itself and is not news.
+            pieces += plan.parts.len().saturating_sub(1);
+        }
+        match pieces {
+            0 => String::new(),
+            1 => " — 1 loose piece".to_string(),
+            many => format!(" — {many} loose pieces"),
+        }
+    }
+
+    /// The DRAWN bodies, by node id -- the same set the cut acts on.
+    fn drawn_bodies(&self) -> Vec<NodeId> {
+        let visible = self.drawn_nodes();
+        self.doc
+            .nodes()
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| visible.get(*index).copied().unwrap_or(false))
+            .map(|(_, node)| node.id)
+            .collect()
+    }
+
+    /// Build the cutter's planes from a screen-space hull.
+    ///
+    /// Each edge of the hull becomes a plane containing that edge and the view
+    /// direction, so the region removed is the PRISM the polygon sweeps out
+    /// going away from the viewer -- the same width front and back. `None` if
+    /// any edge is degenerate: all or nothing, because a polygon missing one
+    /// side is not a smaller region, it is an open wedge that carries on for
+    /// ever.
+    ///
+    /// The straight drag is the exception and keeps its plane through the eye:
+    /// a single half-space has no aperture, so there is nothing for a taper to
+    /// widen, and that construction is what ships and what the side-convention
+    /// test observes.
+    ///
+    /// # The eye is `camera.eye()`, and that is a bug fix
+    ///
+    /// [`OrbitCamera::ray`] returns the point where the ray crosses the NEAR
+    /// PLANE, not the eye -- and it must keep doing so, because every pick in
+    /// the application starts there and a test pins it. The cut used that point
+    /// as its apex, and for a single plane that is correct **by accident**: the
+    /// near point lies on the first ray, and the normal is perpendicular to
+    /// both rays, so the offset falls out of the dot product exactly.
+    ///
+    /// With several planes it stops cancelling. Plane `k`'s normal is not
+    /// perpendicular to the ray the near point came from, so plane `k` is
+    /// displaced by `(P0 - E) . n_k` -- a different amount for every side --
+    /// and the pyramid's apex opens into a small polyhedral gap. The bound is
+    /// `near()`, which is a hundredth of the camera distance and about 1.5 mm
+    /// on a framed 100 mm model, six voxels at 0.25 mm. In practice it is less,
+    /// because for a small hull all the rays are nearly parallel and the dot
+    /// product is a fraction of that; it grows with the model and with how wide
+    /// the gesture is.
+    ///
+    /// # The sign is measured, not assumed
+    ///
+    /// For a polygon the winding decides which side each plane removes, and
+    /// getting it backwards inverts the cutter: instead of removing the inside
+    /// of the loop it removes everything except a pyramid. Rather than reason
+    /// about the handedness of the camera basis, the y-flip in the pixel-to-NDC
+    /// step and the hull's winding all at once -- three chances to be wrong
+    /// with one symptom -- the normals are built to one convention and then
+    /// CHECKED against a point known to be inside the region. If the check
+    /// fails they are all flipped. A sign that is verified costs one dot
+    /// product per plane, once per gesture, and cannot be got wrong by a later
+    /// change to any of the three.
+    fn cutter_from_hull(&self, hull: &[Vec2]) -> Option<Vec<brokkr_core::ClipPlane>> {
+        let eye = self.camera.eye();
+
+        // Two points name one plane and no region: this is the straight drag,
+        // and it keeps its own construction so that the side convention a test
+        // observes is untouched.
+        if let [from, to] = hull {
+            let (_, first) = self.ray_through(*from);
+            let (_, second) = self.ray_through(*to);
+            return brokkr_core::ClipPlane::new(eye, second.cross(first)).map(|plane| vec![plane]);
+        }
+        if hull.len() < 3 {
+            return None;
+        }
+
+        // **A prism, not a pyramid**, and the difference is the loudest thing
+        // about this tool in use. Building each side plane through the EYE
+        // makes the removed region the view frustum's own wedge: it widens with
+        // distance in exactly the proportion the projection does. At the
+        // framing this application picks -- `camera.rs` puts the eye at
+        // `radius / sin(fov/2) * 1.15`, about 90 mm for a 30 mm ball -- the
+        // front face is 60 mm away and the back 120, so **the exit hole comes
+        // out twice the diameter of the entry hole**. Circling a lump takes a
+        // cone out of everything behind it.
+        //
+        // Building them along the VIEW DIRECTION instead makes the sides
+        // parallel, so the cutter is the same width all the way through: what a
+        // bandsaw does, and what a symmetric pair of cuts needs in order to
+        // come out symmetric.
+        //
+        // The trade is real and worth stating. A pyramid is screen-exact at
+        // every depth -- the region removed is precisely the screen area swept,
+        // whatever it passes through. A prism is exact only at the focus depth,
+        // which is where the preview is drawn; further away the region takes
+        // slightly less than the outline appeared to cover, and nearer slightly
+        // more. That is the better error to have: it is bounded by the model's
+        // own depth rather than growing with it, and it errs toward the
+        // recoverable direction on the far side.
+        //
+        // This is the orthographic-cut behaviour without an orthographic
+        // camera. The camera is untouched; only the cutter is parallel.
+        let facing = (self.camera.target - eye).try_normalize()?;
+        let corner = |pixel: Vec2| {
+            let (origin, ray) = self.ray_through(pixel);
+            let denominator = ray.dot(facing);
+            if denominator.abs() < 1.0e-6 {
+                return origin;
+            }
+            origin + ray * ((self.camera.target - origin).dot(facing) / denominator)
+        };
+
+        let mut planes = Vec::with_capacity(hull.len());
+        for index in 0..hull.len() {
+            let here = corner(hull[index]);
+            let next = corner(hull[(index + 1) % hull.len()]);
+            planes.push(brokkr_core::ClipPlane::new(here, (next - here).cross(facing))?);
+        }
+
+        // A point genuinely inside the prism: the centroid of a CONVEX polygon
+        // is inside it, so the point at the focus depth under the centroid is
+        // in the middle of the region.
+        let centroid = hull.iter().copied().sum::<Vec2>() / hull.len() as f32;
+        let inside = corner(centroid);
+        if planes.iter().any(|plane| plane.distance(inside) < 0.0) {
+            for plane in &mut planes {
+                plane.normal = -plane.normal;
+            }
+        }
+        debug_assert!(
+            planes.iter().all(|plane| plane.distance(inside) >= 0.0),
+            "the cutter excludes its own centre, so the hull is not convex"
+        );
+        Some(planes)
+    }
+
     ///
     /// **It cuts every body the user can SEE**, which is [`Document::clip`]'s
     /// whole job: solo narrows the set, a hidden body the line passes over is
@@ -5258,11 +5740,15 @@ impl Brokkr {
     /// below tells the two apart and names the body -- see there for why that
     /// matters more than the count does.
     ///
-    /// The plane is the one containing the eye and both ends of the line, so it
-    /// is exactly the surface the line sweeps out going away from the viewer --
-    /// which is what makes a screen-space drag mean something in three
-    /// dimensions, and why the cut passes through the whole model rather than
-    /// stopping at the first surface.
+    /// # The shape comes from the stroke
+    ///
+    /// [`cut::read_stroke`] decides whether the drag was a line, an open curve
+    /// or a closed loop, and hands back a convex polygon in screen pixels. Each
+    /// of its edges becomes a plane through the EYE, so the cutter is the
+    /// pyramid the polygon sweeps out going away from the viewer -- which is
+    /// what makes a screen-space gesture mean something in three dimensions.
+    /// A two-point polygon is the straight drag that has always shipped, and it
+    /// still produces exactly one plane and one cross product.
     ///
     /// **Which side goes is set by the drag direction**: the material to the
     /// LEFT of the arrow, as drawn on screen, is removed -- so a left to right
@@ -5273,63 +5759,150 @@ impl Brokkr {
     /// from reasoning about the cross product. The sign depends on the ray
     /// order, the handedness of the camera basis and whether the pixel-to-NDC
     /// step flips Y, and getting it backwards means the tool removes the half
-    /// the user meant to keep.
+    /// the user meant to keep. For a polygon the sign is not reasoned about at
+    /// all -- see [`Brokkr::cutter_from_hull`].
     fn finish_cut(&mut self, from: Vec2) {
-        let Some(to) = self.cursor else {
-            return;
-        };
-        // A click is not a cut. Without this, arming the tool and clicking once
-        // would take an arbitrary half of the model away. Ctrl only changes
-        // which field the half-space is written into, so the same slop applies
-        // and the word changes with it.
-        if from.distance(to) < CLICK_SLOP_PX {
-            let what = if self.control { "mask" } else { "cut" };
-            self.status = format!("{what} cancelled: drag a line across the model");
-            return;
+        // The path is taken whatever happens next, so no outcome below can
+        // leave it to leak into the next gesture.
+        let mut path = std::mem::take(&mut self.cut_path);
+        if let Some(to) = self.cursor {
+            // The release position, which no motion event may have delivered if
+            // the pointer stopped moving before the button came up.
+            if path.last().is_none_or(|last| *last != to) {
+                path.push(to);
+            }
+        }
+        // Older gestures reached here with only the press position recorded.
+        if path.is_empty() {
+            path.push(from);
         }
 
-        let (eye, first) = self.ray_through(from);
-        let (_, second) = self.ray_through(to);
-        // Both rays leave the same eye, so their cross product is normal to the
-        // plane through the two of them. The order is what decides the sign,
-        // and therefore which side is cut.
-        let Some(plane) = brokkr_core::ClipPlane::new(eye, second.cross(first)) else {
-            self.status = "cut cancelled: that line has no direction".to_string();
+        let Some(gesture) = cut::read_stroke(&path, CLICK_SLOP_PX) else {
+            // A click is not a cut. Without this, arming the tool and clicking
+            // once would take an arbitrary half of the model away. Ctrl only
+            // changes which field the region is written into, so the same slop
+            // applies and the word changes with it.
+            //
+            // It also catches a stroke that went somewhere and enclosed
+            // nothing -- out and straight back -- which is not a click and is
+            // just as much not a region. Hulling that into a sliver thinner
+            // than the lattice would remove material in some places and not
+            // others depending on where the voxels fell, while reporting
+            // success.
+            let what = if self.control { "mask" } else { "cut" };
+            self.status = format!("{what} cancelled: drag a shape across the model");
+            self.refresh_overlay();
             return;
         };
 
+        let Some(planes) = self.cutter_from_hull(&gesture.hull) else {
+            // All or nothing: dropping one side plane of a polygon does not
+            // make a smaller cutter, it opens the region into an unbounded
+            // wedge that carries on across the whole model.
+            self.status = "cut cancelled: that shape has no direction".to_string();
+            self.refresh_overlay();
+            return;
+        };
+
+        // **The width guard is in VOXELS and not in pixels, and that is the
+        // whole point of it.** A long thin loop clears any plausible area
+        // threshold in pixels while enclosing a lens a fraction of a voxel
+        // across, and whether any voxel centre falls inside such a lens depends
+        // on where the lattice happens to sit. The slot then appears in some
+        // places and not others, or nowhere at all -- after bricks were
+        // classified, promoted, written and counted, so the status line reports
+        // a successful cut over a model that did not visibly change.
+        //
+        // Measured at the focus depth, which is where the preview is drawn and
+        // therefore where the user believes the shape is.
+        if gesture.hull.len() >= 3 {
+            let across = self.hull_width_in_voxels(&gesture.hull);
+            if across < MIN_CUT_WIDTH_VOXELS {
+                self.status = "cut cancelled: that loop is thinner than the voxel grid".to_string();
+                self.refresh_overlay();
+                return;
+            }
+        }
+
+        // **Bounded by default, and shift is what asks for the old behaviour.**
+        // The default is the one that answers the request -- circle the spur
+        // and the spur goes -- and the unbounded cut is a modifier away rather
+        // than the other way round, because a cut that takes more than it was
+        // asked for is the complaint every surveyed tool has and a cut that
+        // takes less is one more drag.
+        //
+        // Read at the RELEASE, like ctrl, and previewed while it is held, so
+        // the verb is visible rather than inferred from a key state nobody can
+        // see. Silent mode flips at release are named in the research as the
+        // top pitfall of this whole family of tools.
+        let mut depth_note: Option<&'static str> = None;
+        let mut planes = planes;
+        let mut depth_mm = None;
+        if !self.shift
+            && let Some((cap, thickness)) = self.depth_cap(&gesture.hull, &mut depth_note)
+        {
+            depth_mm = Some(thickness);
+            planes.push(cap);
+        }
+
         // **Ctrl turns the cut into a selection**, which is increment 25c's
-        // "no new gesture": the same drag, the same plane, the same brick
+        // "no new gesture": the same drag, the same region, the same brick
         // classification, writing protection instead of removing material. It
         // is checked here at the RELEASE rather than at the press, because that
-        // is where the plane exists and because a user who realises mid-drag
+        // is where the region exists and because a user who realises mid-drag
         // that they meant to select can still say so.
+        //
+        // Only the straight drag routes here for now: the mask generator takes
+        // one half-space, and giving it a convex region is its own phase. A
+        // shaped ctrl-drag would otherwise silently mask a half-space nobody
+        // drew, which is worse than saying it is not built.
         if self.control {
-            self.mask_halfspace(plane);
+            self.mask_cutter(&planes, gesture.shape);
             // One shot per arming, exactly as the cut is: the assignment below
             // carries that property and this arm must not skip it.
             self.tool = Tool::Sculpt;
+            self.refresh_overlay();
             return;
         }
 
         // **The cut crosses every VISIBLE body**, which is what
-        // `Document::clip` is for: solo narrows the set, a hidden body the line
-        // passes over comes back bit-identical, and the whole gesture is ONE
-        // undo entry of N `Change::Bricks`. Direct manipulation acts on what is
-        // drawn.
+        // `Document::clip_convex` is for: solo narrows the set, a hidden body
+        // the gesture passes over comes back bit-identical, and the whole
+        // gesture is ONE undo entry of N `Change::Bricks`. Direct manipulation
+        // acts on what is drawn.
         let visible = self.drawn_nodes();
-        let outcome = self.doc.clip(plane, &visible);
+        let outcome = self.doc.clip_convex(&planes, &visible);
         if outcome.bricks > 0 {
             let before = self.history.stats();
             if let Some(entry) = outcome.entry {
                 self.history.push(entry);
             }
             self.unsaved = true;
-            self.status = if outcome.bodies_cut > 1 {
-                format!("cut {} bricks across {} bodies", outcome.bricks, outcome.bodies_cut)
-            } else {
-                format!("cut {} bricks", outcome.bricks)
+            let where_ = match gesture.shape {
+                cut::CutShape::Line => String::new(),
+                cut::CutShape::Curve => " inside the curve".to_string(),
+                cut::CutShape::Lasso => " inside the lasso".to_string(),
             };
+            // How deep it went, which is the whole difference between this and
+            // the cut that shipped before it. A shaped cut that says only how
+            // many bricks it took leaves the user to discover from the other
+            // side whether it stopped.
+            let how_deep = match (depth_mm, depth_note) {
+                (_, Some(note)) => format!(" — {note}"),
+                (Some(deep), None) => format!(", {deep:.0} mm deep"),
+                (None, None) if gesture.shape == cut::CutShape::Line => String::new(),
+                (None, None) => " — all the way through".to_string(),
+            };
+            let body_count = if outcome.bodies_cut.len() > 1 {
+                format!(" across {} bodies", outcome.bodies_cut.len())
+            } else {
+                String::new()
+            };
+            self.status = format!(
+                "cut {} bricks{where_}{body_count}{how_deep}{}",
+                outcome.bricks,
+                self.loose_pieces_note(&outcome.bodies_cut)
+            );
             // After the cut's own message on purpose: an eviction that took
             // a deleted body with it outranks a count of bricks.
             self.record_history(before);
@@ -7335,7 +7908,7 @@ impl Brokkr {
     /// a line the user draws across what they can see, and a mask drawn the same
     /// way has to mean the same thing. One compound entry of N
     /// `Change::WholeMask`, so one ctrl+Z takes the whole gesture back.
-    fn mask_halfspace(&mut self, plane: brokkr_core::ClipPlane) {
+    fn mask_cutter(&mut self, planes: &[brokkr_core::ClipPlane], shape: cut::CutShape) {
         let feather_mm = HALFSPACE_FEATHER_VOXELS * self.doc.voxel_size();
         let drawn = self.drawn_nodes();
         let bodies: Vec<NodeId> = self
@@ -7353,7 +7926,13 @@ impl Brokkr {
             let Some(volume) = self.doc.volume_mut(body) else {
                 continue;
             };
-            let mask = volume.generated_mask(MaskRecipe::Halfspace { plane, feather_mm });
+            // Straight to `cutter_mask` rather than through `MaskRecipe`, and
+            // that is deliberate. `MaskRecipe` derives `Copy` and travels
+            // inside `Message`, so a slice in it would need a lifetime, an
+            // `Arc` would cost the `Copy`, and a fixed array would put several
+            // hundred bytes into every message the application sends. The
+            // recipe stays the single-plane one it always was.
+            let mask = volume.cutter_mask(planes, feather_mm);
             if mask.is_free() {
                 // The plane missed this body entirely, so it keeps whatever it
                 // was carrying. Replacing it with an empty mask would throw a
@@ -7367,7 +7946,7 @@ impl Brokkr {
         }
 
         if changes.is_empty() {
-            self.status = "the mask line missed the model".to_string();
+            self.status = "the mask gesture missed the model".to_string();
             return;
         }
         let before = self.history.stats();
@@ -7375,10 +7954,21 @@ impl Brokkr {
         self.record_history(before);
         self.unsaved = true;
         self.remesh_dirty();
-        self.status = if touched > 1 {
-            format!("masked that half of {touched} bodies")
-        } else {
-            format!("masked that half of {}", self.active_body_name())
+        // Names what was protected, and then names the thing to do next.
+        // **Circling a lump and being told only that it is masked is half an
+        // answer**: the reason to select rather than cut is to lift the lump
+        // off as its own body, and a user who is not told that is available
+        // will reach for the panel and hunt for it.
+        let what = match shape {
+            cut::CutShape::Line => "that half",
+            cut::CutShape::Curve => "inside the curve",
+            cut::CutShape::Lasso => "inside the lasso",
+        };
+        let where_ =
+            if touched > 1 { format!("{touched} bodies") } else { self.active_body_name() };
+        self.status = match shape {
+            cut::CutShape::Line => format!("masked {what} of {where_}"),
+            _ => format!("masked {what} on {where_} — split it off from the BODIES panel"),
         };
     }
 
@@ -7908,7 +8498,14 @@ impl Brokkr {
                     PointerButton::Left => match self.tool {
                         // The mode was chosen deliberately and the next left
                         // drag is the line, not a stroke.
-                        Tool::Cut => DragKind::Cutting,
+                        Tool::Cut => {
+                            // The press is the first point of the path, and the
+                            // clear is what stops a cancelled gesture leaking
+                            // into the next one.
+                            self.cut_path.clear();
+                            self.cut_path.push(position);
+                            DragKind::Cutting
+                        }
                         // Deliberately does NOT pick: masking paints the ACTIVE
                         // body, and a press that silently moved the target
                         // mid-mask would paint protection onto a body the user
@@ -8094,13 +8691,26 @@ impl Brokkr {
                         self.camera.pan(delta, self.viewport_size.y);
                         self.publish_camera();
                     }
-                    // The cut line is only drawn while it is being dragged;
-                    // the model is not touched until the button comes up, so
-                    // the line can be adjusted freely. A press that chose a
-                    // body is over: dragging must not turn it into a stroke on
-                    // a body the user has only just arrived at.
-                    Some(DragKind::Cutting)
-                    | Some(DragKind::Sizing)
+                    // The cut accumulates its path here and redraws the
+                    // preview; the model is not touched until the button comes
+                    // up, so the shape can be adjusted freely and what is drawn
+                    // is what will go. A press that chose a body is over:
+                    // dragging must not turn it into a stroke on a body the
+                    // user has only just arrived at.
+                    Some(DragKind::Cutting) => {
+                        // Spaced rather than every event, so an identical
+                        // looking stroke reduces to the same shape whether it
+                        // was drawn quickly or slowly.
+                        if self
+                            .cut_path
+                            .last()
+                            .is_none_or(|last| last.distance(position) >= cut::CUT_PATH_SPACING_PX)
+                        {
+                            self.cut_path.push(position);
+                            self.refresh_overlay();
+                        }
+                    }
+                    Some(DragKind::Sizing)
                     | Some(DragKind::Selecting)
                     | Some(DragKind::Refused)
                     | None => {}
@@ -8722,6 +9332,18 @@ impl Brokkr {
                     return Task::none();
                 }
                 if self.tool == Tool::Cut {
+                    // A LIVE path is thrown away without disarming, exactly as
+                    // a live gizmo drag is above and for the same reason:
+                    // Escape mid-gesture means "not that shape", not "not any
+                    // cut". The tool stays armed so the next drag is still a
+                    // cut, which is what a user who mis-drew a lasso wants.
+                    if !self.cut_path.is_empty() {
+                        self.cut_path.clear();
+                        self.drag = None;
+                        self.refresh_overlay();
+                        self.status = "cancelled the cut".to_string();
+                        return Task::none();
+                    }
                     self.tool = Tool::Sculpt;
                 }
                 self.adding = false;
@@ -8778,7 +9400,13 @@ impl Brokkr {
                 self.swap_strength(|app| app.tool = tool);
                 self.status = match tool {
                     Tool::Cut => {
-                        "cut armed: drag a line across the model, the left of the arrow goes"
+                        // Names all three readings, because the shape is
+                        // inferred and a user who is not told a loop is
+                        // available will never draw one. The line is named
+                        // first: it is the default, and it is what the tool
+                        // did before it learned the other two.
+                        "cut armed: drag a line and the left of the arrow goes, or draw a \
+                         loop around what to remove"
                             .to_string()
                     }
                     Tool::Mask => "mask: drag to protect, ctrl or alt to unprotect, \
@@ -11343,6 +11971,521 @@ mod tests {
         assert_eq!(app.doc.active_volume().brick_coords().count(), before, "a click cut the model");
         assert!(!app.unsaved, "a click that cut nothing marked the document unsaved");
         assert!(app.status.contains("cancelled"), "reported: {}", app.status);
+    }
+
+    /// Add a sphere to whatever is already there.
+    ///
+    /// **Not `seed_sphere`, which OVERWRITES.** Seeding clears every brick the
+    /// sphere's box touches before writing, so seeding a small sphere onto a
+    /// large one carves a moat around it rather than adding a lump to it: the
+    /// fixture ends up as a ball with a pit, and a test that asserts "the spur
+    /// went" passes for the wrong reason. A union is `min` of the two distance
+    /// fields, which is what this does.
+    fn union_sphere(volume: &mut brokkr_core::Volume, centre: Vec3, radius: f32) {
+        let voxel_size = volume.voxel_size();
+        let band = brokkr_core::NARROW_BAND * voxel_size;
+        let (lo, hi) =
+            volume.voxel_bounds(centre - (radius + band * 2.0), centre + (radius + band * 2.0));
+        volume.edit_voxels(lo, hi, |_, position, value| {
+            let outside = (position.distance(centre) - radius) / voxel_size;
+            value.min(outside).clamp(brokkr_core::INSIDE, brokkr_core::OUTSIDE)
+        });
+    }
+
+    /// Drag a closed loop, from a list of viewport positions.
+    fn drag_loop(app: &mut Brokkr, points: &[Vector]) {
+        let first = *points.first().expect("a loop needs points");
+        press(app, first);
+        for point in points.iter().skip(1) {
+            app.on_pointer(PointerEvent::Moved { position: *point, size: SIZE });
+        }
+        app.on_pointer(PointerEvent::Moved { position: first, size: SIZE });
+        release(app);
+    }
+
+    /// A circle of viewport positions around the middle of the screen.
+    fn loop_around(radius: f32, steps: usize) -> Vec<Vector> {
+        let centre = centre_of_viewport();
+        (0..steps)
+            .map(|step| {
+                let angle = step as f32 / steps as f32 * std::f32::consts::TAU;
+                centre + Vector::new(angle.cos() * radius, angle.sin() * radius)
+            })
+            .collect()
+    }
+
+    /// **The region cut is the region drawn**, checked in world space rather
+    /// than by looking at the screen.
+    ///
+    /// This is the test whose absence let the apex bug survive a design review.
+    /// The cut used the ray's NEAR-PLANE point as the pyramid's apex instead of
+    /// the eye; with one plane that cancels exactly, and with several it
+    /// displaces every side by a different amount. It was invisible to any test
+    /// comparing the preview against the drawing, because the preview projects
+    /// the same screen points and is therefore screen-exact either way.
+    ///
+    /// So this projects the RESULT back: every point that lost material must
+    /// fall inside the drawn polygon, and points well outside it must be
+    /// untouched. A displaced apex fails the second half.
+    #[test]
+    fn the_region_cut_matches_the_region_drawn() {
+        let mut app = app();
+        app.camera.yaw = 0.0;
+        app.camera.pitch = 0.0;
+        app.publish_camera();
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+
+        let radius = SIZE.y * 0.15;
+        drag_loop(&mut app, &loop_around(radius, 24));
+        assert!(app.unsaved, "the lasso did not cut: {}", app.status);
+
+        // Probe a ring of world points at the depth the camera focuses on,
+        // spanning well inside the loop and well outside it.
+        let centre = centre_of_viewport();
+        let volume = app.doc.active_volume();
+        let mut inside_survived = 0;
+        let mut outside_removed = 0;
+        for step in 0..48 {
+            let angle = step as f32 / 48.0 * std::f32::consts::TAU;
+            for (scale, expect_gone) in [(0.45_f32, true), (2.2_f32, false)] {
+                let pixel = centre + Vector::new(angle.cos(), angle.sin()) * (radius * scale);
+                // Where that pixel meets the sphere's front face, before the
+                // cut: the model is a ball of known radius at the origin.
+                let (origin, ray) = app.ray_through(Vec2::new(pixel.x, pixel.y));
+                let Some(hit) = ray_meets_ball(origin, ray, MODEL_RADIUS_MM) else {
+                    continue;
+                };
+                // A little inside the surface, so a grazing sample does not
+                // decide the outcome.
+                let probe = hit + ray * 0.5;
+                let gone = volume.sample_world(probe) > 0.0;
+                if expect_gone && !gone {
+                    inside_survived += 1;
+                }
+                if !expect_gone && gone {
+                    outside_removed += 1;
+                }
+            }
+        }
+        assert_eq!(inside_survived, 0, "material survived well inside the drawn loop");
+        assert_eq!(outside_removed, 0, "material was removed well outside the drawn loop");
+    }
+
+    /// Where a ray first meets a ball at the origin, if it does.
+    fn ray_meets_ball(origin: Vec3, ray: Vec3, radius: f32) -> Option<Vec3> {
+        let b = origin.dot(ray);
+        let c = origin.length_squared() - radius * radius;
+        let discriminant = b * b - c;
+        if discriminant < 0.0 {
+            return None;
+        }
+        let t = -b - discriminant.sqrt();
+        (t > 0.0).then(|| origin + ray * t)
+    }
+
+    /// **The preview must be drawn in FRONT of the model it describes.**
+    ///
+    /// This is the one that `cargo test` could not see and a screenshot could.
+    /// The outline was first projected onto the plane through the camera's
+    /// target -- which is the middle of the model -- so the polygon sat INSIDE
+    /// the sphere and the depth test threw it away. Every headless assertion
+    /// passed: the geometry was built, the vertex counts were right, the shape
+    /// was correct, and the screen showed nothing at all.
+    ///
+    /// The straight-line cut hid it for a while, because its band reaches three
+    /// model radii out and the part past the silhouette has nothing in front of
+    /// it. So the band appeared over the background and vanished over the
+    /// model, which reads as a rendering quirk rather than as a preview drawn
+    /// in the wrong place.
+    ///
+    /// Depth is what is asserted, not pixels, because depth is the thing that
+    /// was wrong and it is checkable without a compositor.
+    #[test]
+    fn the_live_preview_is_drawn_in_front_of_the_model() {
+        let mut app = app();
+        app.camera.yaw = 0.0;
+        app.camera.pitch = 0.0;
+        app.publish_camera();
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+
+        let points = loop_around(SIZE.y * 0.15, 12);
+        press(&mut app, points[0]);
+        for point in points.iter().skip(1) {
+            app.on_pointer(PointerEvent::Moved { position: *point, size: SIZE });
+        }
+        app.on_pointer(PointerEvent::Moved { position: points[0], size: SIZE });
+
+        assert!(!app.overlay.lines.is_empty(), "the live lasso drew no outline");
+
+        // The nearest the model can be to the eye: the camera looks at the
+        // origin and the body is a ball of MODEL_RADIUS_MM about it.
+        let eye = app.camera.eye();
+        let nearest_surface = eye.length() - MODEL_RADIUS_MM;
+        for vertex in app.overlay.lines.iter().chain(&app.overlay.surfaces) {
+            let away = Vec3::from_array(vertex.position).distance(eye);
+            assert!(
+                away < nearest_surface,
+                "a preview vertex sits {away} from the eye, behind the model's near face at \
+                 {nearest_surface} -- the depth test will hide it"
+            );
+        }
+    }
+
+    /// **The depth cap spares the wall behind the spur.**
+    ///
+    /// The fixture is the one the design argues about: a lump sticking out with
+    /// another surface close behind it, close enough that placing the cap one
+    /// band past the lump's back face would eat into the wall. Circling the
+    /// lump must take the lump and leave the wall EXACTLY as it was.
+    ///
+    /// `assert_same_field` rather than a thickness measurement, because a
+    /// thickness measurement is what `is_printable` does not have: it counts
+    /// holes and winding, so a wall thinned from the front with a clean step is
+    /// still "printable" and no other assertion in this repo would notice.
+    #[test]
+    fn a_lasso_over_a_spur_leaves_the_wall_behind_it_alone() {
+        let mut app = app();
+        app.camera.yaw = 0.0;
+        app.camera.pitch = 0.0;
+        app.publish_camera();
+
+        // Rebuilt as a spur in front of a wall, in camera-relative terms so the
+        // fixture does not depend on which way yaw zero points.
+        let eye = app.camera.eye();
+        let toward_camera = (eye - app.camera.target).normalize();
+        {
+            let volume = app.doc.active_volume_mut();
+            *volume = brokkr_core::Volume::new(volume.voxel_size());
+            // The wall: a big ball centred behind the origin, so its near face
+            // sits a little way behind the spur.
+            volume.seed_sphere(-toward_camera * 34.0, 30.0);
+            // The spur: small, in front, straddling the wall's near face so it
+            // is attached rather than floating. UNIONED, because seeding it
+            // would clear the wall's bricks around it and leave a moat.
+            union_sphere(volume, toward_camera * 6.0, 7.0);
+            volume.mark_everything_dirty();
+        }
+        app.rebuild_everything();
+
+        let before = app.doc.active_volume().duplicated(glam::IVec3::ZERO);
+
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        drag_loop(&mut app, &loop_around(SIZE.y * 0.06, 20));
+        assert!(app.unsaved, "the lasso did not cut: {}", app.status);
+
+        // The wall's far side, well behind anything the spur occupies: it must
+        // read exactly as it did.
+        let deep = -toward_camera * 50.0;
+        let after = app.doc.active_volume().sample_world(deep);
+        assert_eq!(
+            before.sample_world(deep),
+            after,
+            "the cut reached through to the back of the wall"
+        );
+        // And the spur itself is gone.
+        let spur = toward_camera * 10.0;
+        assert!(
+            app.doc.active_volume().sample_world(spur) > 0.0,
+            "the spur survived the lasso that circled it"
+        );
+    }
+
+    /// Shift asks for the old behaviour, and it must actually get it: the same
+    /// loop with shift held goes all the way through.
+    #[test]
+    fn shift_makes_the_same_lasso_cut_through() {
+        let mut app = app();
+        app.camera.yaw = 0.0;
+        app.camera.pitch = 0.0;
+        app.publish_camera();
+        let eye = app.camera.eye();
+        let toward_camera = (eye - app.camera.target).normalize();
+        {
+            let volume = app.doc.active_volume_mut();
+            *volume = brokkr_core::Volume::new(volume.voxel_size());
+            volume.seed_sphere(-toward_camera * 34.0, 30.0);
+            union_sphere(volume, toward_camera * 6.0, 7.0);
+            volume.mark_everything_dirty();
+        }
+        app.rebuild_everything();
+
+        app.shift = true;
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        drag_loop(&mut app, &loop_around(SIZE.y * 0.06, 20));
+
+        let deep = -toward_camera * 50.0;
+        assert!(
+            app.doc.active_volume().sample_world(deep) > 0.0,
+            "shift did not cut through: {}",
+            app.status
+        );
+    }
+
+    /// **The hole is the same size where it goes in and where it comes out.**
+    ///
+    /// The cutter is built along the view direction rather than from the eye,
+    /// so its sides are parallel. Built from the eye instead -- which is the
+    /// obvious construction and the one this shipped with first -- the removed
+    /// region is the view frustum's own wedge and widens exactly as the
+    /// projection does. At the framing this application picks that is not
+    /// subtle: the eye sits about 90 mm from a 30 mm ball, so the front face is
+    /// 60 mm away and the back 120, and **the exit hole comes out twice the
+    /// diameter of the entry hole**.
+    ///
+    /// Measured rather than reasoned about, because the factor depends on the
+    /// framing rule, the field of view and the model's size all at once, and a
+    /// test that recomputed those would be asserting its own arithmetic.
+    #[test]
+    fn a_cut_through_leaves_the_same_hole_at_both_ends() {
+        let mut app = app();
+        app.camera.yaw = 0.0;
+        app.camera.pitch = 0.0;
+        app.publish_camera();
+
+        let eye = app.camera.eye();
+        let facing = (app.camera.target - eye).normalize();
+        // Any direction across the view, to scan outward along.
+        let across = facing.cross(Vec3::Y).normalize_or(Vec3::X);
+
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        // Shift, so the cut goes all the way through and there are two ends to
+        // compare. With the depth cap on there is only one.
+        app.shift = true;
+        drag_loop(&mut app, &loop_around(SIZE.y * 0.10, 24));
+        assert!(app.unsaved, "the lasso did not cut: {}", app.status);
+
+        // How far the hole reaches from the axis, on a slab a little inside
+        // each face so a grazing sample cannot decide it.
+        let reach_at = |depth: f32| {
+            let volume = app.doc.active_volume();
+            let mut last_gone = 0.0_f32;
+            let mut radius = 0.0_f32;
+            while radius < 28.0 {
+                let probe = facing * depth + across * radius;
+                if volume.sample_world(probe) > 0.0 {
+                    last_gone = radius;
+                } else {
+                    break;
+                }
+                radius += 0.25;
+            }
+            last_gone
+        };
+
+        let front = reach_at(-25.0);
+        let back = reach_at(25.0);
+        assert!(front > 1.0, "no hole at the front face: {front}");
+        assert!(back > 1.0, "no hole at the back face: {back}");
+        assert!(
+            (back - front).abs() < front * 0.15,
+            "the hole flares through the model: {front:.2} mm going in, {back:.2} mm coming \
+             out -- the cutter is a pyramid from the eye rather than a prism"
+        );
+    }
+
+    /// **Ctrl with a loop selects instead of cutting, and the selection becomes
+    /// a body.**
+    ///
+    /// This is the whole "circle the lump and it becomes a layer" route, end to
+    /// end through the application: the same drag, the same hull, the same
+    /// classification, writing protection instead of removing material -- and
+    /// then the shipped masked split lifting it off.
+    ///
+    /// The field must come through the mask step bit-identical. Ctrl and no
+    /// ctrl differ in which map they write, and a ctrl gesture that moved one
+    /// voxel of geometry would be a destructive operation wearing a
+    /// selection's clothes.
+    #[test]
+    fn a_ctrl_lasso_selects_a_region_and_it_can_be_split_off() {
+        let mut app = app();
+        app.camera.yaw = 0.0;
+        app.camera.pitch = 0.0;
+        app.publish_camera();
+
+        let before = app.doc.active_volume().duplicated(glam::IVec3::ZERO);
+        let bodies_before = app.doc.nodes().len();
+
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        app.control = true;
+        drag_loop(&mut app, &loop_around(SIZE.y * 0.12, 20));
+        app.control = false;
+
+        assert!(
+            !app.doc.active_volume().mask().is_free(),
+            "a ctrl lasso protected nothing: {}",
+            app.status
+        );
+        // Compared by sampling rather than through the core's own helper,
+        // which is behind a test-only module this crate cannot reach.
+        for probe in [
+            Vec3::new(0.0, 0.0, MODEL_RADIUS_MM - 2.0),
+            Vec3::new(8.0, 4.0, MODEL_RADIUS_MM - 6.0),
+            Vec3::ZERO,
+            Vec3::new(-12.0, 0.0, 0.0),
+        ] {
+            assert_eq!(
+                before.sample_world(probe),
+                app.doc.active_volume().sample_world(probe),
+                "a ctrl lasso moved the field at {probe:?}"
+            );
+        }
+        assert!(app.status.contains("lasso"), "the status does not name the shape: {}", app.status);
+
+        // And the selection lifts off as its own row.
+        update(&mut app, Message::BodySplitMasked);
+        assert!(
+            app.doc.nodes().len() > bodies_before,
+            "the masked split produced no new body: {}",
+            app.status
+        );
+    }
+
+    /// **A cut that severs a body says so.**
+    ///
+    /// Two shells inside one `Volume` look right on screen, export as one
+    /// object and arrive at the slicer in two pieces. Nothing before this said
+    /// a word about it.
+    #[test]
+    fn a_cut_that_severs_a_body_reports_the_loose_piece() {
+        let mut app = app();
+        app.camera.yaw = 0.0;
+        app.camera.pitch = 0.0;
+        app.publish_camera();
+
+        // A dumbbell: two balls joined by a thin neck, arranged across the view
+        // so a straight drag can part them.
+        let eye = app.camera.eye();
+        let facing = (app.camera.target - eye).normalize();
+        let across = facing.cross(Vec3::Y).normalize_or(Vec3::X);
+        {
+            let volume = app.doc.active_volume_mut();
+            *volume = brokkr_core::Volume::new(volume.voxel_size());
+            volume.seed_sphere(across * -14.0, 10.0);
+            union_sphere(volume, across * 14.0, 10.0);
+            // The neck, as a chain of overlapping spheres: there is no capsule
+            // primitive, and a union of them is the same solid.
+            for step in 0..=56 {
+                let t = step as f32 / 56.0;
+                union_sphere(volume, across * (-14.0 + t * 28.0), 2.5);
+            }
+            volume.mark_everything_dirty();
+        }
+        app.rebuild_everything();
+        assert_eq!(
+            app.doc.split_plan(app.doc.active()).map(|plan| plan.parts.len()),
+            Some(1),
+            "the fixture is already in pieces before the cut"
+        );
+
+        // Cut the neck: a lasso around the middle, deep enough to part it.
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        app.shift = true;
+        drag_loop(&mut app, &loop_around(SIZE.y * 0.035, 16));
+        app.shift = false;
+
+        assert!(
+            app.status.contains("loose piece"),
+            "a severed body was not reported: {}",
+            app.status
+        );
+    }
+
+    /// A lasso disarms the tool exactly as a line does. The one-shot property
+    /// belongs to the gesture, not to the shape of it.
+    #[test]
+    fn a_lasso_disarms_the_cut_like_a_line_does() {
+        let mut app = app();
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        drag_loop(&mut app, &loop_around(SIZE.y * 0.15, 20));
+        assert_ne!(app.tool, Tool::Cut, "the cut stayed armed after a lasso");
+    }
+
+    /// The status names the shape, because "cut 812 bricks" over a lasso and
+    /// over a plane describe very different things happening to the model.
+    #[test]
+    fn the_status_says_which_shape_cut() {
+        let mut app = app();
+        app.camera.yaw = 0.0;
+        app.camera.pitch = 0.0;
+        app.publish_camera();
+
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        drag_loop(&mut app, &loop_around(SIZE.y * 0.15, 24));
+        assert!(app.status.contains("lasso"), "a lasso reported: {}", app.status);
+
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        press(&mut app, Vector::new(SIZE.x * 0.1, SIZE.y * 0.3));
+        app.on_pointer(PointerEvent::Moved {
+            position: Vector::new(SIZE.x * 0.9, SIZE.y * 0.3),
+            size: SIZE,
+        });
+        release(&mut app);
+        assert!(!app.status.contains("lasso"), "a straight drag reported: {}", app.status);
+    }
+
+    /// A loop thinner than the lattice is refused with its own sentence rather
+    /// than reporting a successful cut over a model that did not change.
+    #[test]
+    fn a_loop_thinner_than_the_voxel_grid_is_refused() {
+        let mut app = app();
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        let before = app.doc.active_volume().brick_coords().count();
+
+        // Long, and about a pixel wide: out along the middle of the viewport
+        // and back a hair below.
+        let middle = SIZE.y * 0.5;
+        let mut path = vec![Vector::new(SIZE.x * 0.2, middle)];
+        for step in 1..=20 {
+            path.push(Vector::new(SIZE.x * (0.2 + 0.03 * step as f32), middle));
+        }
+        for step in (0..=20).rev() {
+            path.push(Vector::new(SIZE.x * (0.2 + 0.03 * step as f32), middle + 0.4));
+        }
+        drag_loop(&mut app, &path);
+
+        assert_eq!(
+            app.doc.active_volume().brick_coords().count(),
+            before,
+            "a sliver loop changed the model"
+        );
+        assert!(app.status.contains("cancelled"), "reported: {}", app.status);
+    }
+
+    /// Escape mid-drag throws the shape away and leaves the tool armed, which
+    /// is the treatment a live gizmo drag already gets.
+    #[test]
+    fn escape_mid_path_leaves_the_cut_armed() {
+        let mut app = app();
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        press(&mut app, Vector::new(SIZE.x * 0.2, SIZE.y * 0.5));
+        app.on_pointer(PointerEvent::Moved {
+            position: Vector::new(SIZE.x * 0.5, SIZE.y * 0.4),
+            size: SIZE,
+        });
+        assert!(!app.cut_path.is_empty(), "the path did not accumulate");
+
+        update(&mut app, Message::MenuClosed);
+
+        assert_eq!(app.tool, Tool::Cut, "escape mid-path disarmed the tool");
+        assert!(app.cut_path.is_empty(), "escape left the path behind");
+        assert!(!app.unsaved, "escape mid-path still cut");
+    }
+
+    /// The tool card has to say what the gesture in progress will do. "PLANE
+    /// CUT" over a lasso is a lie about which material is about to go.
+    #[test]
+    fn the_live_label_follows_the_shape_being_drawn() {
+        let mut app = app();
+        update(&mut app, Message::ToolChanged(Tool::Cut));
+        assert_eq!(app.live_tool_label(), "PLANE CUT", "an unstarted cut is not a plane cut");
+
+        let points = loop_around(SIZE.y * 0.15, 20);
+        press(&mut app, points[0]);
+        for point in points.iter().skip(1) {
+            app.on_pointer(PointerEvent::Moved { position: *point, size: SIZE });
+        }
+        app.on_pointer(PointerEvent::Moved { position: points[0], size: SIZE });
+        assert_eq!(app.live_tool_label(), "LASSO CUT", "a live loop still says plane cut");
     }
 
     #[test]

--- a/crates/brokkr-app/src/app/panel.rs
+++ b/crates/brokkr-app/src/app/panel.rs
@@ -1234,9 +1234,24 @@ impl Brokkr {
             // work: hiding a body is a draw-time skip and it keeps every slice
             // it holds. A user reading "the pool is full" and reaching for the
             // eye would see the count stay exactly where it is.
+            //
+            // **And there are two ways to be full, which need different
+            // sentences.** The allocator never splits or merges blocks and it
+            // is the bump watermark, not what is live, that fails a request --
+            // so an editing session that only ever SHRINKS meshes walks the
+            // watermark up while the live total falls. Thirty trims measures
+            // 1.45x on the render bench. In that state "delete a body or
+            // resample coarser" is advice about a problem the user does not
+            // have: there is room, it is just stranded, and only a full rebuild
+            // of the view gets it back.
+            let fragmented = pool.vertices_watermark > (pool.vertices as u64).saturating_mul(5) / 4;
+            let remedy = if fragmented {
+                "the pool is fragmented by editing, not full -- reopen the file to recover it"
+            } else {
+                "delete a body or resample coarser -- hiding one frees nothing"
+            };
             let warning = format!(
-                "MESH POOL FULL: {} bricks missing from the view\ndelete a body or resample \
-                 coarser -- hiding one frees nothing",
+                "MESH POOL FULL: {} bricks missing from the view\n{remedy}",
                 pool.overflowed
             );
             stacked = stacked.push(

--- a/crates/brokkr-app/src/cut.rs
+++ b/crates/brokkr-app/src/cut.rs
@@ -1,0 +1,794 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Reading a screen gesture as a convex cutter.
+//!
+//! Everything here is two dimensional and in widget pixels. It knows nothing
+//! about the camera, the document or the field: it turns the path a pointer
+//! took into a small convex polygon, and `app` turns that polygon into the
+//! [`brokkr_core::ClipPlane`]s that do the work. Keeping the split there is
+//! what makes the fiddly part -- which strokes mean what, and what a hull does
+//! to a stroke that doubles back -- testable without a camera or a volume.
+//!
+//! # One gesture, three readings
+//!
+//! There is one drag and no shape picker, and the shape is inferred from what
+//! was drawn. That is a deliberate rejection of the strip of shape buttons
+//! every comparable tool ships: the tool card is already at the height where
+//! anything further has to displace something, and a stroke that is obviously
+//! a straight line does not need to be declared one.
+//!
+//! * [`CutShape::Line`] -- what ships today. One plane, infinite, through the
+//!   whole model. It is the DEFAULT rather than a special case, and the
+//!   threshold that leaves it is deliberately generous: a hand-drawn "straight"
+//!   drag across most of a window wanders by more pixels than anyone expects,
+//!   and turning the one cut people already rely on into a lasso because their
+//!   hand shook would be much worse than occasionally reading a gentle arc as a
+//!   line.
+//! * [`CutShape::Curve`] -- an open stroke. The stroke is extended past both
+//!   ends along the direction it was travelling and then hulled, which is what
+//!   ZBrush does when it extrapolates a short stroke "to the edge, following
+//!   the final path". Without the extension the hull of an arc is a thin
+//!   crescent, so a shallow curve across a shoulder -- the first thing anyone
+//!   tries -- would gouge a sliver out of the middle and leave everything above
+//!   it standing.
+//! * [`CutShape::Lasso`] -- a stroke whose ends met. The hull of the points.
+//!
+//! # The hull, and what it costs
+//!
+//! **The region removed is always convex, and it is always the hull of what was
+//! drawn rather than the stroke itself.** A C-shaped lasso therefore takes the
+//! gap in the C as well. That is a real limitation and it is not hidden: the
+//! preview draws the decimated hull, so what is shown is exactly what goes, and
+//! the divergence between the two is visible before the button comes up rather
+//! than discovered afterwards.
+//!
+//! The alternative -- decomposing a non-convex polygon and taking the union of
+//! the pieces -- is not merely harder, it is actively broken on a signed
+//! distance field: at a point deep inside the union but on an internal seam the
+//! value comes out exactly zero rather than large and positive, so the brick
+//! spans zero, classifies as crossing instead of removed, is promoted to a
+//! dense 128 KB, and is then refused by the collapse test. The result is a
+//! permanently resident brick in the middle of a region the user just deleted,
+//! once per seam, with the exported mesh perfectly correct and nothing to see.
+
+use glam::Vec2;
+
+/// Sides a cut hull may have, before the depth caps.
+///
+/// Every side is a plane, and every plane is a dot product per voxel of every
+/// brick it crosses. Sixteen is where the cost stops being free and the shape
+/// stops getting visibly better: a hand-drawn loop simplified to sixteen
+/// vertices is not distinguishable from the same loop at forty at any zoom the
+/// viewport offers.
+pub const MAX_CUT_PLANES: usize = 16;
+
+/// How far the pointer must travel before another point is kept.
+///
+/// The raw event stream is far denser than the shape needs and its density
+/// depends on how fast the hand moved, which would make an identical-looking
+/// stroke simplify differently depending on speed.
+pub const CUT_PATH_SPACING_PX: f32 = 2.0;
+
+/// How far a stroke may wander from its own chord and still be a straight line.
+///
+/// **Two terms, and the relative one is what matters.** A fixed pixel tolerance
+/// is wrong at both ends of the range: eight pixels is a lot of wobble on a
+/// short drag and nothing at all on one that crosses the window. The fraction
+/// is what makes a long drag stay a line, and the long drag is precisely the
+/// case where reading a lasso by accident would be most destructive.
+///
+/// Both numbers are judgement rather than measurement, and this is the constant
+/// most likely to want moving after a day of real use. [`CutShape::Line`] is
+/// the safe reading, so they err generous.
+pub const LASSO_DEVIATION_PX: f32 = 10.0;
+
+/// The same tolerance as a fraction of the stroke's own chord. See
+/// [`LASSO_DEVIATION_PX`].
+pub const LASSO_DEVIATION_FRACTION: f32 = 0.06;
+
+/// How close a stroke's ends must come for it to count as closed.
+///
+/// Generous, because closing a loop exactly is fiddly with a mouse and the
+/// failure of reading a closed loop as open is loud -- the extension points
+/// send the cutter off across the whole view.
+pub const CLOSE_RADIUS_PX: f32 = 28.0;
+
+/// How far past its ends an open stroke is extended, as a multiple of the
+/// stroke's own span.
+///
+/// Large enough that the extended hull covers the viewport for any stroke worth
+/// making, small enough that the numbers stay far from where `f32` gets coarse.
+const EXTENSION_SPANS: f32 = 8.0;
+
+/// How the stroke was read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CutShape {
+    /// A straight drag: one infinite plane, exactly as the cut has always
+    /// worked.
+    Line,
+    /// An open stroke, extended past both ends and hulled.
+    Curve,
+    /// A closed stroke: the hull of what was drawn.
+    Lasso,
+}
+
+impl CutShape {
+    /// What the live tool strip says while this shape is being drawn.
+    pub fn label(self) -> &'static str {
+        match self {
+            CutShape::Line => "PLANE CUT",
+            CutShape::Curve => "CURVE CUT",
+            CutShape::Lasso => "LASSO CUT",
+        }
+    }
+}
+
+/// A gesture read as a convex region of the screen.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CutGesture {
+    pub shape: CutShape,
+    /// The region, in widget pixels, wound counter-clockwise in a y-down
+    /// coordinate system.
+    ///
+    /// Exactly two points for [`CutShape::Line`] -- the ends of the drag, which
+    /// name one plane and no region. Three or more, and at most
+    /// [`MAX_CUT_PLANES`], for the other two.
+    pub hull: Vec<Vec2>,
+}
+
+/// Read a pointer path as a cutter, or `None` if it is not a gesture.
+///
+/// `None` is a click, or a path so short it cannot name a direction. It is not
+/// an error -- the caller says so in the status line -- and refusing here is
+/// the point: a destructive tool must decline an ambiguous gesture rather than
+/// pick an interpretation.
+pub fn read_stroke(path: &[Vec2], click_slop_px: f32) -> Option<CutGesture> {
+    let first = *path.first()?;
+    let last = *path.last()?;
+
+    // The span of the whole path, not the distance between its ends: a stroke
+    // that returns to where it started has a zero chord and is still a gesture.
+    let span = path_span(path);
+    if span < click_slop_px {
+        return None;
+    }
+
+    let closed = path.len() >= 3 && first.distance(last) <= CLOSE_RADIUS_PX;
+
+    if !closed {
+        let chord = first.distance(last);
+        let tolerance = LASSO_DEVIATION_PX.max(chord * LASSO_DEVIATION_FRACTION);
+        if straightness(path) <= tolerance {
+            // Deliberately the raw ends and not a hull. This is today's cut and
+            // it must stay today's cut: two points, one plane, one cross
+            // product, and the side convention that a test observes rather than
+            // derives.
+            return Some(CutGesture { shape: CutShape::Line, hull: vec![first, last] });
+        }
+    }
+
+    let simplified = simplify(path, CUT_PATH_SPACING_PX);
+    let points = if closed { simplified } else { extended(&simplified, span) };
+
+    let hull = decimate(convex_hull(&points), MAX_CUT_PLANES);
+    if hull.len() < 3 {
+        // Collinear after all -- a there-and-back stroke, or one whose hull
+        // collapsed. There is no region here and inventing one would remove
+        // material along a line the user did not draw a side for.
+        return None;
+    }
+
+    Some(CutGesture { shape: if closed { CutShape::Lasso } else { CutShape::Curve }, hull })
+}
+
+/// The longest distance between any point of the path and its first point.
+///
+/// Used instead of the chord so that a there-and-back stroke is still measured
+/// as having gone somewhere.
+fn path_span(path: &[Vec2]) -> f32 {
+    let Some(&first) = path.first() else {
+        return 0.0;
+    };
+    path.iter().map(|point| first.distance(*point)).fold(0.0, f32::max)
+}
+
+/// The furthest any point strays from the line between the path's ends.
+fn straightness(path: &[Vec2]) -> f32 {
+    let (Some(&first), Some(&last)) = (path.first(), path.last()) else {
+        return 0.0;
+    };
+    path.iter().map(|point| distance_to_segment(*point, first, last)).fold(0.0, f32::max)
+}
+
+/// Perpendicular distance from a point to a segment, clamped to its ends.
+fn distance_to_segment(point: Vec2, from: Vec2, to: Vec2) -> f32 {
+    let along = to - from;
+    let length_squared = along.length_squared();
+    if length_squared <= f32::EPSILON {
+        return point.distance(from);
+    }
+    let t = ((point - from).dot(along) / length_squared).clamp(0.0, 1.0);
+    point.distance(from + along * t)
+}
+
+/// The stroke with a far point added past each end, along the direction the
+/// stroke was going when it got there.
+///
+/// This is what turns an open curve into a region. Without it the hull of an
+/// arc is the arc's own thin crescent, and cutting with that removes a sliver
+/// from the middle of the stroke and nothing else -- which looks like the tool
+/// is broken, because the one thing the user asked for is the part it leaves.
+fn extended(path: &[Vec2], span: f32) -> Vec<Vec2> {
+    let mut points = path.to_vec();
+    let reach = span * EXTENSION_SPANS;
+
+    // Taken from the end SEGMENT rather than from the whole chord: the
+    // extension has to continue the direction the stroke was travelling when it
+    // stopped, which on a curve is nothing like the direction from end to end.
+    if let (Some(&first), Some(&second)) = (path.first(), path.get(1))
+        && let Some(away) = (first - second).try_normalize()
+    {
+        points.push(first + away * reach);
+    }
+    if path.len() >= 2
+        && let (Some(&last), Some(&before)) = (path.last(), path.get(path.len() - 2))
+        && let Some(away) = (last - before).try_normalize()
+    {
+        points.push(last + away * reach);
+    }
+    points
+}
+
+/// Douglas-Peucker: drop every point that lies within `epsilon` of the line
+/// its neighbours already describe.
+///
+/// Iterative rather than recursive. A pointer path can carry thousands of
+/// points and the recursion depth of the textbook form is bounded only by the
+/// path length, which is a stack overflow driven by how long someone held the
+/// button down.
+pub fn simplify(path: &[Vec2], epsilon: f32) -> Vec<Vec2> {
+    if path.len() <= 2 {
+        return path.to_vec();
+    }
+    let mut keep = vec![false; path.len()];
+    keep[0] = true;
+    keep[path.len() - 1] = true;
+
+    let mut pending = vec![(0usize, path.len() - 1)];
+    while let Some((start, end)) = pending.pop() {
+        if end <= start + 1 {
+            continue;
+        }
+        let mut worst = 0.0;
+        let mut at = start;
+        for (index, point) in path.iter().enumerate().take(end).skip(start + 1) {
+            let distance = distance_to_segment(*point, path[start], path[end]);
+            if distance > worst {
+                worst = distance;
+                at = index;
+            }
+        }
+        if worst > epsilon {
+            keep[at] = true;
+            pending.push((start, at));
+            pending.push((at, end));
+        }
+    }
+
+    path.iter().zip(keep).filter_map(|(point, keep)| keep.then_some(*point)).collect()
+}
+
+/// Andrew's monotone chain convex hull.
+///
+/// Returns the hull wound counter-clockwise in a y-down coordinate system,
+/// with no repeated first point. Fewer than three input points come back as
+/// they went in.
+pub fn convex_hull(points: &[Vec2]) -> Vec<Vec2> {
+    if points.len() < 3 {
+        return points.to_vec();
+    }
+    let mut sorted = points.to_vec();
+    sorted.sort_by(|a, b| a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y)));
+    sorted.dedup();
+    if sorted.len() < 3 {
+        return sorted;
+    }
+
+    // Positive for a left turn in a y-down system, which is what makes the
+    // finished hull counter-clockwise on screen.
+    let turn = |o: Vec2, a: Vec2, b: Vec2| (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+
+    let mut hull: Vec<Vec2> = Vec::with_capacity(sorted.len() * 2);
+    for &point in &sorted {
+        while hull.len() >= 2 && turn(hull[hull.len() - 2], hull[hull.len() - 1], point) <= 0.0 {
+            hull.pop();
+        }
+        hull.push(point);
+    }
+    let lower = hull.len() + 1;
+    for &point in sorted.iter().rev().skip(1) {
+        while hull.len() >= lower && turn(hull[hull.len() - 2], hull[hull.len() - 1], point) <= 0.0
+        {
+            hull.pop();
+        }
+        hull.push(point);
+    }
+    // The last point is the first one again.
+    hull.pop();
+    hull
+}
+
+/// Drop hull vertices until at most `most` remain: outlier spikes first, then
+/// whichever vertex is bending the outline least.
+///
+/// **Two rules and not one, and the order between them is the whole design.**
+///
+/// The first rule exists because `min` over the planes is exact inside the
+/// region and outside a face, but outside a convex EDGE it over-estimates by
+/// `r * (1 - sin(t/2))` at a wedge of interior angle `t` -- 0.88 of a voxel at
+/// a right angle and 2.48 at twenty degrees, taken at the edge of the narrow
+/// band. An outlier sample on a shaky hand-drawn loop IS an acute hull vertex,
+/// so the sharpest corners are both the most expensive to approximate and the
+/// least likely to have been meant. Anything sharper than [`SPIKE_ANGLE`] goes
+/// before anything else is considered.
+///
+/// The second rule is Visvalingam-Whyatt: drop the vertex whose triangle with
+/// its two neighbours has the least area, which is the vertex whose removal
+/// changes the outline least.
+///
+/// **Angle alone is not enough, and the failure is not obvious.** On a hand-drawn
+/// loop -- or any roughly round one -- every vertex has nearly the same angle,
+/// so an angle-only rule picks whichever tie it happens to break first, and
+/// removing a vertex makes its two neighbours sharper. The next pass therefore
+/// picks a neighbour, and the one after that its neighbour, and the decimation
+/// eats its way around one arc of the loop and leaves a long chord across it.
+/// The hull is still convex, still has the right vertex count, and quietly
+/// spares a sixty-degree wedge of everything the user drew a line around. This
+/// was caught by `the_region_cut_matches_the_region_drawn` and by nothing else.
+///
+/// Dropping a hull vertex only ever SHRINKS the region either way, so
+/// decimation errs toward removing less material, which is the recoverable
+/// direction.
+///
+/// # The keys are cached, and that is worth a paragraph
+///
+/// This runs on **every pointer motion event** while a cut is being drawn, over
+/// the whole hull accumulated so far, so its cost is what decides whether a
+/// long or shaky stroke stays smooth. Recomputing every vertex's key on every
+/// removal is `h^2/2` evaluations of two `try_normalize` (two square roots), an
+/// `acos` and a cross product: measured at 1.90 ms for a 512-vertex hull,
+/// 7.36 ms at 1024 and 28.13 ms at 2048 -- past the frame at the sizes a
+/// determined scribble reaches.
+///
+/// Removing a vertex changes the `before`/`at`/`after` triple of exactly TWO
+/// others, its two neighbours. Everything else keeps the key it already had, so
+/// caching and repairing those two is not an approximation of the old
+/// behaviour, it is the same computation with the redundant part removed: same
+/// keys, same `<` comparison, same first-lowest-index tie-break, same output
+/// vertex for vertex. Measured at 0.15 / 0.58 / 2.10 ms for the same three
+/// sizes -- **12 to 13 times faster**.
+pub fn decimate(mut hull: Vec<Vec2>, most: usize) -> Vec<Vec2> {
+    let floor = most.max(3);
+    if hull.len() <= floor {
+        return hull;
+    }
+    let key_at = |hull: &[Vec2], index: usize| {
+        let before = hull[(index + hull.len() - 1) % hull.len()];
+        let at = hull[index];
+        let after = hull[(index + 1) % hull.len()];
+        let angle = interior_angle(before, at, after);
+        // The tuple IS the ordering: a spike sorts by its angle in the first
+        // slot and beats every non-spike, which all share an infinite first
+        // slot and are separated by area.
+        if angle < SPIKE_ANGLE {
+            (angle, 0.0)
+        } else {
+            (f32::INFINITY, triangle_area(before, at, after))
+        }
+    };
+
+    let mut keys: Vec<(f32, f32)> = (0..hull.len()).map(|index| key_at(&hull, index)).collect();
+
+    while hull.len() > floor {
+        let mut worst = 0usize;
+        let mut best = (f32::INFINITY, f32::INFINITY);
+        for (index, key) in keys.iter().enumerate() {
+            if *key < best {
+                best = *key;
+                worst = index;
+            }
+        }
+        hull.remove(worst);
+        keys.remove(worst);
+        // The two vertices that were either side of the one just removed are
+        // now neighbours, so their triples changed and nobody else's did. After
+        // the removal those are the entries at `worst` and the one before it,
+        // both taken modulo the NEW length.
+        let left = (worst + hull.len() - 1) % hull.len();
+        let right = worst % hull.len();
+        keys[left] = key_at(&hull, left);
+        keys[right] = key_at(&hull, right);
+    }
+    hull
+}
+
+/// Interior angle below which a hull vertex is treated as an outlier spike
+/// rather than as part of the outline.
+///
+/// A right angle. Nothing drawn deliberately as part of a loop comes to a
+/// corner sharper than this -- a hand tracing round a lump produces obtuse
+/// vertices throughout -- while a single stray sample spikes far below it.
+const SPIKE_ANGLE: f32 = std::f32::consts::FRAC_PI_2;
+
+/// Twice the area of the triangle three points make. The factor is dropped
+/// because only the ordering is used.
+fn triangle_area(before: Vec2, at: Vec2, after: Vec2) -> f32 {
+    let a = before - at;
+    let b = after - at;
+    (a.x * b.y - a.y * b.x).abs()
+}
+
+/// The interior angle at `at`, in radians, or `TAU` when it is degenerate.
+///
+/// Degenerate comes back as the largest possible angle so that a coincident
+/// vertex is never chosen as the sharpest corner -- it has no angle to be
+/// sharp, and picking it would drop a real corner instead.
+fn interior_angle(before: Vec2, at: Vec2, after: Vec2) -> f32 {
+    let (Some(a), Some(b)) = ((before - at).try_normalize(), (after - at).try_normalize()) else {
+        return std::f32::consts::TAU;
+    };
+    a.dot(b).clamp(-1.0, 1.0).acos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SLOP: f32 = 4.0;
+
+    fn line(from: Vec2, to: Vec2, steps: usize) -> Vec<Vec2> {
+        (0..=steps).map(|step| from.lerp(to, step as f32 / steps as f32)).collect()
+    }
+
+    /// The default, and the one that must not move: a straight drag is one
+    /// plane and two points, whatever else this module learns to read.
+    #[test]
+    fn a_straight_drag_is_still_a_line() {
+        let path = line(Vec2::new(100.0, 300.0), Vec2::new(900.0, 300.0), 200);
+        let gesture = read_stroke(&path, SLOP).expect("a long drag is a gesture");
+        assert_eq!(gesture.shape, CutShape::Line);
+        assert_eq!(gesture.hull.len(), 2, "a line is two points and one plane");
+        assert_eq!(gesture.hull[0], path[0]);
+        assert_eq!(gesture.hull[1], *path.last().unwrap());
+    }
+
+    /// **The regression this tolerance exists to prevent.** A hand does not
+    /// draw a straight line, and a drag across most of a window that wobbles by
+    /// a couple of dozen pixels is a line by intent. Reading it as a lasso would
+    /// make the one cut people already rely on conditional on hand steadiness.
+    #[test]
+    fn a_wobbly_long_drag_is_still_a_line() {
+        let path: Vec<Vec2> = (0..=200)
+            .map(|step| {
+                let t = step as f32 / 200.0;
+                // +-20 px of wander across an 800 px drag.
+                Vec2::new(100.0 + t * 800.0, 300.0 + (t * 9.0).sin() * 20.0)
+            })
+            .collect();
+        let gesture = read_stroke(&path, SLOP).expect("a long drag is a gesture");
+        assert_eq!(gesture.shape, CutShape::Line, "a shaky hand turned a line into a region");
+    }
+
+    /// And the other side of it: a stroke that is deliberately, obviously bent
+    /// must not be flattened into a plane through the middle of the model.
+    #[test]
+    fn a_deliberate_arc_is_a_curve() {
+        let path: Vec<Vec2> = (0..=100)
+            .map(|step| {
+                let t = step as f32 / 100.0;
+                Vec2::new(100.0 + t * 800.0, 400.0 - (t * std::f32::consts::PI).sin() * 250.0)
+            })
+            .collect();
+        let gesture = read_stroke(&path, SLOP).expect("an arc is a gesture");
+        assert_eq!(gesture.shape, CutShape::Curve);
+        assert!(gesture.hull.len() >= 3, "a curve must name a region");
+    }
+
+    /// The failure the extension points exist to fix. Hulling an arc on its own
+    /// gives a thin crescent, so the cut would take a sliver out of the middle
+    /// of the stroke and leave the thing the user was cutting off standing.
+    #[test]
+    fn a_curve_covers_more_than_the_crescent_between_its_ends() {
+        let path: Vec<Vec2> = (0..=100)
+            .map(|step| {
+                let t = step as f32 / 100.0;
+                Vec2::new(100.0 + t * 800.0, 400.0 - (t * std::f32::consts::PI).sin() * 250.0)
+            })
+            .collect();
+        let gesture = read_stroke(&path, SLOP).expect("an arc is a gesture");
+
+        let reach = gesture
+            .hull
+            .iter()
+            .map(|point| point.distance(Vec2::new(500.0, 400.0)))
+            .fold(0.0, f32::max);
+        assert!(
+            reach > 800.0,
+            "the curve's hull stayed inside the stroke, so it is the crescent: reach {reach}"
+        );
+    }
+
+    /// A closed loop is its own hull, with no extension anywhere.
+    #[test]
+    fn a_closed_loop_is_a_lasso_and_stays_where_it_was_drawn() {
+        let path: Vec<Vec2> = (0..=64)
+            .map(|step| {
+                let angle = step as f32 / 64.0 * std::f32::consts::TAU;
+                Vec2::new(400.0, 300.0) + Vec2::new(angle.cos(), angle.sin()) * 120.0
+            })
+            .collect();
+        let gesture = read_stroke(&path, SLOP).expect("a loop is a gesture");
+        assert_eq!(gesture.shape, CutShape::Lasso);
+        for point in &gesture.hull {
+            let out = point.distance(Vec2::new(400.0, 300.0));
+            assert!(
+                (100.0..=140.0).contains(&out),
+                "a lasso's hull left the loop it was drawn as: {out} from centre"
+            );
+        }
+    }
+
+    /// A click is not a cut, and neither is a twitch.
+    #[test]
+    fn a_click_is_not_a_gesture() {
+        assert!(read_stroke(&[], SLOP).is_none());
+        assert!(read_stroke(&[Vec2::new(10.0, 10.0)], SLOP).is_none());
+        assert!(read_stroke(&line(Vec2::ZERO, Vec2::new(2.0, 0.0), 4), SLOP).is_none());
+    }
+
+    /// A stroke that goes out and comes straight back covers real distance and
+    /// still encloses nothing. It must be refused rather than hulled into a
+    /// sliver, because a sliver thinner than the lattice removes material in
+    /// some places and not others depending on where the voxels happen to fall.
+    #[test]
+    fn a_there_and_back_stroke_encloses_nothing() {
+        let mut path = line(Vec2::new(100.0, 300.0), Vec2::new(500.0, 300.0), 100);
+        path.extend(line(Vec2::new(500.0, 300.0), Vec2::new(100.0, 300.0), 100));
+        // Reads as closed -- it ends where it started -- and hulls to a line.
+        assert!(read_stroke(&path, SLOP).is_none(), "a degenerate loop produced a region");
+    }
+
+    /// No stroke may produce more planes than the ceiling, however intricate.
+    #[test]
+    fn a_hull_never_exceeds_the_plane_ceiling() {
+        let path: Vec<Vec2> = (0..=400)
+            .map(|step| {
+                let angle = step as f32 / 400.0 * std::f32::consts::TAU;
+                let wobble = 120.0 + (angle * 17.0).sin() * 30.0;
+                Vec2::new(400.0, 300.0) + Vec2::new(angle.cos(), angle.sin()) * wobble
+            })
+            .collect();
+        let gesture = read_stroke(&path, SLOP).expect("a loop is a gesture");
+        assert!(
+            gesture.hull.len() <= MAX_CUT_PLANES,
+            "an intricate loop produced {} planes",
+            gesture.hull.len()
+        );
+    }
+
+    #[test]
+    fn the_hull_of_a_square_is_its_corners() {
+        let points = [
+            Vec2::new(0.0, 0.0),
+            Vec2::new(10.0, 0.0),
+            Vec2::new(10.0, 10.0),
+            Vec2::new(0.0, 10.0),
+            // Interior points, which must not survive.
+            Vec2::new(5.0, 5.0),
+            Vec2::new(2.0, 8.0),
+        ];
+        let hull = convex_hull(&points);
+        assert_eq!(hull.len(), 4, "the hull kept an interior point: {hull:?}");
+    }
+
+    /// The hull must wind consistently, because the sign of the plane normals
+    /// built from it depends on the winding and a hull that sometimes came back
+    /// the other way round would cut the wrong side at random.
+    #[test]
+    fn the_hull_winds_the_same_way_whatever_order_it_is_given() {
+        let square = [
+            Vec2::new(0.0, 0.0),
+            Vec2::new(10.0, 0.0),
+            Vec2::new(10.0, 10.0),
+            Vec2::new(0.0, 10.0),
+        ];
+        let signed_area = |hull: &[Vec2]| {
+            (0..hull.len())
+                .map(|index| {
+                    let a = hull[index];
+                    let b = hull[(index + 1) % hull.len()];
+                    a.x * b.y - b.x * a.y
+                })
+                .sum::<f32>()
+        };
+        let forward = signed_area(&convex_hull(&square));
+        let mut backward: Vec<Vec2> = square.to_vec();
+        backward.reverse();
+        assert!(forward.abs() > 0.0, "the hull has no area");
+        assert_eq!(
+            forward.is_sign_positive(),
+            signed_area(&convex_hull(&backward)).is_sign_positive(),
+            "the hull's winding depends on the order it was handed its points"
+        );
+    }
+
+    /// Decimation drops the sharpest corner, not the smallest one. A long thin
+    /// spike off an otherwise round hull is the vertex to lose.
+    #[test]
+    fn decimation_drops_the_sharpest_corner_first() {
+        let mut hull: Vec<Vec2> = (0..8)
+            .map(|step| {
+                let angle = step as f32 / 8.0 * std::f32::consts::TAU;
+                Vec2::new(angle.cos(), angle.sin()) * 100.0
+            })
+            .collect();
+        // A spike: far out, and therefore very acute.
+        let spike = Vec2::new(0.0, -600.0);
+        hull.insert(2, spike);
+
+        let kept = decimate(hull, 8);
+        assert_eq!(kept.len(), 8);
+        assert!(!kept.contains(&spike), "the spike survived decimation: {kept:?}");
+    }
+
+    /// **Decimation must spread, not eat an arc.**
+    ///
+    /// On a round loop every vertex has nearly the same angle. An angle-only
+    /// rule breaks the tie the same way every pass, and removing a vertex makes
+    /// its neighbours sharper -- so it works its way around one arc and leaves
+    /// a long chord across it. The hull stays convex and keeps the right vertex
+    /// count, and quietly spares a whole wedge of what the user drew a line
+    /// around.
+    ///
+    /// Asserted on the area kept rather than on which vertices survived: what
+    /// matters is that the polygon still covers the loop, not which particular
+    /// samples represent it.
+    #[test]
+    fn decimating_a_round_loop_keeps_its_whole_area() {
+        let circle: Vec<Vec2> = (0..48)
+            .map(|step| {
+                let angle = step as f32 / 48.0 * std::f32::consts::TAU;
+                Vec2::new(angle.cos(), angle.sin()) * 100.0
+            })
+            .collect();
+        let area = |hull: &[Vec2]| {
+            (0..hull.len())
+                .map(|index| {
+                    let a = hull[index];
+                    let b = hull[(index + 1) % hull.len()];
+                    a.x * b.y - b.x * a.y
+                })
+                .sum::<f32>()
+                .abs()
+                * 0.5
+        };
+
+        let full = area(&circle);
+        let kept = area(&decimate(circle.clone(), MAX_CUT_PLANES));
+        // A regular 16-gon inscribed in a circle keeps 97.4% of its area. Any
+        // rule that eats one arc loses far more than that: chopping a 60 degree
+        // wedge off alone costs about 9%.
+        assert!(
+            kept > full * 0.95,
+            "decimation lost {:.1}% of the loop, so it ate an arc rather than spreading",
+            (1.0 - kept / full) * 100.0
+        );
+    }
+
+    /// And the two rules together: a spike on a round loop must still go first,
+    /// and the rest of the loop must still be spread over.
+    #[test]
+    fn a_spike_goes_before_the_loop_is_thinned() {
+        let mut points: Vec<Vec2> = (0..20)
+            .map(|step| {
+                let angle = step as f32 / 20.0 * std::f32::consts::TAU;
+                Vec2::new(angle.cos(), angle.sin()) * 100.0
+            })
+            .collect();
+        let spike = Vec2::new(0.0, -900.0);
+        points.insert(7, spike);
+
+        let kept = decimate(points, MAX_CUT_PLANES);
+        assert!(!kept.contains(&spike), "the spike outlived ordinary vertices: {kept:?}");
+        let reach = kept.iter().map(|p| p.length()).fold(0.0, f32::max);
+        assert!(reach < 200.0, "something far out survived: reach {reach}");
+    }
+
+    /// **The cached decimation is the naive one, vertex for vertex.**
+    ///
+    /// `decimate` caches each vertex's key and repairs only the two neighbours
+    /// of whatever it just removed. That is sound because removing a vertex
+    /// changes no other triple -- but "sound because I reasoned it through" is
+    /// how an off-by-one in the modular index survives, so this runs the
+    /// straightforward O(h^2) form beside it and demands the same answer.
+    ///
+    /// Over awkward shapes on purpose: ties everywhere (a regular polygon),
+    /// spikes that must go first, and a jittery loop where the ordering is
+    /// decided by small float differences.
+    #[test]
+    fn caching_the_decimation_keys_changes_nothing_it_produces() {
+        /// The form this replaced: every key recomputed on every removal.
+        fn naive(mut hull: Vec<Vec2>, most: usize) -> Vec<Vec2> {
+            while hull.len() > most.max(3) {
+                let mut worst = 0usize;
+                let mut best = (f32::INFINITY, f32::INFINITY);
+                for index in 0..hull.len() {
+                    let before = hull[(index + hull.len() - 1) % hull.len()];
+                    let after = hull[(index + 1) % hull.len()];
+                    let angle = interior_angle(before, hull[index], after);
+                    let key = if angle < SPIKE_ANGLE {
+                        (angle, 0.0)
+                    } else {
+                        (f32::INFINITY, triangle_area(before, hull[index], after))
+                    };
+                    if key < best {
+                        best = key;
+                        worst = index;
+                    }
+                }
+                hull.remove(worst);
+            }
+            hull
+        }
+
+        let regular: Vec<Vec2> = (0..40)
+            .map(|step| {
+                let angle = step as f32 / 40.0 * std::f32::consts::TAU;
+                Vec2::new(angle.cos(), angle.sin()) * 100.0
+            })
+            .collect();
+
+        let mut spiky = regular.clone();
+        spiky.insert(9, Vec2::new(0.0, -700.0));
+        spiky.insert(23, Vec2::new(640.0, 30.0));
+
+        let jittery: Vec<Vec2> = (0..64)
+            .map(|step| {
+                let angle = step as f32 / 64.0 * std::f32::consts::TAU;
+                let wobble = 100.0 + (angle * 11.0).sin() * 23.0 + (angle * 3.0).cos() * 7.0;
+                Vec2::new(angle.cos(), angle.sin()) * wobble
+            })
+            .collect();
+
+        for (name, points) in [("regular", regular), ("spiky", spiky), ("jittery", jittery)] {
+            for most in [3, 5, 8, MAX_CUT_PLANES, 30] {
+                assert_eq!(
+                    decimate(points.clone(), most),
+                    naive(points.clone(), most),
+                    "{name} decimated to {most} differs from the straightforward form"
+                );
+            }
+        }
+    }
+
+    /// Simplification must not move the ends: they are the line's two points
+    /// and the curve's two extension anchors.
+    #[test]
+    fn simplifying_keeps_both_ends() {
+        let path = line(Vec2::new(3.0, 7.0), Vec2::new(103.0, 57.0), 50);
+        let simple = simplify(&path, 2.0);
+        assert_eq!(simple.first(), path.first());
+        assert_eq!(simple.last(), path.last());
+        assert!(simple.len() < path.len(), "a straight path did not simplify");
+    }
+
+    /// A path of thousands of points must not recurse its way through the
+    /// stack. This is the shape a user produces by holding the button down.
+    #[test]
+    fn simplifying_a_very_long_path_does_not_overflow_the_stack() {
+        let path: Vec<Vec2> = (0..20_000)
+            .map(|step| Vec2::new(step as f32 * 0.01, (step as f32 * 0.01).sin() * 50.0))
+            .collect();
+        assert!(!simplify(&path, 0.5).is_empty());
+    }
+}

--- a/crates/brokkr-app/src/cut_preview.rs
+++ b/crates/brokkr-app/src/cut_preview.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The live cut preview: what the drag so far is going to remove.
+//!
+//! Built here and handed to `brokkr-gpu` as plain coloured vertices, exactly as
+//! the brush cursor is, and for the same reasons -- `brokkr-core` never learns
+//! that a screen exists and the GPU crate never learns what a cut is.
+//!
+//! # Why this exists at all
+//!
+//! Before it, the cut had **no preview of any kind**. `DragKind::Cutting` fell
+//! into a do-nothing arm on every motion event, nothing anywhere drew a line,
+//! and the comment above that arm said the opposite. The user dragged a
+//! destructive, irreversible-except-by-undo gesture across their model seeing
+//! nothing but the brush ring -- which implies a press would sculpt.
+//!
+//! # What is drawn is what goes
+//!
+//! **The decimated hull, and never the raw stroke.** The hull is what the
+//! planes are built from, so drawing the stroke would show one shape and remove
+//! another, and the difference is exactly where the surprises are: a lasso with
+//! a dent in it is cut as though the dent were not there, and a hand-drawn loop
+//! is simplified to sixteen sides. Both are visible before the button comes up
+//! precisely because this draws the hull.
+//!
+//! For a straight drag the hull is two points and there is no region, so what
+//! is drawn instead is the line and a shaded band on the side that goes -- the
+//! side convention being the one thing about the plane cut that cannot be
+//! worked out by looking at it.
+//!
+//! # Why it is drawn at the focus depth
+//!
+//! The cutter is a pyramid from the eye, so it has no single depth. It is drawn
+//! on the plane through the camera's target, facing the camera, because that is
+//! where the model the user is looking at actually is. The consequence is worth
+//! stating plainly rather than hiding: the region is screen-exact and the
+//! **taper is not shown**. A small loop takes slightly more than its outline at
+//! the back of the model than at the front. Every tool with a perspective
+//! camera has this, and the alternative -- drawing the frustum's true silhouette
+//! -- is a solid that occludes the thing being cut.
+
+use brokkr_gpu::OverlayBatch;
+use glam::{Vec2, Vec3};
+
+use crate::cut::CutShape;
+use crate::theme::{self, linear};
+
+/// Opacity of the shaded region that is going to be removed.
+///
+/// Low, and lower than the mirror planes': this sits directly over the material
+/// it is about to take, and a fill dense enough to read as a colour would hide
+/// the shape of the thing being cut at the moment that shape matters most.
+const DOOMED_ALPHA: f32 = 0.16;
+
+/// Opacity of the same region when the cut will go all the way through.
+///
+/// Denser, because it is taking more. **The point is that the difference is
+/// visible WHILE shift is held**, not inferred from the key state at the moment
+/// of release: the research names a silent mode flip at release as the top
+/// pitfall of this whole family of tools, and this design ships exactly one
+/// modifier precisely so that the one it ships can be previewed.
+const THROUGH_ALPHA: f32 = 0.34;
+
+/// Opacity of the outline. Nearly solid -- the outline is the measurement, and
+/// it has to be legible over both the model and the background.
+const OUTLINE_ALPHA: f32 = 0.95;
+
+/// How far the shaded band beside a straight cut line reaches, as a multiple of
+/// the model's radius.
+///
+/// The plane is infinite and the band cannot be, so it reaches comfortably past
+/// anything on screen and stops. Matching `cursor`'s `PLANE_OVERSHOOT` in
+/// spirit: enough that it reads as "everything that side" rather than as a
+/// rectangle of its own.
+const BAND_OVERSHOOT: f32 = 3.0;
+
+/// Add the cut preview to an overlay batch.
+///
+/// `at` maps a point in widget pixels onto the world, and is the caller's
+/// `ray_through` closed over the camera -- passed in rather than taken as a
+/// camera so that this module stays testable without one.
+///
+/// `through` says the cut will not be depth-capped -- shift, or a straight drag,
+/// which is infinite by definition. It only changes how densely the region is
+/// shaded, and that is the whole job: the difference between "this takes the
+/// lump" and "this takes everything behind it too" has to be on screen before
+/// the button comes up.
+///
+/// `doomed` is the world-space normal of the cut plane, for the straight drag
+/// only: the side it points at is the side that goes. **It is passed in rather
+/// than worked out here, and that is the point.** The side convention is the
+/// one thing about the plane cut nobody can derive by looking -- it falls out of
+/// the ray order, the handedness of the camera basis and the y-flip in the
+/// pixel-to-NDC step -- so the preview takes the answer from the same plane the
+/// cut is about to use instead of deriving it a second time. A second derivation
+/// is a second chance to get it backwards, and getting it backwards here means
+/// the preview confidently shades the half the user is about to keep.
+///
+/// Appends rather than clearing, because the cut preview shares the sculpt
+/// overlay batch with the brush ring and the mirror planes. There is no fourth
+/// pipeline: `overlay.rs` records that the next overlay should reuse the third
+/// rather than add to the list, and this one does.
+pub fn build(
+    batch: &mut OverlayBatch,
+    hull: &[Vec2],
+    shape: CutShape,
+    model_radius: f32,
+    doomed: Option<Vec3>,
+    through: bool,
+    at: impl Fn(Vec2) -> Vec3,
+) {
+    let outline = linear(theme::ERROR, OUTLINE_ALPHA);
+    let fill = linear(theme::ERROR, if through { THROUGH_ALPHA } else { DOOMED_ALPHA });
+
+    match shape {
+        // Two points and no region: draw the line, and shade the side that
+        // goes. The side is the one piece of information a user cannot recover
+        // by looking, so it is the piece the preview owes them.
+        CutShape::Line => {
+            let [from, to] = hull else {
+                return;
+            };
+            let (start, end) = (at(*from), at(*to));
+            batch.push_line(start, end, outline);
+
+            let (Some(along), Some(normal)) = ((end - start).try_normalize(), doomed) else {
+                return;
+            };
+            // The plane's normal, with the component along the line taken out,
+            // which leaves the direction across the line that the plane removes.
+            // Gram-Schmidt rather than a cross product with the view: a cross
+            // product needs a second vector to be right about, and this needs
+            // none.
+            let Some(across) = (normal - along * normal.dot(along)).try_normalize() else {
+                return;
+            };
+            let reach = (model_radius * BAND_OVERSHOOT).max(1.0);
+            let far = along * reach;
+            batch.push_quad(
+                start - far,
+                end + far,
+                end + far + across * reach,
+                start - far + across * reach,
+                fill,
+            );
+        }
+        CutShape::Curve | CutShape::Lasso => {
+            if hull.len() < 3 {
+                return;
+            }
+            let points: Vec<Vec3> = hull.iter().map(|point| at(*point)).collect();
+            for index in 0..points.len() {
+                batch.push_line(points[index], points[(index + 1) % points.len()], outline);
+            }
+            // A fan from the first vertex, which is watertight for a convex
+            // polygon and is the reason `push_triangle` exists rather than
+            // faking a fan out of quads.
+            for index in 1..points.len() - 1 {
+                batch.push_triangle(points[0], points[index], points[index + 1], fill);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A flat projection standing in for a camera: pixels straight onto the
+    /// z = 0 plane. Enough for every question this module answers, all of which
+    /// are about how many primitives come out and in what arrangement.
+    fn flat(point: Vec2) -> Vec3 {
+        Vec3::new(point.x, point.y, 0.0)
+    }
+
+    fn square() -> Vec<Vec2> {
+        vec![Vec2::new(0.0, 0.0), Vec2::new(10.0, 0.0), Vec2::new(10.0, 10.0), Vec2::new(0.0, 10.0)]
+    }
+
+    /// A closed shape draws a closed outline: exactly one segment per hull
+    /// edge, including the one back to the start.
+    #[test]
+    fn a_lasso_draws_a_closed_loop_of_one_segment_per_edge() {
+        let mut batch = OverlayBatch::default();
+        build(&mut batch, &square(), CutShape::Lasso, 30.0, None, false, flat);
+
+        // Two vertices per segment.
+        assert_eq!(batch.lines.len(), 4 * 2, "the outline is not one segment per edge");
+        // A fan over n points is n - 2 triangles, three vertices each.
+        assert_eq!(batch.surfaces.len(), 2 * 3, "the fill is not a fan over the hull");
+    }
+
+    /// The outline must actually close. An open outline reads as a curve and
+    /// would say the region is not enclosed when it is.
+    #[test]
+    fn the_outline_returns_to_where_it_started() {
+        let mut batch = OverlayBatch::default();
+        build(&mut batch, &square(), CutShape::Lasso, 30.0, None, false, flat);
+
+        let first = batch.lines.first().expect("an outline").position;
+        let last = batch.lines.last().expect("an outline").position;
+        assert_eq!(first, last, "the outline did not close: {first:?} to {last:?}");
+    }
+
+    /// The fill sits over the region and never outside it, which is what makes
+    /// "what is shaded is what goes" true rather than approximately true.
+    #[test]
+    fn the_fill_stays_inside_the_outline() {
+        let mut batch = OverlayBatch::default();
+        build(&mut batch, &square(), CutShape::Lasso, 30.0, None, false, flat);
+
+        for vertex in &batch.surfaces {
+            let [x, y, _] = vertex.position;
+            assert!(
+                (0.0..=10.0).contains(&x) && (0.0..=10.0).contains(&y),
+                "a fill vertex left the hull: {:?}",
+                vertex.position
+            );
+        }
+    }
+
+    /// A straight drag has no region, so it draws its line and a band on one
+    /// side -- and the band must never reach across to the side being KEPT,
+    /// which is the half the user is relying on surviving.
+    ///
+    /// Asserted as "never on the wrong side" rather than "always on the right
+    /// side": the quad is anchored ON the line, so two of its corners sit
+    /// exactly at zero, and a strict test would read the anchor as a straddle.
+    #[test]
+    fn a_line_never_shades_the_side_it_keeps() {
+        let mut batch = OverlayBatch::default();
+        let hull = vec![Vec2::new(0.0, 5.0), Vec2::new(10.0, 5.0)];
+        // The plane's normal points at +y, so +y is the side that goes.
+        build(&mut batch, &hull, CutShape::Line, 30.0, Some(Vec3::Y), false, flat);
+
+        assert_eq!(batch.lines.len(), 2, "a line is one segment");
+        assert!(!batch.surfaces.is_empty(), "a line drew no doomed side");
+        for vertex in &batch.surfaces {
+            assert!(
+                vertex.position[1] >= 5.0,
+                "the band reached onto the kept side: {:?}",
+                vertex.position
+            );
+        }
+        assert!(
+            batch.surfaces.iter().any(|v| v.position[1] > 5.0),
+            "the band has no width, so it names no side at all"
+        );
+    }
+
+    /// And the other normal shades the other side. Without this the test above
+    /// would pass on a band that ignored `doomed` and always went one way.
+    #[test]
+    fn flipping_the_plane_flips_the_shaded_side() {
+        let hull = vec![Vec2::new(0.0, 5.0), Vec2::new(10.0, 5.0)];
+        let side = |normal| {
+            let mut batch = OverlayBatch::default();
+            build(&mut batch, &hull, CutShape::Line, 30.0, Some(normal), false, flat);
+            batch.surfaces.iter().map(|v| v.position[1]).fold(5.0_f32, f32::max)
+        };
+        assert!(side(Vec3::Y) > 5.0, "+y did not shade upward");
+        assert!(
+            side(-Vec3::Y) <= 5.0,
+            "-y shaded the same side as +y, so the preview ignores which side goes"
+        );
+    }
+
+    /// Nothing is drawn for a shape that has no region, rather than a
+    /// degenerate primitive that the renderer would silently drop.
+    #[test]
+    fn a_degenerate_hull_draws_nothing() {
+        for (hull, shape) in [
+            (vec![], CutShape::Lasso),
+            (vec![Vec2::ZERO, Vec2::new(1.0, 1.0)], CutShape::Lasso),
+            (vec![], CutShape::Line),
+            (vec![Vec2::ZERO], CutShape::Line),
+        ] {
+            let mut batch = OverlayBatch::default();
+            build(&mut batch, &hull, shape, 30.0, Some(Vec3::Y), false, flat);
+            assert!(batch.is_empty(), "a degenerate {shape:?} drew something");
+        }
+    }
+
+    /// The preview appends. It shares the sculpt batch with the brush ring and
+    /// the mirror planes, and clearing here would delete them.
+    #[test]
+    fn building_the_preview_keeps_what_was_already_in_the_batch() {
+        let mut batch = OverlayBatch::default();
+        batch.push_line(Vec3::ZERO, Vec3::X, [1.0, 1.0, 1.0, 1.0]);
+        let before = batch.lines.len();
+
+        build(&mut batch, &square(), CutShape::Lasso, 30.0, None, false, flat);
+
+        assert!(batch.lines.len() > before, "the preview drew nothing");
+        assert_eq!(
+            batch.lines[0].position,
+            Vec3::ZERO.to_array(),
+            "the preview cleared the batch it was given"
+        );
+    }
+
+    /// The one modifier this tool ships is previewed rather than inferred, so
+    /// the two states have to actually look different.
+    #[test]
+    fn cutting_through_is_shaded_differently_from_cutting_to_depth() {
+        let alpha = |through| {
+            let mut batch = OverlayBatch::default();
+            build(&mut batch, &square(), CutShape::Lasso, 30.0, None, through, flat);
+            batch.surfaces[0].colour[3]
+        };
+        assert_ne!(
+            alpha(false),
+            alpha(true),
+            "shift changes what the cut takes and the preview says nothing about it"
+        );
+        assert!(alpha(true) > alpha(false), "taking MORE should not read as fainter");
+    }
+}

--- a/crates/brokkr-app/src/main.rs
+++ b/crates/brokkr-app/src/main.rs
@@ -31,6 +31,8 @@ mod breadcrumbs;
 mod camera;
 mod crash;
 mod cursor;
+mod cut;
+mod cut_preview;
 mod gizmo;
 mod icon;
 // `/dev/input` and the evdev crate are Linux only, and so is everything that

--- a/crates/brokkr-app/src/viewport.rs
+++ b/crates/brokkr-app/src/viewport.rs
@@ -721,6 +721,17 @@ pub(crate) fn shortcut(character: &str, command: bool, shift: bool, alt: bool) -
         // it is up it goes back to sculpting, which `Message::ToolChanged`
         // does for every tool.
         "w" => Some(Message::ToolChanged(Tool::Transform)),
+        // The cut. `c` for cut, which is nobody else's key in particular --
+        // ZBrush reaches its clip family through a modifier chord rather than a
+        // letter, so there is no muscle memory to carry over and the obvious
+        // initial is free. Pressed while the cut is armed it goes back to
+        // sculpting, which `Message::ToolChanged` does for every tool.
+        //
+        // A key rather than a second strip button, deliberately: `panel.rs`
+        // records the tool strip as already over what fits a 768-high window
+        // without scrolling, so a tool that already HAS a button does not get
+        // to add another one.
+        "c" => Some(Message::ToolChanged(Tool::Cut)),
         // Hold to see the mask, whatever the `show mask` toggle says. ZBrush's
         // own mask-visibility key is H, taken rather than invented so muscle
         // memory carries over, and held rather than latched because that is the

--- a/crates/brokkr-core/benches/budget.rs
+++ b/crates/brokkr-core/benches/budget.rs
@@ -14,9 +14,9 @@
 use std::time::{Duration, Instant};
 
 use brokkr_core::{
-    BRICK_DIM, BrickCoord, BrickMesh, Brush, BrushDirection, BrushKind, BrushScratch, Document,
-    Entry, FalloffCurve, History, MaskField, MeshScratch, Pattern, PatternKind, Stamp, Stroke,
-    Symmetry, UndoOutcome, Volume,
+    BRICK_DIM, BrickCoord, BrickMesh, Brush, BrushDirection, BrushKind, BrushScratch, ClipCounts,
+    ClipPlane, Document, Entry, FalloffCurve, History, INSIDE, MaskField, MeshScratch, NARROW_BAND,
+    OUTSIDE, Pattern, PatternKind, Stamp, Stroke, Symmetry, UndoOutcome, Volume,
 };
 use glam::{IVec3, Vec3};
 
@@ -95,6 +95,12 @@ const MASKED_EDIT_BUDGET: Duration = Duration::from_micros(5_000);
 const LARGE_BRUSH_EDIT_BUDGET: Duration = Duration::from_micros(8_000);
 /// Remeshing whatever the edit dirtied.
 const REMESH_BUDGET: Duration = Duration::from_micros(8_000);
+
+/// Sides a decimated cut hull is allowed, from the cut tool plan.
+///
+/// The budget rows use the ceiling rather than a typical stroke: a gate set at
+/// the average passes while the worst case a user can actually draw does not.
+const MAX_CUT_PLANES: usize = 16;
 
 /// Voxels across the model, which is the M0 target size.
 const EFFECTIVE_RESOLUTION: f32 = 256.0;
@@ -654,12 +660,368 @@ fn main() {
         after.resident_bytes as f64 / (1024.0 * 1024.0)
     );
 
+    measure_the_cut(voxel_size);
+
     if passed {
         println!("\nall budgets met");
     } else {
         eprintln!("\nBUDGET EXCEEDED: see the lines marked OVER above");
         std::process::exit(1);
     }
+}
+
+/// What one cut cost, in the eight quantities the cut tool plan asks for.
+///
+/// **A baseline and not a gate**, deliberately. Nothing here folds into
+/// `passed`: before this function there was no measurement of `clip` at all, so
+/// every number it prints is the first of its kind, and a threshold invented on
+/// the same day as the first measurement is not a budget -- it is the
+/// measurement with a pass mark drawn around it. The budgets are shown beside
+/// the timings so the distance is legible; turning any of them into a gate is a
+/// later decision made against a run, and the shaped cut's own phases are where
+/// that happens.
+///
+/// The eighth quantity the plan lists -- the `MeshPool` vertices watermark --
+/// is **not here and cannot be**: the pool lives in `brokkr-gpu`, which depends
+/// on this crate rather than the other way round, and it needs a real device.
+/// It is measured in `brokkr-gpu`'s own bench, against the same thirty-cut
+/// scenario, and saying so here is cheaper than leaving a reader to wonder
+/// whether it was forgotten.
+struct CutMeasurement {
+    counts: ClipCounts,
+    dirtied: usize,
+    /// Of those, how many meshed to no triangles at all.
+    empty: usize,
+    /// Heap the recorder held at the moment the cut finished, before the
+    /// run-length encoding that `end_stroke` does. See
+    /// [`Volume::recorder_bytes`].
+    recorder_bytes: usize,
+    /// What the undo entry costs once encoded, which is what the history budget
+    /// actually charges -- printed beside the peak precisely because the two
+    /// differ by a factor nobody had written down.
+    entry_bytes: usize,
+    clip: Duration,
+    /// Turning the recorder's raw bricks into a run-length-encoded entry.
+    ///
+    /// Separated from the clip because it is not obviously part of it, and it
+    /// turned out to be most of what `Document::clip` costs.
+    encode: Duration,
+    remesh: Duration,
+}
+
+/// Cut `volume` once and report everything about it.
+///
+/// Brackets the stroke here rather than going through `Document::clip` because
+/// the recorder peak is only observable while the recorder is open, and
+/// `Document::clip` opens and closes it internally. What it costs to be a
+/// document rather than a volume -- the per body box gate and the entry
+/// assembly -- is measured separately below.
+/// Repetitions of each cut scenario, of which the FASTEST is reported.
+///
+/// The minimum and not the median, and that is a considered choice for this
+/// particular measurement. Contention only ever makes a run slower -- a
+/// scheduler that takes the core away adds time and never gives any back -- so
+/// on a machine that is doing anything else the minimum is the closest estimate
+/// of the work itself, where a median mostly reports how busy the machine was.
+///
+/// The brush rows above take p95 instead, and correctly: they measure per-event
+/// latency during a stroke, where the tail IS the user experience. This measures
+/// how expensive an operation is, which is a different question.
+///
+/// It does not make a loaded machine's numbers publishable. It makes two of them
+/// comparable to each other, which is what a before-and-after needs.
+const CUT_REPEATS: usize = 5;
+
+/// The fastest of [`CUT_REPEATS`] runs of one cut, on a fresh fixture each time.
+///
+/// Every run reseeds, because a cut is destructive: repeating it on the same
+/// volume would measure a first cut and then four cuts through a hole.
+fn fastest_cut(
+    fixture: impl Fn() -> Volume,
+    planes: &[ClipPlane],
+    meshes: &mut Vec<BrickMesh>,
+) -> CutMeasurement {
+    let mut best: Option<CutMeasurement> = None;
+    for _ in 0..CUT_REPEATS {
+        let mut volume = fixture();
+        let run = cut_once_convex(&mut volume, planes, meshes);
+        // Compared on the clip alone: it is the number the plane count moves,
+        // and taking the min of each column independently would report a run
+        // that never happened.
+        if best.as_ref().is_none_or(|best| run.clip + run.encode < best.clip + best.encode) {
+            best = Some(run);
+        }
+    }
+    best.expect("CUT_REPEATS is not zero")
+}
+
+fn cut_once(volume: &mut Volume, plane: ClipPlane, meshes: &mut Vec<BrickMesh>) -> CutMeasurement {
+    cut_once_convex(volume, std::slice::from_ref(&plane), meshes)
+}
+
+/// The sides of a regular prism whose axis runs along `direction`.
+///
+/// [`MAX_CUT_PLANES`]-sided, because that is the ceiling the plan sets on hull
+/// decimation and the ceiling is what a budget has to be measured at. Normals
+/// point INWARD, so the intersection is the prism's interior.
+fn prism_sides(centre: Vec3, direction: Vec3, radius: f32) -> Vec<ClipPlane> {
+    let axis = direction.normalize();
+    // Any two unit vectors across the axis.
+    let helper = if axis.x.abs() < 0.9 { Vec3::X } else { Vec3::Y };
+    let u = axis.cross(helper).normalize();
+    let v = axis.cross(u);
+
+    (0..MAX_CUT_PLANES)
+        .map(|side| {
+            let angle = side as f32 / MAX_CUT_PLANES as f32 * std::f32::consts::TAU;
+            let (sin, cos) = angle.sin_cos();
+            let outward = u * cos + v * sin;
+            ClipPlane::new(centre + outward * radius, -outward).expect("a unit normal")
+        })
+        .collect()
+}
+
+/// A prism capped front and back: the bounded cutter, in full.
+fn prism(centre: Vec3, direction: Vec3, radius: f32, depth: f32) -> Vec<ClipPlane> {
+    let axis = direction.normalize();
+    let mut planes = prism_sides(centre, axis, radius);
+    planes.push(ClipPlane::new(centre - axis * depth, axis).expect("a unit normal"));
+    planes.push(ClipPlane::new(centre + axis * depth, -axis).expect("a unit normal"));
+    planes
+}
+
+fn cut_once_convex(
+    volume: &mut Volume,
+    planes: &[ClipPlane],
+    meshes: &mut Vec<BrickMesh>,
+) -> CutMeasurement {
+    let mut dirty = Vec::new();
+    // Anything left over from seeding would be charged to the cut.
+    volume.take_dirty(&mut dirty);
+
+    volume.begin_stroke();
+    let started = Instant::now();
+    let counts = volume.clip_convex(planes);
+    let clip = started.elapsed();
+    let recorder_bytes = volume.recorder_bytes();
+    let started = Instant::now();
+    let entry_bytes = volume.end_stroke().map_or(0, |edit| edit.bytes());
+    let encode = started.elapsed();
+
+    dirty.clear();
+    volume.take_dirty(&mut dirty);
+    // `mesh_bricks` and not a loop over `mesh_brick`, because that is what the
+    // application calls and the two are not the same measurement -- the plural
+    // form is where the parallelism is, and timing the serial one would report
+    // a remesh cost no user ever pays.
+    while meshes.len() < dirty.len() {
+        meshes.push(BrickMesh::default());
+    }
+    let started = Instant::now();
+    volume.mesh_bricks(&dirty, &mut meshes[..dirty.len()]);
+    let remesh = started.elapsed();
+    // How much of that remesh produced nothing at all. A cut removes material,
+    // so many of the bricks it dirties end up with no surface in them -- and
+    // `mesh_brick` has no early out, so each of those still costs a 34-cubed
+    // apron gather and a full surface-nets pass to emit zero triangles.
+    let empty = meshes[..dirty.len()].iter().filter(|mesh| mesh.is_empty()).count();
+
+    CutMeasurement {
+        counts,
+        dirtied: dirty.len(),
+        empty,
+        recorder_bytes,
+        entry_bytes,
+        clip,
+        encode,
+        remesh,
+    }
+}
+
+fn print_cut(label: &str, m: &CutMeasurement) {
+    println!(
+        "  {:<20} classified {:>6}  crossed {:>5}  removed {:>5}  changed {:>5}  dirtied {:>6} ({} empty)",
+        label,
+        m.counts.classified,
+        m.counts.crossed,
+        m.counts.removed,
+        m.counts.changed,
+        m.dirtied,
+        m.empty
+    );
+    println!(
+        "  {:<20} clip {:>7.3} ms   encode {:>7.3} ms   remesh {:>7.3} ms   peak {:>6.1} MB   entry {:>5.2} MB",
+        "",
+        millis(m.clip),
+        millis(m.encode),
+        millis(m.remesh),
+        m.recorder_bytes as f64 / (1024.0 * 1024.0),
+        m.entry_bytes as f64 / (1024.0 * 1024.0)
+    );
+}
+
+/// Seed the fixture the cut rows measure: one ball with spurs sticking out of
+/// it.
+///
+/// The spurs are the point. A ball alone measures a plane through a solid,
+/// which is the cheap and uninteresting case; what the cut tool is *for* is
+/// lopping something off that sticks out, and a fixture without protrusions
+/// cannot measure thirty of those in a row. They are seeded at descending
+/// latitudes around the equator so no two share a brick column, which is what
+/// keeps thirty successive cuts thirty separate pieces of work rather than one
+/// piece done thirty times.
+fn ball_with_spurs(voxel_size: f32, centre: Vec3, radius: f32, spurs: usize) -> Volume {
+    let mut volume = Volume::new(voxel_size);
+    volume.seed_sphere(centre, radius);
+    for index in 0..spurs {
+        let angle = index as f32 / spurs as f32 * std::f32::consts::TAU;
+        let tilt = (index as f32 * 0.37).sin() * 0.7;
+        let direction =
+            Vec3::new(angle.cos() * tilt.cos(), tilt.sin(), angle.sin() * tilt.cos()).normalize();
+        // Straddling the surface, so each spur is a lump attached to the body
+        // rather than a free floating ball the cut would find nothing holding.
+        //
+        // **Unioned rather than seeded, and that is not a detail.**
+        // `seed_sphere` clears every brick its box touches before writing, so
+        // seeding a small sphere onto a large one carves a MOAT around it: the
+        // fixture would be a ball with thirty pits in it, and a bench measuring
+        // "thirty cuts trimming spurs" would be measuring thirty cuts through
+        // craters. A union is `min` of the two fields.
+        let spur = centre + direction * radius;
+        let spur_radius = radius * 0.12;
+        let band = NARROW_BAND * voxel_size;
+        let (lo, hi) = volume
+            .voxel_bounds(spur - (spur_radius + band * 2.0), spur + (spur_radius + band * 2.0));
+        volume.edit_voxels(lo, hi, |_, position, value| {
+            let outside = (position.distance(spur) - spur_radius) / voxel_size;
+            value.min(outside).clamp(INSIDE, OUTSIDE)
+        });
+    }
+    volume.mark_everything_dirty();
+    volume
+}
+
+/// The cut baseline: what a plane costs today, before the shaped cut exists.
+fn measure_the_cut(voxel_size: f32) {
+    const SPURS: usize = 30;
+
+    let centre = Vec3::splat(EFFECTIVE_RESOLUTION * voxel_size * 0.5);
+    let radius = EFFECTIVE_RESOLUTION * voxel_size * 0.47;
+    let mut meshes: Vec<BrickMesh> = Vec::new();
+
+    println!();
+    println!("cut baseline (report only -- see `measure_the_cut`)");
+    // Seeded once for the census, and again per row: `Volume` has no `Clone`
+    // on purpose, and re-seeding is deterministic and outside every timed
+    // region, so it is the honest way to give each row the same fixture.
+    let stats = ball_with_spurs(voxel_size, centre, radius, SPURS).stats();
+    println!(
+        "  fixture: {} bricks ({} dense, {} uniform), {:.1} MB resident, {SPURS} spurs",
+        stats.dense_bricks + stats.uniform_bricks,
+        stats.dense_bricks,
+        stats.uniform_bricks,
+        stats.resident_bytes as f64 / (1024.0 * 1024.0)
+    );
+    println!(
+        "  budgets for scale: edit {:.0} ms, remesh {:.0} ms",
+        millis(EDIT_BUDGET),
+        millis(REMESH_BUDGET)
+    );
+
+    let fixture = || ball_with_spurs(voxel_size, centre, radius, SPURS);
+    let far = centre + Vec3::X * (radius * 10.0);
+    let spur = centre + Vec3::X * radius;
+
+    for (label, cutter) in [
+        // Through the middle: the expensive shape. Half the bricks are dropped
+        // whole and a sheet of them straight through the model is promoted
+        // dense.
+        ("plane, midline", vec![ClipPlane::new(centre, Vec3::X).unwrap()]),
+        // A plane that misses. This is the row to watch when the cut takes a
+        // shape: it is pure classification, over a body it never touches.
+        ("plane, misses", vec![ClipPlane::new(far, Vec3::X).unwrap()]),
+        // The shape, at the limit the plan sets: a sixteen-sided prism with two
+        // depth caps. Three rows, because they answer different questions --
+        // what the classification costs when it must reject, what it costs when
+        // it must resolve, and what the depth caps are worth.
+        ("16-plane, misses", prism(far + Vec3::X * radius, Vec3::X, radius * 0.2, radius * 0.4)),
+        ("16-plane, over a spur", prism(spur, Vec3::X, radius * 0.2, radius * 0.4)),
+        // Same silhouette as the row above with no depth cap, which isolates
+        // what the caps are worth.
+        ("16-plane, through", prism_sides(spur, Vec3::X, radius * 0.2)),
+    ] {
+        print_cut(label, &fastest_cut(fixture, &cutter, &mut meshes));
+    }
+
+    // Thirty in a row, which is the scenario the plan singles out: a cut only
+    // ever shrinks the meshes it touches, so every one of these orphans mesh
+    // pool blocks that nothing in an editing session ever reclaims. The core
+    // cannot see the pool -- the counts below are the input to that failure,
+    // and `brokkr-gpu`'s bench measures the failure itself.
+    let mut trimmed = ball_with_spurs(voxel_size, centre, radius, SPURS);
+    let mut worst = Duration::ZERO;
+    let mut total_dirty = 0usize;
+    let mut peak_recorder = 0usize;
+    let mut first = None;
+    let mut last = None;
+    for index in 0..SPURS {
+        let angle = index as f32 / SPURS as f32 * std::f32::consts::TAU;
+        let tilt = (index as f32 * 0.37).sin() * 0.7;
+        let direction =
+            Vec3::new(angle.cos() * tilt.cos(), tilt.sin(), angle.sin() * tilt.cos()).normalize();
+        // Just inside the spur's root, facing out: today's plane cuts the whole
+        // model, so this also takes whatever else is beyond it -- which is
+        // exactly the unbounded behaviour the shaped cut is being built to fix,
+        // and it is worth the baseline carrying the cost of it.
+        let plane = ClipPlane::new(centre + direction * (radius * 0.98), direction).unwrap();
+        let m = cut_once(&mut trimmed, plane, &mut meshes);
+        worst = worst.max(m.clip);
+        total_dirty += m.dirtied;
+        peak_recorder = peak_recorder.max(m.recorder_bytes);
+        if index == 0 {
+            first = Some(m);
+        } else if index == SPURS - 1 {
+            last = Some(m);
+        }
+    }
+    if let Some(m) = &first {
+        print_cut("30 cuts, first", m);
+    }
+    if let Some(m) = &last {
+        print_cut("30 cuts, last", m);
+    }
+    let after = trimmed.stats();
+    println!(
+        "  {:<20} worst clip {:.3} ms   {} brick-dirties total   recorder peak {:.1} MB",
+        "30 cuts, summed",
+        millis(worst),
+        total_dirty,
+        peak_recorder as f64 / (1024.0 * 1024.0)
+    );
+    println!(
+        "  {:<20} {} dense, {} uniform, {:.1} MB resident after",
+        "",
+        after.dense_bricks,
+        after.uniform_bricks,
+        after.resident_bytes as f64 / (1024.0 * 1024.0)
+    );
+
+    // What being a document costs on top of being a volume: the per body box
+    // gate that rejects a body the plane cannot reach, and assembling one undo
+    // entry across all of them.
+    let mut doc = Document::from_volume(ball_with_spurs(voxel_size, centre, radius, SPURS));
+    let visible = vec![true; doc.nodes().len()];
+    let started = Instant::now();
+    let outcome = doc.clip(ClipPlane::new(centre, Vec3::X).unwrap(), &visible);
+    println!(
+        "  {:<20} {:.3} ms for {} bricks across {} of {} bodies crossed",
+        "Document::clip",
+        millis(started.elapsed()),
+        outcome.bricks,
+        outcome.bodies_cut.len(),
+        outcome.bodies_crossed
+    );
+    println!();
 }
 
 /// Grow a brick list by one in every direction, the way the renderer must so

--- a/crates/brokkr-core/src/brush.rs
+++ b/crates/brokkr-core/src/brush.rs
@@ -1245,10 +1245,20 @@ impl Brush {
                 // blending brushes below keep a legal lerp factor -- which is what
                 // makes smooth, flatten and clay converge on their target instead
                 // of extrapolating away from it.
-                let weight = shaped * pattern.weight(position) * free;
-                if weight <= 0.0 {
+                //
+                // **Kept apart from the mask, because two brushes cannot fold it
+                // in.** See the `Flatten` and `Clay` arms: their target is a
+                // plane distance that can be far outside the narrow band, and
+                // scaling the lerp factor by the mask does not scale the RESULT
+                // when both the masked and the unmasked blend overshoot the band
+                // and clamp to the same edge. Everything else here is either a
+                // displacement, where a factor on the weight is a factor on the
+                // move, or blends toward a target already in band.
+                let patterned = shaped * pattern.weight(position);
+                if patterned <= 0.0 || free <= 0.0 {
                     return value;
                 }
+                let weight = patterned * free;
 
                 match kind {
                     BrushKind::Inflate => value + field_sign * weight * displacement,
@@ -1299,9 +1309,35 @@ impl Brush {
                         region.sample((position + pull) / voxel_size)
                     }
 
+                    // **The mask is applied to the RESULT, not to the lerp
+                    // factor, and this is the one brush family where that
+                    // distinction has teeth.**
+                    //
+                    // `plane` is the signed distance to the stroke's reference
+                    // plane in voxels and is unbounded -- a voxel at the rim of a
+                    // wide brush on a curved surface is tens of voxels from it.
+                    // Folding the mask into `weight` then means the masked blend
+                    // overshoots the narrow band just as the unmasked one does,
+                    // and `edit_voxels_where`'s clamp puts both on the same edge:
+                    // a half protected voxel was carved exactly as hard as an
+                    // unprotected one. Measured before this changed: 505 of
+                    // 15,536 moved Flatten voxels and 2,783 of 28,444 Clay voxels
+                    // took the full unmasked effect through half protection.
+                    //
+                    // So the unmasked result is computed first and clamped to
+                    // what the field can actually hold, and the mask then chooses
+                    // a point between the voxel's own value and that. Both ends
+                    // are in band, so the result is too.
+                    //
+                    // **Unmasked is bit-identical**, which is what made this
+                    // safe to change in a shipped brush: an unmasked edit resolves
+                    // `free` to exactly 1.0 through `Freedom::OPEN`, so `weight`
+                    // was already `patterned`, and the `free >= 1.0` arm returns
+                    // the clamped value the caller's own clamp produced anyway.
                     BrushKind::Flatten => {
                         let plane = (position - plane_point).dot(stroke_normal) / voxel_size;
-                        value + (plane - value) * weight
+                        let target = (value + (plane - value) * patterned).clamp(INSIDE, OUTSIDE);
+                        admit(value, target, free)
                     }
 
                     BrushKind::Move => {
@@ -1310,21 +1346,55 @@ impl Brush {
                         value
                     }
 
+                    // The same shape as `Flatten` above, and the same reason.
                     BrushKind::Clay => {
                         let plane = (position - plane_point).dot(stroke_normal) / voxel_size;
-                        let blended = value + (plane - value) * weight;
+                        let blended = value + (plane - value) * patterned;
                         // Keep only the half of the operation that moves material
                         // the way the user asked for. Without this, clay carves
                         // away any bump standing above its plane.
-                        match direction {
+                        //
+                        // Applied to the UNMASKED blend, before the mask admits
+                        // a fraction of it. The other order would let the mask
+                        // pull a voxel back across `value` and turn the direction
+                        // guard into the thing it was guarding against.
+                        let kept = match direction {
                             BrushDirection::Add => blended.min(value),
                             BrushDirection::Subtract => blended.max(value),
-                        }
+                        };
+                        admit(value, kept.clamp(INSIDE, OUTSIDE), free)
                     }
                 }
             },
         );
     }
+}
+
+/// How much of a finished edit the mask lets through.
+///
+/// `target` is what the brush would have written with no mask at all, already
+/// clamped to what the field can hold; the result is that far from `value` in
+/// proportion to `free`. Both ends are in band, so the answer is too.
+///
+/// **This exists because a factor on the lerp is not a factor on the result.**
+/// Most of the brushes fold the mask into their weight and are right to: a
+/// displacement scaled by `free` moves `free` as far, and a blend toward a
+/// target that is already in band cannot overshoot. Flatten and Clay blend
+/// toward a plane distance that is unbounded, so scaling their weight scales an
+/// overshoot that the clamp then flattens back to the same band edge either way
+/// -- which is a mask that does nothing.
+///
+/// # Why `free >= 1.0` takes `target` rather than the lerp
+///
+/// Bit identity, and the same reason `clip::cut_voxel` has the same branch:
+/// `value + (target - value) * 1.0` is not `target` in binary floating point
+/// whenever `target - value` rounds. An unmasked edit resolves `free` to
+/// exactly 1.0 through `Freedom::OPEN`, so without this arm every unmasked
+/// Flatten and Clay stroke in every model would shift in the last bit on the
+/// build that introduced it.
+#[inline]
+fn admit(value: f32, target: f32, free: f32) -> f32 {
+    if free >= 1.0 { target } else { value + (target - value) * free }
 }
 
 /// Whether clay's and flatten's blend toward a plane provably clamps straight
@@ -3368,6 +3438,126 @@ mod skipping_tests {
                 from_plain > 1.0e-3,
                 "{kind} {direction:?} ignored a half mask: it did exactly what it does unmasked"
             );
+        }
+    }
+
+    /// **`admit` must hand back its target untouched at full freedom**, which
+    /// is the whole reason an unmasked Flatten or Clay stroke is unchanged by
+    /// the mask moving out of their weight.
+    ///
+    /// `value + (target - value) * 1.0` is NOT `target` in binary floating
+    /// point whenever `target - value` rounds -- the same fact `clip::cut_voxel`
+    /// documents and branches on. An unmasked edit resolves `free` to exactly
+    /// 1.0 through `Freedom::OPEN`, so losing this arm would shift the last bit
+    /// of every voxel of every unmasked Flatten and Clay stroke in every model,
+    /// and no geometric assertion in this file would notice.
+    ///
+    /// Verified once against the real thing rather than only here: stamping
+    /// both brushes unmasked, before and after this change, produced identical
+    /// checksums over the whole affected box for both directions.
+    #[test]
+    fn full_freedom_admits_the_target_to_the_bit() {
+        let mut rng = crate::testing::Noise::seeded(0x5ee_d10);
+        for _ in 0..200_000 {
+            // Values across the band and a little past it, since `target`
+            // arrives clamped but `value` is whatever the field held.
+            let value = INSIDE + (rng.below(1_000_001) as f32 / 1_000_000.0) * (OUTSIDE - INSIDE);
+            let target = INSIDE + (rng.below(1_000_001) as f32 / 1_000_000.0) * (OUTSIDE - INSIDE);
+            assert_eq!(
+                admit(value, target, 1.0).to_bits(),
+                target.to_bits(),
+                "admit({value}, {target}, 1.0) did not return the target unchanged"
+            );
+        }
+        // And it really does interpolate below that, or the branch above would
+        // be hiding a mask that does nothing.
+        assert!((admit(-3.0, 3.0, 0.5) - 0.0).abs() < 1.0e-6);
+        assert_eq!(admit(-3.0, 3.0, 0.0), -3.0);
+    }
+
+    /// **A half-protected voxel must get half the stroke, and for the two
+    /// brushes that blend toward a PLANE it did not.**
+    ///
+    /// The mask enters as a factor on the brush weight, and for a lerp toward a
+    /// target that is the right place for it -- as long as the target is in
+    /// range. Flatten and Clay blend toward the signed distance to the stroke's
+    /// reference plane, in voxels, which is unbounded: a voxel near the edge of
+    /// a wide brush on a curved surface can be tens of voxels from that plane.
+    /// The blend then overshoots the narrow band by so much that halving it
+    /// still overshoots, and the clamp in `edit_voxels_where` puts both the
+    /// masked and the unmasked result on the same band edge. The mask does
+    /// nothing at all for those voxels.
+    ///
+    /// Measured before the fix: 505 of 15,536 moved Flatten voxels and 2,783 of
+    /// 28,444 Clay voxels took the FULL unmasked effect through half
+    /// protection.
+    ///
+    /// **`a_fully_masked_block_feels_no_brush_at_all` cannot see this.** Its
+    /// half-protected arm asserts only that the result differs from both the
+    /// untouched fixture and the unmasked stamp -- which is true of a result
+    /// that is 99% of the way to the unmasked one. This asserts the fraction.
+    ///
+    /// Smooth is the control: it blends toward a local average, which is in
+    /// band by construction, so it was always right and must stay right.
+    #[test]
+    fn a_half_masked_stroke_moves_a_voxel_half_way() {
+        // A byte of 127 out of 255 leaves `1.0 - 127/255` of the stroke.
+        const HELD: u8 = PROTECTED / 2;
+        let free = 1.0 - HELD as f32 / 255.0;
+
+        let at = ON_THE_BALL;
+        // Wide enough that the reference plane is far from the voxels at the
+        // rim, which is the only place the overshoot happens.
+        let radius = 24.0;
+        let reach = Vec3::splat(radius + 2.0);
+        let (lo, hi) = ball().voxel_bounds(at - reach, at + reach);
+
+        for kind in [BrushKind::Flatten, BrushKind::Clay, BrushKind::Smooth] {
+            for direction in [BrushDirection::Add, BrushDirection::Subtract] {
+                let brush = Brush { kind, radius, strength: 1.0, ..Brush::default() };
+                let untouched = ball();
+                let normal = untouched.gradient_world(at);
+                let stamp = stamp_at(at, normal, direction);
+
+                let mut unmasked = ball();
+                brush.apply(&mut unmasked, &stamp, &mut BrushScratch::new());
+
+                let mut masked = ball();
+                paint_bricks(&mut masked, lo, hi, |_| HELD);
+                brush.apply(&mut masked, &stamp, &mut BrushScratch::new());
+
+                let mut moved = 0usize;
+                let mut worst = 0.0f32;
+                let mut worst_at = None;
+                for z in lo.z..=hi.z {
+                    for y in lo.y..=hi.y {
+                        for x in lo.x..=hi.x {
+                            let cell = IVec3::new(x, y, z);
+                            let was = untouched.sample_voxel(cell);
+                            let full = unmasked.sample_voxel(cell);
+                            // Only voxels the stroke actually moved can say
+                            // anything about what a fraction of it does.
+                            if (full - was).abs() < 0.05 {
+                                continue;
+                            }
+                            moved += 1;
+                            let got = masked.sample_voxel(cell);
+                            let want = was + (full - was) * free;
+                            if (got - want).abs() > worst {
+                                worst = (got - want).abs();
+                                worst_at = Some((cell, was, full, got, want));
+                            }
+                        }
+                    }
+                }
+
+                assert!(moved > 100, "{kind} {direction:?} moved only {moved} voxels unmasked");
+                assert!(
+                    worst < 1.0e-3,
+                    "{kind} {direction:?}: a half protected voxel is {worst} away from half \
+                     the stroke, worst at {worst_at:?}"
+                );
+            }
         }
     }
 

--- a/crates/brokkr-core/src/clip.rs
+++ b/crates/brokkr-core/src/clip.rs
@@ -47,6 +47,88 @@
 //! An unmasked body never reaches any of this: the mask is resolved once for the
 //! whole volume, and a body that protects nothing anywhere takes the same
 //! branches, and writes the same bits, as it did before masks existed.
+//!
+//! # What a cut actually costs
+//!
+//! Measured by `benches/budget.rs`'s `measure_the_cut`, on a 256³ effective
+//! volume: a ball of 423 bricks with thirty spurs unioned onto its equator,
+//! 41.9 MB resident. **The machine was not idle**, so the timings are upper
+//! bounds -- each row is the fastest of five runs, since contention only ever
+//! adds time -- and the counts are exact.
+//!
+//! A cut is three costs, and the interesting thing is which one is biggest.
+//! For a plane through the middle of the fixture, before any of the work below:
+//!
+//! | | ms | share |
+//! |---|---|---|
+//! | remesh | 5.17 | 44% |
+//! | undo encode | 3.62 | 31% |
+//! | the cut proper | 2.89 | 25% |
+//!
+//! **The classification was never any of it.** Seventeen planes against a body
+//! they miss costs 0.013 ms, because the `Keeps` early exit rejects almost
+//! every brick on the first plane it tries. Every obvious optimisation aims
+//! there, and there was nothing there to get.
+//!
+//! ## Where it went instead
+//!
+//! | | before | after |
+//! |---|---|---|
+//! | plane, midline: cut / encode / remesh | 2.89 / 3.62 / 5.17 | **2.02 / 1.05 / 2.41** |
+//! | 17-plane prism over a spur | 0.83 / 0.15 / 1.19 | **0.62 / 0.17 / 0.81** |
+//! | 17-plane prism straight through | 2.39 / 0.25 / 2.37 | **1.68 / 0.23 / 1.65** |
+//! | `Document::clip`, midline | 11.9 | **7.4** |
+//!
+//! **81% of the remesh was building nothing.** A plane through the middle
+//! dirties 669 bricks and 540 of them mesh to zero triangles -- a cut removes
+//! material, so most of what it dirties ends up empty on one side or solid on
+//! the other -- and each still paid a 34-cubed apron gather and a full
+//! surface-nets pass to say so. Two gates in `Volume::mesh_brick` now answer
+//! from the neighbourhood's stored form and from a linear scan of the gathered
+//! apron. See `Volume::neighbourhood_has_no_surface`.
+//!
+//! **The undo encode was serial and is embarrassingly parallel.** Every brick
+//! run-length encodes independently and `StrokeEdit::from_recording` did them
+//! one at a time, next door to a `par_iter` doing the identical shape of job.
+//!
+//! **Half the recorded bricks were copied for nothing.** A dropped brick IS the
+//! prior undo needs, and `record_for_undo` + a bare remove cloned 128 KB and
+//! then discarded the original. See `Volume::remove_brick_recording`.
+//!
+//! **Thirty cuts in a row do not degrade here**, and resident bytes go *down*
+//! (41.9 → 39.9 MB). Whatever the repeated-cut risk is, it is not in this
+//! crate -- it is the mesh pool's bump allocator, which lives in `brokkr-gpu`
+//! and is measured there: thirty trims take it from 1.11x to 1.45x watermark
+//! over live.
+//!
+//! # What a SHAPED cut costs, and where THAT cost was
+//!
+//! A sixteen-sided prism -- the ceiling hull decimation allows -- plus a depth
+//! cap, so seventeen planes. Naively that is 20 million dot products for 37
+//! crossing bricks, and it measured **17.8 ms against a 4 ms edit budget**.
+//! Three changes, all bit-exact, took it to 1.68 ms:
+//!
+//! 1. **Per-brick plane pruning** (`classify_active`). A plane already
+//!    saturated across a brick cannot decide any voxel in it. Most bricks a
+//!    hull crosses are straddled by two or three faces, not seventeen.
+//! 2. **Specialised write loops** for one to four planes, which is nearly every
+//!    crossing brick. Each holds its planes as values the compiler keeps in
+//!    registers and makes ONE pass over the brick.
+//! 3. **Plane-major writing** above that (`write_cut_brick_plane_major`): one
+//!    plane per pass over a scratch buffer, so it is still in a register, where
+//!    holding them all at once is no longer possible.
+//!
+//! `several_planes_write_the_minimum_of_their_distances_exactly` compares the
+//! result bit for bit against the definition written out through `edit_voxels`,
+//! because "this optimisation cannot change the answer" is the kind of claim
+//! that is convincing and occasionally wrong.
+//!
+//! The specialisation was found by accident and is worth more than it looks:
+//! routing the SINGLE-plane path through a slice, which is the obvious way to
+//! write this, cost **9.6 ms against 2.2 ms** on the plane through the middle
+//! -- a four-fold regression in the cut that ships today, invisible to every
+//! test, caused by nothing but the plane no longer being a value the compiler
+//! could keep in a register.
 
 use glam::{IVec3, Vec3};
 
@@ -125,6 +207,13 @@ enum Cut {
 /// different things to the user: the first means "your mask stopped this", the
 /// second means "your line missed". [`Document::clip`] carries both up so
 /// the status line can tell them apart.
+///
+/// The three behind them -- `classified`, `crossed`, `removed` -- are not for
+/// the user at all. They are the classification's own census, and they exist
+/// because "the shaped cut is no more expensive than the plane" is a claim
+/// about which arm each brick took, which no count of what *changed* can
+/// settle: a plane and a loop that remove the same bricks can reach that
+/// result having promoted wildly different numbers of them to dense.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ClipCounts {
     /// Bricks whose contents changed.
@@ -138,6 +227,177 @@ pub struct ClipCounts {
     /// the plane only grazed is in neither, so "the mask blocked the cut" is
     /// never said about a cut that had nothing to remove anyway.
     pub spared_by_mask: usize,
+    /// Bricks that reached the plane arithmetic at all.
+    ///
+    /// Today that is every brick in the body, because the classification loop
+    /// walks the whole map. It is counted rather than inferred from
+    /// [`crate::VolumeStats`] because it is about to stop being every brick:
+    /// a bounded cutter can be rejected against a brick's integer coordinate
+    /// before any float touches it, and the only way to say whether such a
+    /// filter is working is to have measured what it filtered.
+    pub classified: usize,
+    /// Bricks the cut had to promote dense and resolve one voxel at a time.
+    ///
+    /// **The cost number.** Everything expensive about a cut is proportional to
+    /// this: the dense promotion, the 128 KB undo record, the per voxel loop,
+    /// and -- through [`crate::Volume::mark_dirty_voxel_range`] -- most of the
+    /// remesh that follows. A cut whose `crossed` grows without its `changed`
+    /// growing is doing work it throws away.
+    pub crossed: usize,
+    /// Bricks dropped whole, without ever being made dense.
+    ///
+    /// The cheap arm, and worth counting separately from
+    /// [`ClipCounts::changed`] (which includes it) because it is the one a
+    /// shape can win: a loop drawn *around* a lump takes bricks whole that a
+    /// plane covering the same silhouette would have had to cross.
+    pub removed: usize,
+}
+
+/// The removed region's signed distance at a point, in millimetres.
+///
+/// The region is the INTERSECTION of the half-spaces, so a point is inside it
+/// only where every plane says so and the distance to the whole is the smallest
+/// of the distances to the parts: `-max_i(-d_i)` is `min_i d_i`.
+///
+/// **The single-plane path is the plane, bit for bit.** The first distance is
+/// taken outright and only the rest go through `min`, so with one plane no
+/// comparison happens at all and the value is character-for-character what
+/// `plane.distance(at)` returned before this function existed. That is not an
+/// optimisation; it is what makes today's cut provably unchanged, and it is why
+/// this is not written as a fold from `f32::INFINITY`.
+///
+/// # Where it over-estimates
+///
+/// Exactly right inside the region and outside a single face, and too large
+/// outside a convex EDGE, where the true distance is to the edge itself and
+/// this reports the distance to the nearer face's plane. At a wedge of interior
+/// angle `t`, at radius `r`, it over-estimates by `r * (1 - sin(t/2))` -- 0.88
+/// of a voxel at a right angle and 2.48 at 20 degrees, taken at the band edge
+/// where `r` is three voxels.
+///
+/// The direction is the good one. Over-estimating the removed region's distance
+/// makes `max` take slightly LESS at the corner, so a cut corner comes out
+/// rounded rather than sharpened, and a knife edge is the printability failure
+/// no watertightness check can see. It is still worth bounding, which is why
+/// the caller drops the sharpest hull vertices first rather than the smallest.
+///
+/// `pub(crate)` for [`crate::generate`]'s cutter mask, which is this same
+/// region written as protection instead of removal -- and sharing it is the
+/// point, for the reason [`ClipPlane::range_over_box`] gives about the
+/// classification: two copies of the arithmetic would let the mask and the cut
+/// disagree about where the region is.
+#[inline]
+pub(crate) fn cut_distance(planes: &[ClipPlane], at: Vec3) -> f32 {
+    let Some((first, rest)) = planes.split_first() else {
+        // No planes is no region. Returning the identity for `min` here would
+        // be `INFINITY`, which `max` would write over every voxel in the model.
+        // Callers refuse an empty set before reaching this; the value below is
+        // the harmless answer if one ever does not.
+        return f32::NEG_INFINITY;
+    };
+    let mut smallest = first.distance(at);
+    for plane in rest {
+        let (held, now) = (smallest, plane.distance(at));
+        debug_assert!(now.is_finite());
+        smallest = if held < now { held } else { now };
+    }
+    smallest
+}
+
+/// What a convex cutter does to one brick, and which of its planes still
+/// matter there.
+///
+/// `half` is the caller's, and must be: it is one voxel SHORT of the nominal
+/// brick size, because a brick spans `BRICK_DIM` sample positions and the
+/// distance from its first to its last is one voxel less than its extent.
+/// Recomputing it here from `BRICK_DIM * voxel_size` would widen every brick by
+/// a voxel and quietly move which ones classify as crossing.
+///
+/// Both verdicts are sound rather than conservative, and each for its own
+/// reason:
+///
+/// * **Keeps** on the first plane whose farthest corner is a full band behind
+///   it. `min_i d_i <= d_j` everywhere, so if one plane puts the whole brick
+///   behind itself the minimum is behind it too, whatever the other planes say.
+///   This is the early exit, and it is the common case: most bricks in a body
+///   are nowhere near the cutter, and most of those are rejected by the first
+///   plane tested.
+/// * **Removes** only when EVERY plane puts the whole brick a full band past
+///   it, which is exactly saturation inside the polyhedron.
+///
+/// The two are tested in the opposite order from the single-plane code this
+/// replaces, which checked `Removes` first. For one plane they are mutually
+/// exclusive -- `nearest <= farthest` and the band is positive -- so the
+/// reorder cannot change a single-plane verdict. For several it must be this
+/// way round: `Keeps` is decidable from one plane and `Removes` is not.
+///
+/// # Why it also narrows the plane set, and why that is exact
+///
+/// **This is where the shaped cut's real cost lives.** A plane whose nearest
+/// corner is already a full band past it contributes at least `OUTSIDE` at
+/// every point of the brick, in voxels. [`cut_voxel`] saturates there:
+/// `max(old, OUTSIDE)` clamped is `OUTSIDE` whatever `old` was, and whatever
+/// the mask lets through, since the blend runs toward that same target. So for
+/// any voxel in this brick either some other plane is smaller -- in which case
+/// the minimum is that one and this plane never mattered -- or none is, in
+/// which case the minimum is still at least `OUTSIDE` and the voxel saturates
+/// identically. Dropping it cannot change one written bit.
+///
+/// The measurement is what made this worth doing rather than the parallel
+/// classification that was originally planned. Classifying a sixteen-plane hull
+/// against a body it misses costs 0.008 ms where one plane costs 0.002 -- the
+/// classification was never the problem. The per voxel minimum was: 33 crossing
+/// bricks at eighteen planes is 19.5 million dot products, and it measured
+/// 17.8 ms against a 4 ms edit budget. Most bricks a hull crosses are straddled
+/// by two or three of its faces, not eighteen.
+///
+/// `active` is cleared and refilled rather than returned, so a cut over
+/// thousands of bricks allocates once. It is meaningful only for
+/// [`Cut::Crosses`]; the other two verdicts leave it in whatever state the scan
+/// reached, and nothing reads it.
+///
+/// **This is where the shaped cut's real cost lives, and dropping a plane here
+/// is exact rather than approximate.** A plane whose nearest corner is already
+/// a full band past it contributes at least `OUTSIDE` at every point of the
+/// brick, in voxels. `cut_voxel` saturates there: `max(old, OUTSIDE)` clamped is
+/// `OUTSIDE` whatever `old` was, and whatever the mask lets through, since the
+/// blend runs toward that same target. So for any voxel in this brick either
+/// some other plane is smaller -- in which case the minimum is that one and this
+/// plane never mattered -- or none is, in which case the minimum is still at
+/// least `OUTSIDE` and the voxel saturates identically. Removing it from the
+/// slice cannot change one written bit.
+///
+/// The measurement is what made this worth doing rather than the parallelism
+/// the plan proposed. Classification of a sixteen-plane hull over a body it
+/// misses costs 0.008 ms against one plane's 0.002 -- it was never the problem.
+/// The per voxel minimum was: 33 crossing bricks at eighteen planes is 19.5
+/// million dot products, and it measured 17.8 ms against a 4 ms edit budget.
+/// Most bricks a hull crosses are straddled by two or three of its faces, not
+/// eighteen.
+///
+/// `active` is cleared and refilled rather than returned, so a cut over
+/// thousands of bricks allocates once. It is left in an unspecified state
+/// unless the verdict is [`Cut::Crosses`]; nothing else reads it.
+fn classify_active(
+    planes: &[ClipPlane],
+    centre: Vec3,
+    half: Vec3,
+    band_mm: f32,
+    active: &mut Vec<ClipPlane>,
+) -> Cut {
+    active.clear();
+    for plane in planes {
+        let (nearest, farthest) = plane.range_over_box(centre, half);
+        if farthest <= -band_mm {
+            return Cut::Keeps;
+        }
+        if nearest < band_mm {
+            active.push(*plane);
+        }
+    }
+    // Every plane saturated positive across the brick, which is exactly the
+    // condition `classify` calls `Removes`.
+    if active.is_empty() { Cut::Removes } else { Cut::Crosses }
 }
 
 /// Whether the cut would move any voxel of a brick it is not allowed to touch.
@@ -155,20 +415,131 @@ fn cut_would_change_a_voxel(
     brick: &Brick,
     origin: IVec3,
     voxel_size: f32,
-    plane: ClipPlane,
+    planes: &[ClipPlane],
 ) -> bool {
     for z in 0..BRICK_DIM {
         for y in 0..BRICK_DIM {
             for x in 0..BRICK_DIM {
                 let at = (origin + IVec3::new(x as i32, y as i32, z as i32)).as_vec3() * voxel_size;
                 let old = brick.get(x, y, z);
-                if cut_voxel(old, plane.distance(at) / voxel_size, 1.0) != old {
+                if cut_voxel(old, cut_distance(planes, at) / voxel_size, 1.0) != old {
                     return true;
                 }
             }
         }
     }
     false
+}
+
+/// Write one dense brick's worth of the cut.
+///
+/// **Generic over how the cut distance is found, and that is the whole point.**
+/// It is instantiated twice -- once with a closure holding a single `Copy`
+/// [`ClipPlane`], once with one that takes the minimum over a slice -- so the
+/// single-plane instance compiles to a loop with the plane's point and normal
+/// live in registers across all 32,768 voxels, which is exactly the code that
+/// shipped before the cut took a shape.
+///
+/// Writing it once and calling it twice is not tidiness. Fusing the two into
+/// one loop that reads the plane out of a slice measured **9.6 ms against
+/// 2.2 ms** on a plane through the middle of the bench fixture: the compiler
+/// cannot keep a slice element in a register across a write to `data`, so it
+/// reloaded the plane for every voxel. Duplicating the loop body instead would
+/// have worked equally well and left two copies of the mask blend, the clamp
+/// and the millimetre-to-voxel conversion to keep in step.
+///
+/// `distance_mm` returns MILLIMETRES, as [`ClipPlane::distance`] does. The
+/// conversion to voxels happens here, once, because the field stores voxels and
+/// mixing the two moves the cut by a factor of the voxel size.
+#[inline]
+fn write_cut_brick(
+    data: &mut [f32; BRICK_DIM * BRICK_DIM * BRICK_DIM],
+    origin: IVec3,
+    voxel_size: f32,
+    freedom: &Freedom,
+    uniform: Option<f32>,
+    distance_mm: impl Fn(Vec3) -> f32,
+) {
+    for z in 0..BRICK_DIM {
+        for y in 0..BRICK_DIM {
+            for x in 0..BRICK_DIM {
+                let at = (origin + IVec3::new(x as i32, y as i32, z as i32)).as_vec3() * voxel_size;
+                let slot = brick_index(x, y, z);
+                let cut = distance_mm(at) / voxel_size;
+                let free = match uniform {
+                    Some(free) => free,
+                    None => freedom.at(slot),
+                };
+                data[slot] = cut_voxel(data[slot], cut, free);
+            }
+        }
+    }
+}
+
+/// Write one dense brick's worth of the cut, taking the minimum PLANE by plane
+/// rather than voxel by voxel.
+///
+/// Same result as calling [`write_cut_brick`] with a closure that minimises over
+/// the slice, and a different shape of loop. Each pass holds exactly one plane,
+/// so its point and normal stay in registers across all 32,768 voxels and the
+/// arithmetic is a straight-line dot product over contiguous memory; the
+/// voxel-major form has to read a different plane out of a slice on every
+/// iteration and cannot keep any of them.
+///
+/// It costs a 128 KB scratch buffer, reused across every brick of the cut, and
+/// it reads and writes that buffer once per plane. That trade only pays when
+/// there are several planes, which is why the single-plane path does not come
+/// through here -- there it would be two passes over 128 KB where one fused
+/// loop does.
+///
+/// The minimum is taken in MILLIMETRES and converted once at the end, so this
+/// and the voxel-major form round identically: neither divides before the min.
+fn write_cut_brick_plane_major(
+    data: &mut [f32; BRICK_DIM * BRICK_DIM * BRICK_DIM],
+    scratch: &mut [f32; BRICK_DIM * BRICK_DIM * BRICK_DIM],
+    origin: IVec3,
+    voxel_size: f32,
+    freedom: &Freedom,
+    uniform: Option<f32>,
+    planes: &[ClipPlane],
+) {
+    let Some((first, rest)) = planes.split_first() else {
+        return;
+    };
+
+    // The first plane fills rather than minimises, which is what makes this
+    // agree with `cut_distance` to the bit: that also takes the first distance
+    // outright instead of folding from an infinity.
+    for z in 0..BRICK_DIM {
+        for y in 0..BRICK_DIM {
+            for x in 0..BRICK_DIM {
+                let at = (origin + IVec3::new(x as i32, y as i32, z as i32)).as_vec3() * voxel_size;
+                scratch[brick_index(x, y, z)] = first.distance(at);
+            }
+        }
+    }
+    for plane in rest {
+        for z in 0..BRICK_DIM {
+            for y in 0..BRICK_DIM {
+                for x in 0..BRICK_DIM {
+                    let at =
+                        (origin + IVec3::new(x as i32, y as i32, z as i32)).as_vec3() * voxel_size;
+                    let slot = brick_index(x, y, z);
+                    let (held, now) = (scratch[slot], plane.distance(at));
+                    debug_assert!(now.is_finite());
+                    scratch[slot] = if held < now { held } else { now };
+                }
+            }
+        }
+    }
+
+    for slot in 0..data.len() {
+        let free = match uniform {
+            Some(free) => free,
+            None => freedom.at(slot),
+        };
+        data[slot] = cut_voxel(data[slot], scratch[slot] / voxel_size, free);
+    }
 }
 
 /// One voxel's new distance: the cut, admitted by as much of itself as the mask
@@ -180,11 +551,36 @@ fn cut_would_change_a_voxel(
 /// given it. A cut can therefore only ever remove less through a mask, never
 /// more and never something else.
 ///
-/// **The clamp is not optional.** `cut` is `plane.distance(at) / voxel_size`
-/// and is unbounded -- a plane a metre away from a quarter millimetre voxel
-/// gives four thousand -- so without it a `free` of 1 writes a distance far
-/// outside the narrow band into the field, which the project loader then
-/// refuses on the next open.
+/// **The clamp is not optional, and it has to happen BEFORE the blend.** `cut`
+/// is `cut_distance(planes, at) / voxel_size` and is unbounded -- a plane a
+/// metre away from a quarter millimetre voxel gives four thousand -- so without
+/// it a `free` of 1 writes a distance far outside the narrow band into the
+/// field, which the project loader then refuses on the next open.
+///
+/// # Why the order matters, and what it cost
+///
+/// Clamping afterwards instead is correct for an unmasked cut and **silently
+/// wrong for every partially masked one**, which is how it shipped. The blend
+/// runs toward `target`, so with the clamp at the end the target is that raw
+/// four thousand: a voxel at `-3` under half protection, with the cut twenty
+/// voxels past it, came out as `-3 + (20 - -3) * 0.5 = 8.5`, clamped to
+/// `OUTSIDE`. It should have come out at `0.0` -- half way from `-3` to the
+/// most a cut can ever write.
+///
+/// So a half-protected voxel was removed as completely as an unprotected one,
+/// and the mask's feathered edge -- the thing `mask.rs` requires every writer
+/// to produce, so that protection is a gradient and not a step -- did nothing
+/// at all except exactly where `free` was zero. The further the cutter was from
+/// a voxel, the more completely the protection was overwhelmed, which is the
+/// opposite of what anyone would predict and is why it survived: the case that
+/// looks correct while you test it, a cut right at the mask's edge, is the one
+/// case where the two orders nearly agree.
+///
+/// Clamping first makes the blend a convex combination of two values that are
+/// both already in the band, so the result is in the band by construction. The
+/// trailing clamp is kept anyway: it costs nothing, it makes the `free >= 1.0`
+/// arm's output obviously in range, and a `free` outside `0..=1` would
+/// otherwise extrapolate.
 ///
 /// # Why `free == 1` takes the plain `max` instead of the blend
 ///
@@ -196,7 +592,7 @@ fn cut_would_change_a_voxel(
 /// masking, in every model, on the first build that shipped masking.
 #[inline]
 fn cut_voxel(old: f32, cut: f32, free: f32) -> f32 {
-    let target = old.max(cut);
+    let target = old.max(cut).clamp(INSIDE, OUTSIDE);
     let new = if free >= 1.0 { target } else { old + (target - old) * free };
     new.clamp(INSIDE, OUTSIDE)
 }
@@ -213,14 +609,41 @@ impl Volume {
     /// change are recorded, so cutting a corner off a large model costs an undo
     /// entry proportional to the corner rather than to the model.
     pub fn clip(&mut self, plane: ClipPlane) -> ClipCounts {
-        self.with_mask_lifted(|volume, mask| volume.clip_masked(plane, mask))
+        self.clip_convex(std::slice::from_ref(&plane))
+    }
+
+    /// Cut away the convex region every plane in `planes` agrees on.
+    ///
+    /// The removed region is the INTERSECTION of the half-spaces -- material
+    /// goes only where every plane says it should. One plane is therefore
+    /// [`Volume::clip`]'s infinite half-space, which is why that is a wrapper
+    /// over this rather than a second implementation: `min` over one element is
+    /// the element, so the arithmetic is not merely equivalent, it is the same
+    /// arithmetic.
+    ///
+    /// **An empty slice removes nothing**, and that is a decision rather than a
+    /// fallback. The intersection of no half-spaces is all of space, so the
+    /// mathematically faithful answer is to delete the entire model -- which is
+    /// never what a caller with an empty list meant. It is what one would get
+    /// from a gesture whose plane construction failed, and there is no gesture
+    /// for which erasing the document is the right recovery.
+    ///
+    /// Bracket a call in [`Volume::begin_stroke`] and [`Volume::end_stroke`] to
+    /// make it undoable, exactly as a brush stroke is. Only bricks that really
+    /// change are recorded, so cutting a corner off a large model costs an undo
+    /// entry proportional to the corner rather than to the model.
+    pub fn clip_convex(&mut self, planes: &[ClipPlane]) -> ClipCounts {
+        if planes.is_empty() {
+            return ClipCounts::default();
+        }
+        self.with_mask_lifted(|volume, mask| volume.clip_convex_masked(planes, mask))
     }
 
     /// The cut proper, with the mask already lifted off the volume.
     ///
     /// Split out only so that [`Volume::with_mask_lifted`] can hold the mask
     /// across it; everything the cut does is here.
-    fn clip_masked(&mut self, plane: ClipPlane, mask: Option<&MaskField>) -> ClipCounts {
+    fn clip_convex_masked(&mut self, planes: &[ClipPlane], mask: Option<&MaskField>) -> ClipCounts {
         let voxel_size = self.voxel_size();
         let band_mm = NARROW_BAND * voxel_size;
         let brick_mm = BRICK_DIM as f32 * voxel_size;
@@ -231,19 +654,18 @@ impl Volume {
         let coords: Vec<BrickCoord> = self.brick_coords().collect();
         let mut counts = ClipCounts::default();
         let mut touched: Vec<BrickCoord> = Vec::new();
+        // Reused across every brick: see `classify_active`.
+        let mut active: Vec<ClipPlane> = Vec::with_capacity(planes.len());
+        // 128 KB, and only ever allocated by a cut that really has more than
+        // one plane crossing a brick -- so a plane cut, which is every cut that
+        // ships today, never pays for it. See `write_cut_brick_plane_major`.
+        let mut scratch: Option<Box<[f32; BRICK_DIM.pow(3)]>> = None;
 
         for coord in coords {
+            counts.classified += 1;
             let origin = coord.origin();
             let centre = origin.as_vec3() * voxel_size + half;
-            let (nearest, farthest) = plane.range_over_box(centre, half);
-
-            let mut verdict = if nearest >= band_mm {
-                Cut::Removes
-            } else if farthest <= -band_mm {
-                Cut::Keeps
-            } else {
-                Cut::Crosses
-            };
+            let mut verdict = classify_active(planes, centre, half, band_mm, &mut active);
 
             // Removing is dropping the brick, which cannot be done by halves, so
             // anything the mask has to say about this brick sends it down the
@@ -258,18 +680,23 @@ impl Volume {
             }
 
             match verdict {
-                // The plane's own contribution is already saturated positive
-                // across the whole brick, so `max` would make every voxel
-                // OUTSIDE. An absent brick reads as OUTSIDE, so dropping it is
-                // both correct and free.
+                // Every plane's contribution is already saturated positive
+                // across the whole brick, so their minimum is too and `max`
+                // would make every voxel OUTSIDE. An absent brick reads as
+                // OUTSIDE, so dropping it is both correct and free.
                 Cut::Removes => {
-                    self.record_for_undo(coord);
-                    self.remove_brick(coord);
+                    // One call, because the brick being dropped IS the prior
+                    // undo needs: recording and then removing copies 128 KB
+                    // and immediately throws the original away. See
+                    // `Volume::remove_brick_recording`.
+                    self.remove_brick_recording(coord);
                     counts.changed += 1;
+                    counts.removed += 1;
                     touched.push(coord);
                 }
-                // `max(field, plane)` is `field` everywhere in here. Touching it
-                // would cost a dense promotion and an undo entry for no change.
+                // `max(field, cutter)` is `field` everywhere in here. Touching
+                // it would cost a dense promotion and an undo entry for no
+                // change.
                 Cut::Keeps => {}
                 Cut::Crosses => {
                     let Some(present) = self.brick(coord) else {
@@ -290,7 +717,23 @@ impl Volume {
                         // the brick is left alone entirely -- which is also what
                         // keeps a downgraded `Removes` brick present instead of
                         // deleted.
-                        if cut_would_change_a_voxel(present, origin, voxel_size, plane) {
+                        // **The full plane set, not the pruned one.** A brick
+                        // the mask downgraded from `Removes` arrives here with
+                        // an EMPTY active set -- empty is precisely how
+                        // `classify_active` says "every plane saturates across
+                        // this brick" -- and the minimum over no planes is
+                        // negative infinity, which reports that the cut would
+                        // have changed nothing. That is the opposite of the
+                        // truth for a brick the cutter would have taken whole,
+                        // and it drops the brick out of `bricks_spared_by_mask`
+                        // -- so the status line says "the cut missed the model"
+                        // over a cut a mask had just blocked completely, which
+                        // is the one message that sends a user off to redraw a
+                        // gesture that was never the problem.
+                        //
+                        // Only fully protected bricks reach this, so paying the
+                        // full plane count here costs nothing anywhere else.
+                        if cut_would_change_a_voxel(present, origin, voxel_size, planes) {
                             counts.spared_by_mask += 1;
                         }
                         continue;
@@ -303,27 +746,35 @@ impl Volume {
                     let Some(mut brick) = self.take_brick(coord) else {
                         continue;
                     };
+                    // Counted here rather than at the verdict, because the two
+                    // arms above reach this match with a `Crosses` verdict and
+                    // cost nothing dense: an absent brick has nothing to
+                    // promote, and a fully protected one is deliberately left
+                    // where it is. What this number is for is the price of the
+                    // promotion, so it counts promotions.
+                    counts.crossed += 1;
                     let data = brick.make_dense();
-                    for z in 0..BRICK_DIM {
-                        for y in 0..BRICK_DIM {
-                            for x in 0..BRICK_DIM {
-                                let at = (origin + IVec3::new(x as i32, y as i32, z as i32))
-                                    .as_vec3()
-                                    * voxel_size;
-                                // Both terms in voxels, which is what the field
-                                // stores. Mixing millimetres in here would move
-                                // the cut by a factor of the voxel size.
-                                let slot = brick_index(x, y, z);
-                                let cut = plane.distance(at) / voxel_size;
-                                let free = match uniform {
-                                    Some(free) => free,
-                                    None => freedom.at(slot),
-                                };
-                                data[slot] = cut_voxel(data[slot], cut, free);
-                            }
+                    // Specialised on the plane count, and it is worth the two
+                    // call sites. See `write_cut_brick`: with one plane the
+                    // closure captures a `Copy` `ClipPlane` that stays in
+                    // registers for all 32,768 voxels, where reading it back
+                    // out of a slice each time measured four times slower.
+                    match active.as_slice() {
+                        [only] => {
+                            let only = *only;
+                            write_cut_brick(data, origin, voxel_size, &freedom, uniform, |at| {
+                                only.distance(at)
+                            });
+                        }
+                        many => {
+                            let scratch =
+                                scratch.get_or_insert_with(|| Box::new([0.0; BRICK_DIM.pow(3)]));
+                            write_cut_brick_plane_major(
+                                data, scratch, origin, voxel_size, &freedom, uniform, many,
+                            );
                         }
                     }
-                    // A brick the plane merely grazed can come out entirely
+                    // A brick the cutter merely grazed can come out entirely
                     // empty, and one it barely entered can come out unchanged.
                     // Collapsing releases the 128 KB either way.
                     // Already recorded and already taken out of the map, so
@@ -342,10 +793,14 @@ impl Volume {
         // Every brick that changed, plus its neighbours: a brick's apron reads
         // one voxel into each of the 26 around it, so remeshing only what was
         // written would leave a seam along the cut face.
+        //
+        // The dedup that keeps this from costing 27 remeshes per changed brick
+        // is the `FxHashSet` inside `mark_dirty_voxel_range`, not anything
+        // here: `touched` is a plain `Vec` and deliberately so, since a brick
+        // reaches it at most once. Measured at 3.03 dirty bricks per brick
+        // changed rather than 27 -- see the module doc.
         for coord in touched {
-            let origin = coord.origin();
-            self.mark_dirty_voxel_range(origin, coord.max_voxel());
-            let _ = origin;
+            self.mark_dirty_voxel_range(coord.origin(), coord.max_voxel());
         }
         counts
     }
@@ -362,9 +817,22 @@ pub struct CutOutcome {
     /// Bricks changed, summed over every body.
     pub bricks: usize,
     /// Bodies at least one brick of which changed.
-    pub bodies_cut: usize,
+    /// The bodies at least one brick of which changed, in node order.
+    ///
+    /// A list rather than a count, for the same reason
+    /// [`CutOutcome::bodies_spared_by_mask`] is one: the caller has real work
+    /// that is proportional to WHICH bodies changed, not how many. Reporting
+    /// loose pieces means a connectivity walk, and walking a body the cut never
+    /// reached costs as much as walking one it did and can only ever find what
+    /// was already there.
+    ///
+    /// The alternative -- asking each body afterwards whether it has anything
+    /// dirty -- reads the same answer off a set that happens not to have been
+    /// drained yet, and would go quietly wrong the day a remesh moved above the
+    /// status line.
+    pub bodies_cut: Vec<NodeId>,
     /// Bodies the half-space reached at all, whether or not it found anything
-    /// there to remove. Always at least `bodies_cut`.
+    /// there to remove. Always at least `bodies_cut.len()`.
     pub bodies_crossed: usize,
     /// Bricks the mask kept whole, summed over every body.
     ///
@@ -416,6 +884,32 @@ impl Document {
     /// [`Volume::clip`] itself still cuts one body; this sums what each of them
     /// reports, both the bricks that changed and the bricks a mask kept whole.
     pub fn clip(&mut self, plane: ClipPlane, visible: &[bool]) -> CutOutcome {
+        self.clip_convex(std::slice::from_ref(&plane), visible)
+    }
+
+    /// Cut every body that is DRAWN with a convex cutter, as one gesture.
+    ///
+    /// [`Document::clip`] is this with one plane, and everything its
+    /// documentation says holds here: the gesture acts on what is drawn, one
+    /// gesture is one [`Entry`], and a body the cutter cannot reach is skipped
+    /// without walking its brick map.
+    ///
+    /// # The body gate generalises by reusing the arm the plane version threw
+    ///   away
+    ///
+    /// The single-plane gate binds `let (_, farthest)` and rejects a body lying
+    /// wholly BEHIND the plane. That is the same test as [`classify`]'s
+    /// `Cut::Keeps`, run over a body's bounds instead of a brick's, and it
+    /// generalises the same way: `min_i d_i <= d_j` everywhere, so a body that
+    /// any single plane puts wholly behind it cannot be reached by the
+    /// intersection either.
+    ///
+    /// What is deliberately NOT done here is the mirror of `Cut::Removes` --
+    /// noticing that the cutter swallows a body whole and dropping every brick
+    /// without looking. It would be sound, but a body that small is already
+    /// cheap to walk, and the arm would be a second place where "the mask can
+    /// veto a whole-brick drop" has to be remembered.
+    pub fn clip_convex(&mut self, planes: &[ClipPlane], visible: &[bool]) -> CutOutcome {
         debug_assert_eq!(
             visible.len(),
             self.nodes().len(),
@@ -425,25 +919,34 @@ impl Document {
         let band_mm = NARROW_BAND * self.voxel_size();
         // Resolved up front, so the loop below can take each body mutably in
         // turn without holding a borrow of the node list.
-        let crossed: Vec<NodeId> = self
-            .nodes()
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| visible.get(*index).copied().unwrap_or(false))
-            .filter_map(|(_, node)| {
-                let (low, high) = node.bounds()?;
-                let centre = (low + high) * 0.5;
-                let (_, farthest) = plane.range_over_box(centre, (high - low) * 0.5);
-                // Wholly behind the plane by at least the band: every brick in
-                // it would classify as `Keeps`, so there is nothing to do and
-                // the line did not reach this body at all.
-                (farthest > -band_mm).then_some(node.id)
-            })
-            .collect();
+        let crossed: Vec<NodeId> = if planes.is_empty() {
+            // No cutter reaches nothing. Returning every visible body here
+            // would report "the cut crossed 3 bodies and found nothing", which
+            // describes a cut that happened.
+            Vec::new()
+        } else {
+            self.nodes()
+                .iter()
+                .enumerate()
+                .filter(|(index, _)| visible.get(*index).copied().unwrap_or(false))
+                .filter_map(|(_, node)| {
+                    let (low, high) = node.bounds()?;
+                    let centre = (low + high) * 0.5;
+                    let half = (high - low) * 0.5;
+                    // Wholly behind ANY ONE plane by at least the band: every
+                    // brick in it would classify as `Keeps`, so there is
+                    // nothing to do and the gesture did not reach this body at
+                    // all.
+                    let reached =
+                        planes.iter().all(|plane| plane.range_over_box(centre, half).1 > -band_mm);
+                    reached.then_some(node.id)
+                })
+                .collect()
+        };
 
         let mut outcome = CutOutcome {
             bricks: 0,
-            bodies_cut: 0,
+            bodies_cut: Vec::new(),
             bodies_crossed: crossed.len(),
             bricks_spared_by_mask: 0,
             bodies_spared_by_mask: Vec::new(),
@@ -456,7 +959,7 @@ impl Document {
                 continue;
             };
             volume.begin_stroke();
-            let counts = volume.clip(plane);
+            let counts = volume.clip_convex(planes);
             let edit = volume.end_stroke();
             // Counted whatever else happened in this body: a cut that removed
             // half a body and was blocked on the other half spared bricks just
@@ -470,7 +973,7 @@ impl Document {
             // nothing.
             if let Some(edit) = edit.filter(|edit| !edit.is_empty()) {
                 outcome.bricks += counts.changed;
-                outcome.bodies_cut += 1;
+                outcome.bodies_cut.push(body);
                 changes.push(Change::Bricks { body, edit });
             }
         }
@@ -740,7 +1243,7 @@ mod across_the_document {
         let visible = shown(&doc);
         let outcome = doc.clip(ClipPlane::new(Vec3::ZERO, Vec3::Y).unwrap(), &visible);
 
-        assert_eq!(outcome.bodies_cut, 2, "the cut reached {} bodies", outcome.bodies_cut);
+        assert_eq!(outcome.bodies_cut.len(), 2, "the cut reached {:?}", outcome.bodies_cut);
         assert_eq!(outcome.bodies_crossed, 2);
         assert!(outcome.bricks > 0);
         for (id, probe) in ids.iter().zip(above) {
@@ -802,7 +1305,7 @@ mod across_the_document {
         let visible = shown(&doc);
         let outcome = doc.clip(ClipPlane::new(Vec3::ZERO, Vec3::Y).unwrap(), &visible);
 
-        assert_eq!(outcome.bodies_cut, 1, "the cut reached the hidden body");
+        assert_eq!(outcome.bodies_cut.len(), 1, "the cut reached the hidden body");
         assert_eq!(outcome.bodies_crossed, 1);
         assert_eq!(
             doc.volume(hidden).unwrap().sample_world(probe),
@@ -822,7 +1325,7 @@ mod across_the_document {
             doc.clip(ClipPlane::new(Vec3::new(0.0, 500.0, 0.0), Vec3::Y).unwrap(), &visible);
 
         assert_eq!(outcome.bricks, 0);
-        assert_eq!(outcome.bodies_cut, 0);
+        assert_eq!(outcome.bodies_cut.len(), 0);
         assert_eq!(outcome.bodies_crossed, 0, "a plane 500 mm away counted as crossing a body");
         assert!(outcome.entry.is_none(), "a cut that changed nothing recorded an entry");
     }
@@ -848,7 +1351,7 @@ mod across_the_document {
         let visible = shown(&doc);
         let outcome = doc.clip(plane, &visible);
         assert_eq!(outcome.bodies_crossed, 1, "the plane did not reach the body's box");
-        assert_eq!(outcome.bodies_cut, 0, "the plane found something to remove in an empty corner");
+        assert_eq!(outcome.bodies_cut.len(), 0, "the plane found something in an empty corner");
         assert_eq!(outcome.bricks, 0);
         assert!(outcome.entry.is_none());
     }
@@ -961,6 +1464,517 @@ mod provenance {
             differing, 0,
             "an unmasked cut no longer writes what the plain max wrote: {differing} voxels \
              differ, first at {worst:?}"
+        );
+    }
+
+    /// One plane through [`Volume::clip_convex`] is [`Volume::clip`], to the
+    /// bit.
+    ///
+    /// The reason this is a test rather than an argument is that the argument
+    /// is *almost* airtight and the gap is exactly where a mistake would live.
+    /// `min` over one element is that element, so no comparison happens and no
+    /// rounding can differ -- provided the single-plane path really does take
+    /// the first distance outright rather than folding from `f32::INFINITY`.
+    /// Folding would be equivalent for every finite value and would silently
+    /// stop being equivalent the day a `NaN` reached it, and nothing else in
+    /// this file would notice.
+    ///
+    /// Oblique on all three axes, because an axis-aligned plane lands its
+    /// distances on lattice values and would pass this test even if the
+    /// arithmetic had changed.
+    #[test]
+    fn a_one_plane_convex_cut_is_the_plane_cut_bit_for_bit() {
+        use crate::testing::assert_same_field;
+
+        let plane = ClipPlane::new(Vec3::new(2.0, -1.0, 3.0), Vec3::new(1.0, 2.0, -0.5)).unwrap();
+
+        let mut singular = Volume::new(0.5);
+        singular.seed_sphere(Vec3::ZERO, 20.0);
+        singular.mark_everything_dirty();
+        let one = singular.clip(plane);
+
+        let mut plural = Volume::new(0.5);
+        plural.seed_sphere(Vec3::ZERO, 20.0);
+        plural.mark_everything_dirty();
+        let many = plural.clip_convex(&[plane]);
+
+        assert!(one.changed > 0, "the fixture was not cut");
+        assert_eq!(one, many, "the two paths disagreed about what they did");
+        assert_same_field(&singular, &plural, "one plane through clip_convex");
+    }
+
+    /// **A half-protected voxel must land half way, not all the way.**
+    ///
+    /// This is the regression test for a bug that shipped: the blend ran toward
+    /// the RAW cut distance, which is unbounded, and only the finished value
+    /// was clamped. So a voxel at `-3` under half protection with the cutter
+    /// twenty voxels past it blended toward 20 rather than toward `OUTSIDE`,
+    /// landed at 8.5, and clamped to 3.0 -- removed exactly as completely as an
+    /// unprotected voxel.
+    ///
+    /// **The effect got WORSE the further the cutter was**, which is why it
+    /// survived: a cut drawn right at the edge of a mask, which is how anyone
+    /// would test this by hand, is the one case where the two orders nearly
+    /// agree. Everything further out was silently unprotected.
+    ///
+    /// The far end of the sweep is the part that bites. `free` of 0.5 with the
+    /// cutter one voxel away is nearly right under either order; at twenty
+    /// voxels the old form is off by the whole band.
+    #[test]
+    fn a_partly_protected_voxel_blends_toward_outside_and_not_beyond_it() {
+        for free in [0.25_f32, 0.5, 0.75] {
+            for cut in [1.0_f32, 4.0, 20.0, 4000.0] {
+                for old in [INSIDE, -1.0, 0.0, 1.0] {
+                    let got = cut_voxel(old, cut, free);
+                    // The most a cut can ever write is OUTSIDE, so a fraction
+                    // `free` of the way there is the answer.
+                    let ceiling = old.max(cut).clamp(INSIDE, OUTSIDE);
+                    let want = old + (ceiling - old) * free;
+                    assert!(
+                        (got - want).abs() < 1.0e-6,
+                        "old {old}, cut {cut}, free {free}: got {got}, wanted {want}"
+                    );
+                    assert!(
+                        got < OUTSIDE || ceiling >= OUTSIDE && free >= 1.0,
+                        "a partly protected voxel was driven fully outside: old {old}, cut \
+                         {cut}, free {free} gave {got}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// And the unmasked path is untouched by that fix, which is the property
+    /// that let it be made at all: clamping a value that is already clamped is
+    /// the identity, so `free >= 1` writes exactly what it always wrote.
+    #[test]
+    fn clamping_before_the_blend_does_not_move_an_unmasked_cut() {
+        for cut in [-4000.0_f32, -3.5, -1.0, 0.0, 1.0, 3.5, 4000.0] {
+            for old in [INSIDE, -1.5, 0.0, 1.5, OUTSIDE] {
+                let got = cut_voxel(old, cut, 1.0);
+                let was = old.max(cut).clamp(INSIDE, OUTSIDE);
+                assert_eq!(got.to_bits(), was.to_bits(), "old {old}, cut {cut}");
+            }
+        }
+    }
+
+    /// A cutter of no planes removes nothing.
+    ///
+    /// The intersection of no half-spaces is all of space, so the faithful
+    /// answer is to erase the model. This pins the unfaithful one, because
+    /// there is no gesture whose failure should be answered by deleting
+    /// everything -- and an empty slice is exactly what a gesture whose plane
+    /// construction failed would hand over.
+    #[test]
+    fn a_cutter_with_no_planes_removes_nothing() {
+        use crate::testing::assert_same_field;
+
+        let mut cut = Volume::new(0.5);
+        cut.seed_sphere(Vec3::ZERO, 20.0);
+        cut.mark_everything_dirty();
+
+        let mut untouched = Volume::new(0.5);
+        untouched.seed_sphere(Vec3::ZERO, 20.0);
+        untouched.mark_everything_dirty();
+
+        assert_eq!(cut.clip_convex(&[]).changed, 0, "an empty cutter removed bricks");
+        assert_same_field(&cut, &untouched, "an empty cutter");
+    }
+}
+
+/// The cut as a convex region rather than a half-space.
+///
+/// What these pin is the one property a plane cannot have: **the cutter stops**.
+/// Every test here is built around material the cutter must leave alone that a
+/// plane covering the same silhouette would have taken, because that is the
+/// entire difference and nothing in the single-plane suite can see it.
+#[cfg(test)]
+mod as_a_convex_region {
+    use super::*;
+
+    const VOXEL: f32 = 0.5;
+
+    /// An axis-aligned box as six half-spaces, normals pointing INWARD.
+    ///
+    /// Inward is the direction that makes the box's interior the region that
+    /// goes: a plane's normal points at the side being removed, so for the
+    /// intersection to be the inside of the box each face must point in.
+    /// Getting this backwards produces the complement -- an unbounded region
+    /// with a box-shaped hole in it -- which removes the entire model except a
+    /// box, and is a failure worth being able to recognise on sight.
+    fn box_cutter(low: Vec3, high: Vec3) -> Vec<ClipPlane> {
+        let mut planes = Vec::with_capacity(6);
+        for axis in [Vec3::X, Vec3::Y, Vec3::Z] {
+            planes.push(ClipPlane::new(low, axis).expect("a unit axis"));
+            planes.push(ClipPlane::new(high, -axis).expect("a unit axis"));
+        }
+        planes
+    }
+
+    /// Two balls, far enough apart that a brick belongs to at most one.
+    fn a_ball_and_a_distant_one() -> Volume {
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 20.0);
+        volume.seed_sphere(Vec3::new(60.0, 0.0, 0.0), 8.0);
+        volume.mark_everything_dirty();
+        volume
+    }
+
+    /// **The headline property.** A bounded cutter takes what is inside it and
+    /// leaves what is behind it, where the plane that removes the same near
+    /// material would go on to remove the far ball as well.
+    ///
+    /// The far ball is not decoration. `a_cut_passes_through_the_whole_model`
+    /// asserts the opposite behaviour on the same shape of fixture, and it must
+    /// keep passing: an infinite half-space is still what one plane means. The
+    /// two tests together are what say the boundedness comes from the extra
+    /// planes and not from a change of heart about what a cut is.
+    #[test]
+    fn a_bounded_cutter_stops_where_a_plane_would_carry_on() {
+        let mut volume = a_ball_and_a_distant_one();
+        let counts = volume
+            .clip_convex(&box_cutter(Vec3::new(10.0, -40.0, -40.0), Vec3::new(40.0, 40.0, 40.0)));
+
+        assert!(counts.changed > 0, "the cutter did nothing");
+        assert!(
+            volume.sample_world(Vec3::new(15.0, 0.0, 0.0)) > 0.0,
+            "material survived inside the cutter"
+        );
+        assert!(
+            volume.sample_world(Vec3::new(-15.0, 0.0, 0.0)) < 0.0,
+            "the cutter reached behind itself"
+        );
+        assert!(
+            volume.sample_world(Vec3::new(60.0, 0.0, 0.0)) < 0.0,
+            "the cutter carried on past its far face and took the distant ball"
+        );
+    }
+
+    /// A cutter that encloses material drops bricks whole rather than resolving
+    /// them one voxel at a time. This is the shape's own payoff: a plane
+    /// covering the same silhouette has to cross every brick along an infinite
+    /// sheet, where a loop drawn around a lump saturates inside it.
+    ///
+    /// Asserted on `removed` directly rather than inferred from a drop in
+    /// resident bytes, because there are TWO ways a brick leaves the map -- the
+    /// whole-brick drop, and a crossed brick that collapses to `OUTSIDE` and is
+    /// reinserted as nothing -- and a bytes measurement cannot tell them apart.
+    #[test]
+    fn a_cutter_that_encloses_material_drops_whole_bricks() {
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 30.0);
+        volume.mark_everything_dirty();
+
+        // Comfortably larger than a brick on every axis (a brick is 32 voxels,
+        // 16 mm here), and wholly inside the ball, so bricks in the middle of
+        // it are saturated past the band on all six faces.
+        let counts = volume.clip_convex(&box_cutter(Vec3::splat(-25.0), Vec3::splat(25.0)));
+
+        assert!(counts.removed > 0, "nothing was dropped whole: {counts:?}");
+    }
+
+    /// The memory point, mirrored from the plane's own version of it: a cutter
+    /// must not promote interior tiles it never reaches.
+    ///
+    /// This is the failure mode the plan singles out as the reason v1 is convex
+    /// only -- a decomposed non-convex region evaluates to exactly zero on its
+    /// internal seams, deep inside the removed region, which forces `Crosses`
+    /// where `Removes` was correct and leaves a 128 KB brick resident in a
+    /// space the user just deleted. A convex cutter cannot do that, and this is
+    /// what says so.
+    #[test]
+    fn a_cutter_does_not_promote_untouched_interior_bricks_to_dense() {
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 40.0);
+        volume.mark_everything_dirty();
+        let before = volume.stats();
+        assert!(before.uniform_bricks > 0, "the fixture has no interior tiles to protect");
+
+        // A small box at one end, so almost every interior tile is untouched.
+        volume.clip_convex(&box_cutter(Vec3::new(30.0, -10.0, -10.0), Vec3::new(50.0, 10.0, 10.0)));
+        let after = volume.stats();
+
+        assert!(
+            after.uniform_bricks >= before.uniform_bricks - 4,
+            "interior tiles were promoted to dense: {} before, {} after",
+            before.uniform_bricks,
+            after.uniform_bricks
+        );
+        assert!(
+            after.resident_bytes < before.resident_bytes * 2,
+            "a small cut doubled the resident bytes: {} before, {} after",
+            before.resident_bytes,
+            after.resident_bytes
+        );
+    }
+
+    /// A convex cutter leaves a printable model, which is not free: it adds
+    /// cut-cut edges where two faces of the cutter meet inside the material,
+    /// and those are new geometry the plane never produced.
+    #[test]
+    fn a_box_cut_model_is_still_printable() {
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 20.0);
+        volume.mark_everything_dirty();
+        volume.clip_convex(&box_cutter(Vec3::new(8.0, -30.0, -30.0), Vec3::new(30.0, 30.0, 30.0)));
+
+        let (mesh, report) = volume.export_mesh();
+        assert!(
+            report.is_printable(),
+            "a box cut left the model unprintable: {} ({} triangles)",
+            report.summary(),
+            mesh.triangles.len()
+        );
+    }
+
+    /// **A convex cutter must not leave the model more non-manifold than the
+    /// plane that covers the same silhouette.**
+    ///
+    /// `is_printable` is the obvious gate and it is structurally blind to what
+    /// this adds. It is `boundary_edges == 0 && inconsistent_edges == 0 &&
+    /// triangles > 0` -- it counts holes and winding, and does NOT count
+    /// `non_manifold_edges` at all. A shaped cut adds sixteen sharp cut-cut
+    /// edges running the full depth of the cutter, plus their corner junctions,
+    /// which is exactly the geometry `is_printable` cannot see; and this file
+    /// already records four-way edges at cut rims as a problem that was
+    /// accepted rather than solved.
+    ///
+    /// So the assertion is against a BASELINE on the same fixture rather than
+    /// against zero. Against zero it would fail on the plane cut too, which
+    /// ships; against `is_printable` it would pass on a model with sixteen
+    /// non-manifold seams.
+    #[test]
+    fn a_shaped_cut_is_no_less_manifold_than_the_plane_that_covers_it() {
+        let mut worst_extra = 0i64;
+        for step in 0..6 {
+            let angle = step as f32 / 6.0 * std::f32::consts::TAU;
+            let (sin, cos) = angle.sin_cos();
+            // A prism whose axis is oblique to the lattice at every step, which
+            // is where a sloppy classification shows up.
+            let axis = Vec3::new(cos, 0.35, sin).normalize();
+
+            let mut planed = Volume::new(VOXEL);
+            planed.seed_sphere(Vec3::ZERO, 20.0);
+            planed.mark_everything_dirty();
+            planed.clip_convex(&[ClipPlane::new(axis * 8.0, axis).unwrap()]);
+            let (_, plane_report) = planed.export_mesh();
+
+            let mut shaped = Volume::new(VOXEL);
+            shaped.seed_sphere(Vec3::ZERO, 20.0);
+            shaped.mark_everything_dirty();
+            shaped.clip_convex(&prism(axis * 8.0, axis, 9.0, 16));
+            let (_, shaped_report) = shaped.export_mesh();
+
+            assert!(
+                shaped_report.is_printable(),
+                "a shaped cut at {angle:.2} rad is not printable: {}",
+                shaped_report.summary()
+            );
+            let extra =
+                shaped_report.non_manifold_edges as i64 - plane_report.non_manifold_edges as i64;
+            worst_extra = worst_extra.max(extra);
+        }
+        // Sixteen side planes meeting the surface make more rim than one plane
+        // does, so a small positive number is expected and zero would be a
+        // surprise. What this catches is the shape adding non-manifold edges
+        // out of proportion to the rim it draws -- an order of magnitude, not a
+        // handful.
+        assert!(
+            worst_extra < 64,
+            "a shaped cut added {worst_extra} non-manifold edges over the plane covering the \
+             same silhouette"
+        );
+    }
+
+    /// A regular prism, inward normals, as the app builds one from a hull.
+    fn prism(centre: Vec3, axis: Vec3, radius: f32, sides: usize) -> Vec<ClipPlane> {
+        let axis = axis.normalize();
+        let helper = if axis.x.abs() < 0.9 { Vec3::X } else { Vec3::Y };
+        let u = axis.cross(helper).normalize();
+        let v = axis.cross(u);
+        (0..sides)
+            .map(|side| {
+                let angle = side as f32 / sides as f32 * std::f32::consts::TAU;
+                let (sin, cos) = angle.sin_cos();
+                let outward = u * cos + v * sin;
+                ClipPlane::new(centre + outward * radius, -outward).expect("a unit normal")
+            })
+            .collect()
+    }
+
+    /// **The absolute cost assertion, and it is absolute on purpose.**
+    ///
+    /// The tempting form -- "a lasso dirties no more bricks than the plane that
+    /// covers it" -- gates nothing. A plane pushes every removed brick into the
+    /// touched set, which is half the body, against a small loop's handful of
+    /// wall bricks; it passes by three orders of magnitude and would keep
+    /// passing if a shaped cut promoted every brick it crossed twice over.
+    ///
+    /// So these are numbers, measured on this fixture, that a regression has to
+    /// move. They are generous -- the point is to catch something going badly
+    /// wrong, not to freeze the classification.
+    #[test]
+    fn a_shaped_cut_promotes_a_bounded_number_of_bricks() {
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 20.0);
+        volume.mark_everything_dirty();
+        volume.take_dirty(&mut Vec::new());
+
+        let counts = volume.clip_convex(&prism(Vec3::new(14.0, 0.0, 0.0), Vec3::X, 6.0, 16));
+
+        assert!(counts.changed > 0, "the cutter did nothing to measure");
+        assert!(
+            counts.crossed <= 48,
+            "a small loop promoted {} bricks to dense, which is more than the region it covers",
+            counts.crossed
+        );
+        assert!(
+            volume.dirty_count() <= 200,
+            "a small loop dirtied {} bricks",
+            volume.dirty_count()
+        );
+    }
+
+    /// **The mask must be reported as sparing exactly what the cut would have
+    /// taken -- including the bricks it would have taken WHOLE.**
+    ///
+    /// This is the regression test for a bug the per-brick plane pruning
+    /// introduced. A brick the cutter saturates classifies as `Removes`, and
+    /// `classify_active` says so by leaving the active plane set EMPTY. The
+    /// mask then downgrades it to `Crosses`, and the fully-protected arm asked
+    /// "would the cut have changed anything here?" using that empty set -- over
+    /// which the minimum is negative infinity, so the answer came back "no".
+    ///
+    /// Those bricks fell out of `bricks_spared_by_mask`: on this fixture 152
+    /// were reported where 216 were really spared, the 64 missing ones being
+    /// exactly those the cutter enclosed. A cut a mask had blocked entirely
+    /// could then report **"the cut missed the model"** -- the single most
+    /// misleading thing the status line can say, because it sends the user off
+    /// to redraw a gesture that was never the problem. Nothing else could see
+    /// it: the field really is untouched, the bricks really are all still
+    /// there, and no undo entry really is recorded. Only the count was wrong.
+    ///
+    /// **Asserted against the same cut run unmasked**, rather than against a
+    /// number written down here. "The mask spared what the cut would have
+    /// taken" is the property; a hard-coded 216 would pass just as well if the
+    /// fixture changed underneath it and would say nothing about why.
+    #[test]
+    fn a_mask_spares_exactly_what_the_cut_would_have_taken() {
+        // Big enough that bricks sit wholly INSIDE the cutter with room to
+        // spare, which is what makes them classify `Removes` rather than
+        // merely crossing. A cutter that only ever grazes bricks exercises the
+        // other arm and would pass either way.
+        let cutter = box_cutter(Vec3::splat(-40.0), Vec3::splat(40.0));
+
+        let mut unmasked = Volume::new(VOXEL);
+        unmasked.seed_sphere(Vec3::ZERO, 60.0);
+        unmasked.mark_everything_dirty();
+        let would_take = unmasked.clip_convex(&cutter).changed;
+        assert!(would_take > 0, "the fixture is not cut at all");
+
+        let mut masked = Volume::new(VOXEL);
+        masked.seed_sphere(Vec3::ZERO, 60.0);
+        masked.mark_everything_dirty();
+        // Mask All: an empty map read inverted protects every voxel there is.
+        masked.mask_mut().set_inverted(true);
+        let counts = masked.clip_convex(&cutter);
+
+        assert_eq!(counts.changed, 0, "a fully masked body was cut");
+        assert_eq!(
+            counts.spared_by_mask, would_take,
+            "the mask spared {} bricks but the same cut takes {would_take} unmasked, so the \
+             bricks it would have dropped whole are being reported as spared by nobody",
+            counts.spared_by_mask
+        );
+    }
+
+    /// A cutter the model is nowhere near costs the classification and nothing
+    /// else, and records no undo entry.
+    #[test]
+    fn a_cutter_that_misses_changes_nothing() {
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 20.0);
+        volume.mark_everything_dirty();
+        let before = volume.brick_coords().count();
+
+        let counts = volume.clip_convex(&box_cutter(Vec3::splat(500.0), Vec3::splat(540.0)));
+
+        assert_eq!(counts.changed, 0, "a cutter far outside the model changed bricks");
+        assert_eq!(counts.crossed, 0, "a cutter far outside the model promoted bricks");
+        assert_eq!(volume.brick_coords().count(), before);
+    }
+
+    /// **The multi-plane path writes what the definition says, to the bit.**
+    ///
+    /// This is the test that keeps two optimisations honest at once, and
+    /// without it neither is checkable. A brick crossed by one plane is written
+    /// by a fused voxel-major loop and a brick crossed by several by a
+    /// plane-major one over a scratch buffer; no input takes both, so a
+    /// disagreement between them is invisible. On top of that the plane set is
+    /// PRUNED per brick -- planes that saturate across a brick are dropped from
+    /// its minimum -- and the argument that this is exact rather than
+    /// approximate is exactly the kind that is convincing and occasionally
+    /// wrong.
+    ///
+    /// So the reference here is neither path: it is `min` over ALL the planes
+    /// at every voxel in a box, through `edit_voxels`, which is the definition
+    /// written out. Compared bit for bit, because the claim is bit-identity.
+    ///
+    /// Oblique planes at deliberately awkward angles, so no distance lands on a
+    /// lattice value and the rounding this is about actually happens.
+    #[test]
+    fn several_planes_write_the_minimum_of_their_distances_exactly() {
+        let planes = [
+            ClipPlane::new(Vec3::new(2.0, -1.0, 3.0), Vec3::new(1.0, 2.0, -0.5)).unwrap(),
+            ClipPlane::new(Vec3::new(-3.0, 4.0, 1.0), Vec3::new(-0.7, 1.0, 0.3)).unwrap(),
+            ClipPlane::new(Vec3::new(1.0, 1.0, -2.0), Vec3::new(0.2, -0.4, 1.0)).unwrap(),
+        ];
+
+        let mut cut = Volume::new(VOXEL);
+        cut.seed_sphere(Vec3::ZERO, 20.0);
+        cut.mark_everything_dirty();
+        assert!(cut.clip_convex(&planes).crossed > 0, "no brick took the multi-plane path");
+
+        let mut reference = Volume::new(VOXEL);
+        reference.seed_sphere(Vec3::ZERO, 20.0);
+        reference.mark_everything_dirty();
+        let voxel_size = reference.voxel_size();
+        let (lo, hi) = reference.voxel_bounds(Vec3::splat(-30.0), Vec3::splat(30.0));
+        reference.edit_voxels(lo, hi, |_, position, value| {
+            // The minimum in millimetres and the division afterwards, which is
+            // the order both real paths use. Dividing first would round each
+            // distance separately and this test would fail for a reason that
+            // has nothing to do with what it is checking.
+            let smallest =
+                planes.iter().map(|plane| plane.distance(position)).fold(f32::INFINITY, f32::min);
+            value.max(smallest / voxel_size).clamp(INSIDE, OUTSIDE)
+        });
+
+        let mut differing = 0usize;
+        let mut worst = None;
+        for z in lo.z..=hi.z {
+            for y in lo.y..=hi.y {
+                for x in lo.x..=hi.x {
+                    let cell = IVec3::new(x, y, z);
+                    let coord = BrickCoord::containing(cell);
+                    let local = cell - coord.origin();
+                    let read = |volume: &Volume| {
+                        volume.brick(coord).map_or(OUTSIDE, |brick| {
+                            brick.get(local.x as usize, local.y as usize, local.z as usize)
+                        })
+                    };
+                    let (theirs, ours) = (read(&reference), read(&cut));
+                    if theirs.to_bits() != ours.to_bits() {
+                        differing += 1;
+                        worst.get_or_insert((cell, theirs, ours));
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            differing, 0,
+            "the convex cut is not the minimum of its planes: {differing} voxels differ, first \
+             at {worst:?}"
         );
     }
 }
@@ -1213,7 +2227,7 @@ mod through_a_mask {
         let outcome = doc.clip(ClipPlane::new(Vec3::ZERO, Vec3::Y).unwrap(), &visible);
 
         assert_eq!(outcome.bodies_crossed, 2);
-        assert_eq!(outcome.bodies_cut, 1, "the masked body was cut");
+        assert_eq!(outcome.bodies_cut.len(), 1, "the masked body was cut");
         assert!(outcome.bricks > 0, "the unmasked body was spared as well");
         assert!(outcome.bricks_spared_by_mask > 0, "the masked body reported nothing spared");
         assert_eq!(

--- a/crates/brokkr-core/src/generate.rs
+++ b/crates/brokkr-core/src/generate.rs
@@ -340,6 +340,40 @@ impl Volume {
     /// dense, and a mask over half a dragon costs its boundary rather than its
     /// volume.
     fn halfspace_mask(&self, plane: ClipPlane, feather_mm: f32) -> MaskField {
+        self.cutter_mask(std::slice::from_ref(&plane), feather_mm)
+    }
+
+    /// Protection over the convex region every plane agrees on.
+    ///
+    /// [`Volume::halfspace_mask`] is this with one plane, and it is a wrapper
+    /// rather than a second implementation for the same reason
+    /// [`Volume::clip`] is: `min` over one element is the element, so a
+    /// single-plane mask is not merely equivalent to the one that shipped, it
+    /// is the same arithmetic.
+    ///
+    /// This is the ctrl half of the cut. The same drag, the same hull, the same
+    /// brick classification -- writing protection instead of removing material,
+    /// so that circling a lump SELECTS it and [`Document::split_masked`] can
+    /// then lift it off as its own body. That is the layers model the panel
+    /// already presents, and it is what the research found users prefer over a
+    /// destructive trim for exactly this task.
+    ///
+    /// # The feather is not optional
+    ///
+    /// `mask.rs` records the rule in one line -- every path that writes the
+    /// mask writes a feathered edge, never a step -- and names lasso masks
+    /// writing hard values as the prior-art failure that broke Blender's border
+    /// detection for years. The feather here is the region's own distance,
+    /// which is why it is the SAME `min` the cut uses: a mask whose edge sat
+    /// anywhere other than where the cut would have gone would make ctrl and
+    /// no-ctrl disagree about what the gesture selected.
+    pub fn cutter_mask(&self, planes: &[ClipPlane], feather_mm: f32) -> MaskField {
+        if planes.is_empty() {
+            // No region protects nothing. The alternative reading -- the
+            // intersection of no half-spaces is everything -- would protect the
+            // whole model from a gesture whose construction failed.
+            return self.mask().generated(Vec::new());
+        }
         let voxel_size = self.voxel_size();
         // A feather narrower than a voxel is a step by another name, so the
         // floor is one voxel however small the caller asked for.
@@ -356,13 +390,25 @@ impl Volume {
             .filter_map(|coord| {
                 let origin = coord.origin();
                 let centre = origin.as_vec3() * voxel_size + half;
-                let (nearest, farthest) = plane.range_over_box(centre, half);
-                if farthest <= -feather {
-                    // Wholly on the kept side: no entry at all, which is what
-                    // keeps this proportional to the boundary.
-                    return None;
+                // The same three-way classification the cut makes, against
+                // the feather instead of the narrow band, and with the same
+                // per-brick pruning: a plane already saturated across this
+                // brick writes `PROTECTED` there whatever the others say, so
+                // dropping it from the minimum cannot change a byte.
+                let mut active: Vec<ClipPlane> = Vec::with_capacity(planes.len());
+                for plane in planes {
+                    let (nearest, farthest) = plane.range_over_box(centre, half);
+                    if farthest <= -feather {
+                        // Wholly on the kept side of ONE plane is wholly
+                        // outside the region: no entry at all, which is what
+                        // keeps this proportional to the boundary.
+                        return None;
+                    }
+                    if nearest < feather {
+                        active.push(*plane);
+                    }
                 }
-                if nearest >= feather {
+                if active.is_empty() {
                     return Some((*coord, MaskBrick::Uniform(PROTECTED)));
                 }
                 let mut brick = MaskBrick::dense_filled(UNMASKED);
@@ -372,7 +418,8 @@ impl Volume {
                         for x in 0..BRICK_DIM {
                             let at = (origin + IVec3::new(x as i32, y as i32, z as i32)).as_vec3()
                                 * voxel_size;
-                            data[brick_index(x, y, z)] = feathered(plane.distance(at) / feather);
+                            data[brick_index(x, y, z)] =
+                                feathered(crate::clip::cut_distance(&active, at) / feather);
                         }
                     }
                 }
@@ -1023,6 +1070,134 @@ mod tests {
             MaskRecipe::Halfspace { plane, feather_mm: 1.0 },
         ] {
             assert!(volume.generated_mask(recipe).is_free(), "{recipe:?} invented a mask");
+        }
+    }
+
+    /// **The feather's midpoint lands on the SELECTED side, by one rounding
+    /// step, and nothing else in the codebase says so.**
+    ///
+    /// The chain is three links long and each is in a different file.
+    /// `feathered(0.0)` is `smoothstep(0.5) * 255`, which is 127.5; `f32::round`
+    /// takes halves away from zero, so it is 128; and `split_masked` thresholds
+    /// at `MASKED_ENOUGH_TO_SPLIT`, which is 128, with `>=`.
+    ///
+    /// Change the constant, the curve, or the comparison to `>` and the
+    /// boundary voxel silently changes sides -- which on a ctrl-lasso split is
+    /// a one-voxel slot along the seam between the two bodies, on a model that
+    /// is otherwise correct and passes every printability check there is.
+    #[test]
+    fn the_feather_midpoint_lands_on_the_selected_side() {
+        let middle = feathered(0.0);
+        assert_eq!(middle, 128, "the feather's midpoint moved off 128");
+        assert_eq!(
+            middle,
+            crate::split::MASKED_ENOUGH_TO_SPLIT,
+            "the feather's midpoint and the split threshold have drifted apart"
+        );
+        assert!(
+            middle >= crate::split::MASKED_ENOUGH_TO_SPLIT,
+            "the boundary voxel changed sides: split_masked compares with `>=`"
+        );
+        // And the two sides really are either side of it, so the test above is
+        // about a boundary rather than about a constant that happens to match.
+        assert!(feathered(-0.01) < middle, "just outside the region is not less protected");
+        assert!(feathered(0.01) > middle, "just inside the region is not more protected");
+    }
+
+    /// The voxel a world point falls in, at this module's test voxel size.
+    fn cell(at: Vec3) -> IVec3 {
+        (at / VOXEL).round().as_ivec3()
+    }
+
+    /// The ctrl half of the cut: circling a lump protects the lump and nothing
+    /// else, and touches no voxel of the field.
+    #[test]
+    fn a_cutter_mask_protects_what_is_inside_it_and_leaves_the_field_alone() {
+        use crate::testing::assert_same_field;
+
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 20.0);
+        volume.mark_everything_dirty();
+
+        let mut untouched = Volume::new(VOXEL);
+        untouched.seed_sphere(Vec3::ZERO, 20.0);
+        untouched.mark_everything_dirty();
+
+        // A box around the +X cap, inward normals, exactly as the cut builds
+        // its region.
+        let (low, high) = (Vec3::new(8.0, -30.0, -30.0), Vec3::new(30.0, 30.0, 30.0));
+        let mut planes = Vec::new();
+        for axis in [Vec3::X, Vec3::Y, Vec3::Z] {
+            planes.push(ClipPlane::new(low, axis).unwrap());
+            planes.push(ClipPlane::new(high, -axis).unwrap());
+        }
+
+        let mask = volume.cutter_mask(&planes, VOXEL * 2.0);
+        assert!(!mask.is_free(), "the cutter mask protected nothing at all");
+        assert_eq!(
+            mask.at(cell(Vec3::new(15.0, 0.0, 0.0))),
+            PROTECTED,
+            "the middle of the region is not protected"
+        );
+        assert_eq!(
+            mask.at(cell(Vec3::new(-15.0, 0.0, 0.0))),
+            UNMASKED,
+            "protection leaked outside the region"
+        );
+
+        // Writing a mask must not move one voxel of the field, which is the
+        // whole difference between ctrl and no ctrl.
+        assert_same_field(&volume, &untouched, "writing a cutter mask");
+    }
+
+    /// A region drawn somewhere else must leave a hand-painted mask alone.
+    ///
+    /// `mask_cutter` skips a body whose generated mask `is_free()`, and this is
+    /// the property that skip exists for: without it, circling something on one
+    /// body wipes the protection painted on every other body on screen.
+    #[test]
+    fn a_cutter_that_misses_generates_a_free_mask() {
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 20.0);
+        volume.mark_everything_dirty();
+
+        let (low, high) = (Vec3::splat(500.0), Vec3::splat(540.0));
+        let mut planes = Vec::new();
+        for axis in [Vec3::X, Vec3::Y, Vec3::Z] {
+            planes.push(ClipPlane::new(low, axis).unwrap());
+            planes.push(ClipPlane::new(high, -axis).unwrap());
+        }
+
+        assert!(
+            volume.cutter_mask(&planes, VOXEL * 2.0).is_free(),
+            "a region far from the model still generated protection"
+        );
+    }
+
+    /// One plane through `cutter_mask` is the half-space mask, which is what
+    /// makes the wrapper a wrapper rather than a second implementation.
+    #[test]
+    fn one_plane_through_the_cutter_mask_is_the_half_space_mask() {
+        let mut volume = Volume::new(VOXEL);
+        volume.seed_sphere(Vec3::ZERO, 20.0);
+        volume.mark_everything_dirty();
+
+        let plane = ClipPlane::new(Vec3::new(2.0, -1.0, 3.0), Vec3::new(1.0, 2.0, -0.5)).unwrap();
+        let feather = VOXEL * 2.0;
+        let recipe = volume.generated_mask(MaskRecipe::Halfspace { plane, feather_mm: feather });
+        let direct = volume.cutter_mask(std::slice::from_ref(&plane), feather);
+
+        for probe in [
+            Vec3::new(10.0, 0.0, 0.0),
+            Vec3::new(-10.0, 0.0, 0.0),
+            Vec3::new(2.0, -1.0, 3.0),
+            Vec3::new(0.0, 5.0, -5.0),
+        ] {
+            assert_eq!(
+                recipe.at(cell(probe)),
+                direct.at(cell(probe)),
+                "the two paths disagree at {probe:?}"
+            );
         }
     }
 }

--- a/crates/brokkr-core/src/lib.rs
+++ b/crates/brokkr-core/src/lib.rs
@@ -78,7 +78,7 @@ pub use project::{
     Keyframe, MAX_NAME_BYTES, MAX_VOLUME_BYTES, Outline, ProjectError, ProjectState, View,
     name_that_fits,
 };
-pub use raycast::{Hit, raycast};
+pub use raycast::{Hit, SolidSpans, Span, first_solid_spans, raycast};
 pub use region::FieldRegion;
 pub use similarity::{Bake, Similarity};
 pub use split::{

--- a/crates/brokkr-core/src/raycast.rs
+++ b/crates/brokkr-core/src/raycast.rs
@@ -109,6 +109,125 @@ fn refine(field: &impl Fn(f32) -> f32, mut outside: f32, mut inside: f32) -> f32
     0.5 * (outside + inside)
 }
 
+/// A run of solid along a ray.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Span {
+    /// Distance along the ray where the solid begins.
+    pub enter: f32,
+    /// Distance along the ray where it ends.
+    pub exit: f32,
+}
+
+/// What a ray found: the first run of solid, and where the next one starts.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct SolidSpans {
+    /// The first complete run of solid the ray passed through.
+    ///
+    /// `None` when the ray met no surface, and also when it entered solid and
+    /// never came out within `max_distance` -- an unfinished span has no exit,
+    /// and a depth cap placed from a guessed one would cut where nothing was
+    /// measured.
+    pub first: Option<Span>,
+    /// Where the NEXT run of solid begins, if the ray reached one.
+    ///
+    /// This is the number a depth cap has to respect: it is the surface behind
+    /// the thing being cut off, and the wall that a cutter reaching too far
+    /// would thin from the front without anybody seeing it.
+    pub next_enter: Option<f32>,
+}
+
+/// March a ray and report the first solid run and the start of the one behind
+/// it.
+///
+/// `direction` must be unit length.
+///
+/// # Why this is not [`raycast`] called twice
+///
+/// Three differences, and each one is a bug if it is left out.
+///
+/// **The empty-brick skip only works outside.** [`empty_brick_span`] returns
+/// `None` for any brick that is not uniformly outside, so it accelerates the
+/// air in front of a body and the gap between two bodies, and does nothing at
+/// all for the leg from a surface to the far side of the same solid. Applying
+/// it while inside would be harmless but pointless; not noticing that it does
+/// nothing there is what makes the next point a surprise.
+///
+/// **The step rule has to flip sign inside.** [`raycast`] advances by
+/// `previous_d.max(min_step)`, and inside the solid `previous_d` is negative,
+/// so `max` picks the floor and the march crawls a quarter of a voxel at a
+/// time -- 512 steps buys 128 voxels of interior, which does not cross a model.
+/// Inside, the distance to the surface is `-d`, and stepping by that is what
+/// makes the exit reachable.
+///
+/// **A ray that starts inside contributes nothing.** [`raycast`] reports that
+/// as a hit at zero so the brush has somewhere to go. Here it would be a span
+/// with a fabricated `enter`, and a far cap placed from it sits at a depth
+/// measured from a surface the ray never crossed.
+pub fn first_solid_spans(
+    volume: &Volume,
+    origin: Vec3,
+    direction: Vec3,
+    max_distance: f32,
+) -> SolidSpans {
+    let voxel_size = volume.voxel_size();
+    let min_step = 0.25 * voxel_size;
+    let field = |t: f32| volume.sample_world(origin + direction * t) * voxel_size;
+
+    let mut previous_t = 0.0_f32;
+    let mut previous_d = field(0.0);
+    if previous_d <= 0.0 {
+        return SolidSpans::default();
+    }
+
+    let mut found = SolidSpans::default();
+    let mut enter: Option<f32> = None;
+    let mut inside = false;
+    let mut t = previous_d.max(min_step);
+
+    for _ in 0..MAX_STEPS {
+        if t > max_distance {
+            break;
+        }
+        if !inside && let Some(jump) = empty_brick_span(volume, origin + direction * t, direction) {
+            previous_t = t;
+            t += jump;
+            if t > max_distance {
+                break;
+            }
+        }
+        let d = field(t);
+        if !inside && d <= 0.0 {
+            let crossing = refine(&field, previous_t, t);
+            match enter {
+                None => enter = Some(crossing),
+                Some(_) => {
+                    // The second run: this is the surface behind, and it is all
+                    // the caller needs from it.
+                    found.next_enter = Some(crossing);
+                    break;
+                }
+            }
+            inside = true;
+        } else if inside && d > 0.0 {
+            // Arguments swapped: here `t` is the outside end of the bracket and
+            // `previous_t` the inside one. `refine` branches only on the sign
+            // it samples, so it needs no other change.
+            let crossing = refine(&field, t, previous_t);
+            if let Some(start) = enter
+                && found.first.is_none()
+            {
+                found.first = Some(Span { enter: start, exit: crossing });
+            }
+            inside = false;
+        }
+        previous_t = t;
+        previous_d = d;
+        t += if inside { (-previous_d).max(min_step) } else { previous_d.max(min_step) };
+    }
+
+    found
+}
+
 /// How far the ray may advance from `point` without any chance of stepping
 /// over a surface, when `point` sits in a brick that is empty everywhere.
 ///
@@ -298,5 +417,80 @@ mod tests {
                 hit.distance
             );
         }
+    }
+
+    /// Two balls in a row: the march must report the first as a complete span
+    /// and the second as the surface behind it.
+    ///
+    /// This is the measurement the depth cap is placed from, so getting the
+    /// second number wrong is what makes a cutter eat the wall behind a spur.
+    #[test]
+    fn a_ray_through_two_balls_reports_the_first_and_the_start_of_the_second() {
+        let mut volume = Volume::new(0.5);
+        volume.seed_sphere(Vec3::new(0.0, 0.0, 0.0), 10.0);
+        volume.seed_sphere(Vec3::new(0.0, 0.0, 40.0), 10.0);
+
+        let origin = Vec3::new(0.0, 0.0, -40.0);
+        let spans = first_solid_spans(&volume, origin, Vec3::Z, 200.0);
+
+        let first = spans.first.expect("the ray met the near ball");
+        // Enters at z = -10 and leaves at z = +10, measured from z = -40.
+        assert!((first.enter - 30.0).abs() < 1.0, "entered at {}", first.enter);
+        assert!((first.exit - 50.0).abs() < 1.0, "left at {}", first.exit);
+        let next = spans.next_enter.expect("the ray met the far ball");
+        // The far ball's near face is at z = 30.
+        assert!((next - 70.0).abs() < 1.0, "the next surface was reported at {next}");
+    }
+
+    /// One ball is one span and nothing behind it, which is what tells the
+    /// depth rule there is nothing to spare and the cut may go through.
+    #[test]
+    fn a_ray_through_one_ball_reports_no_surface_behind_it() {
+        let mut volume = Volume::new(0.5);
+        volume.seed_sphere(Vec3::ZERO, 10.0);
+
+        let spans = first_solid_spans(&volume, Vec3::new(0.0, 0.0, -40.0), Vec3::Z, 200.0);
+        assert!(spans.first.is_some(), "the ray missed the ball");
+        assert_eq!(spans.next_enter, None, "a lone ball reported something behind it");
+    }
+
+    /// A ray that misses reports nothing at all, rather than a span of zero
+    /// length that a cap could be placed from.
+    #[test]
+    fn a_ray_that_misses_reports_nothing() {
+        let mut volume = Volume::new(0.5);
+        volume.seed_sphere(Vec3::ZERO, 10.0);
+
+        let spans = first_solid_spans(&volume, Vec3::new(50.0, 0.0, -40.0), Vec3::Z, 200.0);
+        assert_eq!(spans, SolidSpans::default());
+    }
+
+    /// A ray that starts inside contributes nothing, deliberately: it has no
+    /// entry, and a cap placed from a fabricated one sits at a depth measured
+    /// from a surface the ray never crossed.
+    #[test]
+    fn a_ray_that_starts_inside_reports_no_span() {
+        let mut volume = Volume::new(0.5);
+        volume.seed_sphere(Vec3::ZERO, 10.0);
+
+        let spans = first_solid_spans(&volume, Vec3::ZERO, Vec3::Z, 200.0);
+        assert_eq!(spans.first, None, "a ray starting inside invented an entry");
+    }
+
+    /// **The interior leg has to step by the distance to the surface, not by
+    /// the floor.**
+    ///
+    /// Inside the solid the field is negative, so a step rule copied from
+    /// `raycast` picks `min_step` -- a quarter of a voxel -- and 512 steps buys
+    /// 128 voxels. This ball is 400 voxels across, so a march that crawls never
+    /// reaches the far side and reports no span at all.
+    #[test]
+    fn a_ray_crosses_a_body_wider_than_the_step_budget() {
+        let mut volume = Volume::new(0.5);
+        volume.seed_sphere(Vec3::ZERO, 100.0);
+
+        let spans = first_solid_spans(&volume, Vec3::new(0.0, 0.0, -200.0), Vec3::Z, 600.0);
+        let first = spans.first.expect("the march did not cross a 200 mm ball");
+        assert!((first.exit - first.enter - 200.0).abs() < 2.0, "span was {first:?}");
     }
 }

--- a/crates/brokkr-core/src/undo.rs
+++ b/crates/brokkr-core/src/undo.rs
@@ -71,12 +71,21 @@
 
 use std::collections::VecDeque;
 
+use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
 use crate::body::{Document, Node, NodeId, NodeMeta};
 use crate::brick::{Brick, BrickCoord, StoredBrick};
 use crate::mask::{MaskBrick, MaskField};
 use crate::volume::Volume;
+
+/// Bricks below which encoding a stroke's priors stays on one thread.
+///
+/// A dab touches a handful of bricks and encoding them is microseconds, where
+/// spinning up a fan-out for them costs more than it saves. Lower than
+/// `PARALLEL_MESH_THRESHOLD` because an encode is a much bigger unit of work
+/// than a mesh, so the crossover comes sooner.
+const PARALLEL_ENCODE_THRESHOLD: usize = 8;
 
 /// Default ceiling on the brick snapshots undo history holds.
 ///
@@ -164,10 +173,31 @@ impl StrokeEdit {
         }
         // Encoded here, at the one place a stroke's priors enter history, so
         // no caller has to remember to and no path can store a raw brick.
-        let encoded: PriorBricks = bricks
-            .into_iter()
-            .map(|(coord, brick)| (coord, brick.as_ref().map(StoredBrick::encode)))
-            .collect();
+        //
+        // **Across every core, because this is a third of what a cut costs.**
+        // Measured on the budget harness: a plane through the middle of the
+        // fixture spends 2.95 ms in `Volume::clip` and 3.7 ms encoding what it
+        // recorded -- 275 bricks of run-length encoding, a branch and a
+        // bit-compare per voxel over nine million voxels. It is not part of the
+        // cut and nobody had ever timed it separately from one.
+        //
+        // Every brick encodes independently: `StoredBrick::encode` reads one
+        // `&Brick` and returns, touching nothing shared. The map is drained
+        // into a `Vec` first because `FxHashMap`'s iterator is not a parallel
+        // one -- and collecting a Vec back out of `into_par_iter` PRESERVES
+        // ORDER, so the encoded list is exactly the list the serial form
+        // produced from the same map. Undo does not depend on that order, but
+        // silently changing it would be a change nobody asked for.
+        let raw: Vec<(BrickCoord, Option<Brick>)> = bricks.into_iter().collect();
+        let encoded: PriorBricks = if raw.len() < PARALLEL_ENCODE_THRESHOLD {
+            raw.into_iter()
+                .map(|(coord, brick)| (coord, brick.as_ref().map(StoredBrick::encode)))
+                .collect()
+        } else {
+            raw.into_par_iter()
+                .map(|(coord, brick)| (coord, brick.as_ref().map(StoredBrick::encode)))
+                .collect()
+        };
         Some(Self::from_parts(encoded, masks.into_iter().collect(), polarity))
     }
 

--- a/crates/brokkr-core/src/volume.rs
+++ b/crates/brokkr-core/src/volume.rs
@@ -8,8 +8,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::apron::ApronBuffer;
 use crate::brick::{
-    BRICK_DIM, BRICK_VOXELS, Brick, BrickCoord, INSIDE, NARROW_BAND, OUTSIDE, StoredBrick,
-    apron_index, brick_index,
+    APRON_VOXELS, BRICK_DIM, BRICK_VOXELS, Brick, BrickCoord, INSIDE, NARROW_BAND, OUTSIDE,
+    StoredBrick, apron_index, brick_index,
 };
 use crate::mask::{MaskBrick, MaskEdit, MaskField, MaskSlab, PROTECTED, UNMASKED};
 use crate::mesh::{BrickMesh, MeshScratch, mesh_apron};
@@ -805,7 +805,28 @@ impl Volume {
     /// shared by both bricks either side of a seam, so there is no halo to
     /// gather and no step at a brick boundary. See [`crate::mask`].
     pub fn mesh_brick(&self, coord: BrickCoord, scratch: &mut MeshScratch, out: &mut BrickMesh) {
+        if self.neighbourhood_has_no_surface(coord) {
+            out.clear();
+            return;
+        }
         self.gather_apron(coord, &mut scratch.apron);
+        if !apron_straddles_zero(scratch.apron.samples()) {
+            // **The second gate, and it catches what the first cannot.**
+            // `neighbourhood_has_no_surface` decides from the stored form alone
+            // and gives up the moment any of the 27 is dense -- which is most
+            // of the bricks along a cut face, since the face itself is dense.
+            // Their aprons still turn out to be all one sign surprisingly
+            // often: an absent brick beside a solid one only owns boundary
+            // quads where the solid's outermost voxel layer actually straddles
+            // within this brick's own apron window, and after a cut it usually
+            // does not.
+            //
+            // The gather has been paid by this point and is mostly `memcpy` of
+            // contiguous runs. What is skipped is surface nets over 35,937
+            // cells, which is the expensive half.
+            out.clear();
+            return;
+        }
         mesh_apron(&scratch.apron, coord, self.voxel_size, &mut scratch.surface_nets, out);
         self.mask.bytes_at_cells(coord, &out.cells, &mut out.mask);
         debug_assert_eq!(
@@ -813,6 +834,93 @@ impl Volume {
             out.vertices.len(),
             "one mask byte per vertex, or the pool writes a short attribute slice"
         );
+    }
+}
+
+/// Whether an apron holds values either side of zero, so a surface can cross it.
+///
+/// Surface nets emits a vertex only where a cell's eight corners straddle zero,
+/// so an apron entirely one side of zero produces nothing at all. Answering that
+/// costs one linear scan of 39,304 floats -- which the CPU does at memory speed
+/// and can vectorise -- against a surface-nets pass over 35,937 cells, which it
+/// cannot.
+///
+/// **Zero counts as being on both sides**, so an apron containing one is sent
+/// down the full path. `>= 0` and `> 0` split the lattice differently and which
+/// convention the mesher uses is not this function's to assume.
+///
+/// The two accumulators are deliberately kept separate rather than short
+/// circuiting on the first sign change: a branch per sample would cost more
+/// than the arithmetic on the overwhelmingly common case, which is an apron
+/// that is entirely one sign and has to be read to the end anyway.
+#[inline]
+fn apron_straddles_zero(samples: &[f32; APRON_VOXELS]) -> bool {
+    let mut any_positive = false;
+    let mut any_non_positive = false;
+    for value in samples {
+        any_positive |= *value > 0.0;
+        any_non_positive |= *value <= 0.0;
+    }
+    any_positive && any_non_positive
+}
+
+impl Volume {
+    /// Whether no surface can pass through a brick, decided from its
+    /// neighbourhood's stored form alone.
+    ///
+    /// **This is the cut's single biggest saving, and it is a saving on the
+    /// remesh rather than on the cut.** Measured on the budget harness: a plane
+    /// through the middle of the fixture dirties 669 bricks and **540 of them
+    /// mesh to nothing** -- 81%. A shaped cut is much the same, 63% to 68%.
+    /// Every one of those still paid a 34-cubed apron gather (39,304 samples
+    /// copied) and a full surface-nets pass over 35,937 cells, to emit zero
+    /// triangles. That is what a cut does: it removes material, so most of what
+    /// it dirties ends up empty on one side or solid on the other.
+    ///
+    /// # Why it is sound
+    ///
+    /// A brick's mesh comes from its apron, and the apron is gathered from
+    /// exactly this brick and its 26 neighbours. If every one of them is stored
+    /// as a single value -- a tile, or absent, which reads as [`OUTSIDE`] --
+    /// then the apron is piecewise constant with no value other than those.
+    /// Surface nets emits a vertex only where a cell's corners straddle zero,
+    /// so if all of those values are strictly one side of zero, no cell can
+    /// straddle and the mesh is empty.
+    ///
+    /// A `Dense` neighbour takes the slow path even if every voxel in it
+    /// happens to share a sign. That is deliberate: proving it would cost the
+    /// 32,768-voxel scan this is trying to avoid, and a dense brick beside a
+    /// changed one is nearly always a brick with surface in it.
+    ///
+    /// **Zero is treated as a crossing**, not as a sign. `>= 0` and `> 0` split
+    /// the lattice differently and the mesher's convention is not this
+    /// function's to assume, so a stored zero anywhere sends the brick down the
+    /// full path rather than guessing which side it belongs to.
+    fn neighbourhood_has_no_surface(&self, coord: BrickCoord) -> bool {
+        let mut positive = 0u32;
+        let mut negative = 0u32;
+        for dz in -1..=1 {
+            for dy in -1..=1 {
+                for dx in -1..=1 {
+                    let neighbour = BrickCoord(coord.0 + IVec3::new(dx, dy, dz));
+                    let value = match self.bricks.get(&neighbour) {
+                        // Absent reads as outside, which is the common case and
+                        // the one this exists for: the air a cut opens up.
+                        None => OUTSIDE,
+                        Some(Brick::Uniform(value)) => *value,
+                        Some(Brick::Dense(_)) => return false,
+                    };
+                    if value > 0.0 {
+                        positive += 1;
+                    } else if value < 0.0 {
+                        negative += 1;
+                    } else {
+                        return false;
+                    }
+                }
+            }
+        }
+        positive == 0 || negative == 0
     }
 
     /// Mesh many bricks at once, across every core.
@@ -1496,6 +1604,33 @@ impl Volume {
         self.recorder.is_some()
     }
 
+    /// Heap bytes the open stroke recorder is holding, or zero when none is.
+    ///
+    /// **This is the transient peak, and it is not the number history budgets
+    /// against.** [`crate::StrokeEdit`] run-length encodes what it is given, so
+    /// [`crate::StrokeEdit::bytes`] reports what the entry costs once it is
+    /// pushed; between [`Volume::begin_stroke`] and [`Volume::end_stroke`] the
+    /// recorder holds every captured brick as it found it, at 128 KB each for a
+    /// dense one. A cut along the widest axis of a large scan therefore peaks at
+    /// hundreds of megabytes that the history budget never sees, is never
+    /// charged for, and would not refuse.
+    ///
+    /// It exists to be measured. Nothing enforces a limit on it today, and a
+    /// limit invented without a measurement is how a legitimate cut on a large
+    /// body starts being refused; anything that does eventually refuse should
+    /// quote this rather than a ratio.
+    pub fn recorder_bytes(&self) -> usize {
+        let Some(recorder) = self.recorder.as_ref() else {
+            return 0;
+        };
+        // The map's own entries are counted too. They are small beside a dense
+        // brick, but a cut that captured ten thousand absent bricks holds ten
+        // thousand entries and no heap at all, and reporting zero for that
+        // would read as "the recorder is empty".
+        let entries = recorder.len() * (size_of::<BrickCoord>() + size_of::<Option<Brick>>());
+        entries + recorder.values().filter_map(Option::as_ref).map(Brick::heap_bytes).sum::<usize>()
+    }
+
     /// Capture a brick's prior contents if a stroke is being recorded and this
     /// is the first time it has been touched. Returns whether it recorded.
     pub(crate) fn record_for_undo(&mut self, coord: BrickCoord) -> bool {
@@ -1889,13 +2024,39 @@ impl Volume {
         self.bricks.remove(&coord)
     }
 
-    /// Drop a brick entirely, so it reads as empty space again.
+    /// Drop a brick, handing its storage straight to the recorder.
     ///
-    /// Used by the plane cut: a brick wholly past the cut is `OUTSIDE`
-    /// everywhere, and an absent brick already reads that way, so removing it
-    /// is both the correct answer and the free one.
-    pub(crate) fn remove_brick(&mut self, coord: BrickCoord) {
-        self.bricks.remove(&coord);
+    /// **The pair it replaces copies 128 KB it did not have to.**
+    /// `record_for_undo` clones the brick out of the map so undo has the prior,
+    /// and a bare remove then throws the original away -- so the clone existed
+    /// only because the two steps could not see each other. Where a brick is
+    /// being dropped rather than rewritten, the original IS the prior, and it
+    /// can be moved into the recorder instead.
+    ///
+    /// A cut is where this pays: it drops whole bricks by the hundred. On the
+    /// budget harness a plane through the middle of the fixture removes 151
+    /// bricks outright, and every dense one of those was a 128 KB memcpy that
+    /// bought nothing.
+    ///
+    /// The first-touch rule is preserved exactly: a brick already in the
+    /// recorder keeps the contents recorded the first time, and this one is
+    /// discarded, which is what makes a stroke that passes over a brick twice
+    /// still restore the state before the stroke rather than before the second
+    /// pass. [`Volume::take_brick`] is the equivalent for rewriting in place,
+    /// where a copy really is needed because the brick is going back.
+    ///
+    /// **There is deliberately no bare remover beside this.** There was, and
+    /// its only caller was the cut, which paired it with `record_for_undo` --
+    /// so every dropped brick was cloned and then discarded. A bare remover is
+    /// exactly the shape a future caller reaches for, and it would pay the same
+    /// cost again, so it is gone rather than kept for symmetry. A caller with
+    /// no recorder open loses nothing by using this one.
+    pub(crate) fn remove_brick_recording(&mut self, coord: BrickCoord) {
+        let prior = self.bricks.remove(&coord);
+        let Some(recorder) = self.recorder.as_mut() else {
+            return;
+        };
+        recorder.entry(coord).or_insert(prior);
     }
 
     /// World space bounds of the SURFACE, or `None` when there is none.

--- a/crates/brokkr-gpu/benches/render.rs
+++ b/crates/brokkr-gpu/benches/render.rs
@@ -12,7 +12,7 @@
 
 use std::time::{Duration, Instant};
 
-use brokkr_core::{BrickCoord, BrickMesh, Volume};
+use brokkr_core::{BrickCoord, BrickMesh, ClipPlane, Volume};
 use brokkr_gpu::{
     Frustum, PixelRect, SculptRenderer, SlotKey, THE_ONLY_BODY, THUMBNAIL_SIZE, Uniforms,
 };
@@ -52,6 +52,127 @@ fn view_projection(distance: f32) -> Mat4 {
         distance + MODEL_RADIUS * 4.0,
     );
     projection * view
+}
+
+/// Add a sphere to whatever is already there.
+///
+/// **Not `seed_sphere`, which OVERWRITES**: seeding clears every brick its box
+/// touches before writing, so seeding a small sphere onto a large one carves a
+/// moat around it instead of adding a lump to it.
+fn union_sphere(volume: &mut Volume, centre: Vec3, radius: f32) {
+    let voxel_size = volume.voxel_size();
+    let band = brokkr_core::NARROW_BAND * voxel_size;
+    let (lo, hi) =
+        volume.voxel_bounds(centre - (radius + band * 2.0), centre + (radius + band * 2.0));
+    volume.edit_voxels(lo, hi, |_, position, value| {
+        let outside = (position.distance(centre) - radius) / voxel_size;
+        value.min(outside).clamp(brokkr_core::INSIDE, brokkr_core::OUTSIDE)
+    });
+}
+
+/// **Thirty cuts in a row, watching the mesh pool's bump pointer.**
+///
+/// This is the one failure mode the cut tool's design names as a live risk, and
+/// it is invisible from `brokkr-core`: the pool's `BlockAllocator` never splits
+/// or merges blocks, a freed block is reusable only by a request rounding to
+/// the same granule count, and it is the bump `watermark` -- not `live` -- that
+/// fails an allocation. A cut only ever SHRINKS the meshes it touches, so every
+/// changed brick can orphan a block in a large granule class and take a fresh
+/// one off the bump. `MeshPool::reset` is the only cure and, in the whole
+/// application, is reached from `rebuild_everything` and from nothing else --
+/// no editing operation calls it.
+///
+/// So: trim thirty spurs, re-uploading what changed each time exactly as the
+/// application does, and report whether the watermark climbs while `live`
+/// stays flat. A watermark that ends near `live` means the allocator is
+/// reusing; one that ends far above it is the shape of `MESH POOL FULL` with
+/// most of the pool empty.
+fn measure_repeated_cuts(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    renderer: &mut SculptRenderer,
+) {
+    const SPURS: usize = 30;
+    const RADIUS: f32 = 30.0;
+    // Coarser than the render rows above: this measures allocator behaviour
+    // over thirty edits, and the thirty edits are the expensive part.
+    const VOXEL: f32 = 0.25;
+
+    let mut volume = Volume::new(VOXEL);
+    volume.seed_sphere(Vec3::ZERO, RADIUS);
+    let mut directions = Vec::with_capacity(SPURS);
+    for index in 0..SPURS {
+        let angle = index as f32 / SPURS as f32 * std::f32::consts::TAU;
+        let tilt = (index as f32 * 0.37).sin() * 0.7;
+        let direction =
+            Vec3::new(angle.cos() * tilt.cos(), tilt.sin(), angle.sin() * tilt.cos()).normalize();
+        union_sphere(&mut volume, direction * RADIUS, RADIUS * 0.12);
+        directions.push(direction);
+    }
+    volume.mark_everything_dirty();
+
+    let mut coords: Vec<BrickCoord> = Vec::new();
+    let mut meshes: Vec<BrickMesh> = Vec::new();
+    let publish = |renderer: &mut SculptRenderer,
+                   volume: &mut Volume,
+                   coords: &mut Vec<BrickCoord>,
+                   meshes: &mut Vec<BrickMesh>| {
+        coords.clear();
+        volume.take_dirty(coords);
+        while meshes.len() < coords.len() {
+            meshes.push(BrickMesh::default());
+        }
+        volume.mesh_bricks(coords, &mut meshes[..coords.len()]);
+        for (coord, mesh) in coords.iter().zip(meshes.iter()) {
+            renderer.upload_brick(
+                device,
+                queue,
+                SlotKey { body: THE_ONLY_BODY, coord: *coord },
+                mesh,
+            );
+        }
+        coords.len()
+    };
+
+    publish(renderer, &mut volume, &mut coords, &mut meshes);
+    let seeded = renderer.stats();
+    println!(
+        "
+thirty cuts in a row, mesh pool"
+    );
+    println!(
+        "  after seeding:  {:>9} live, {:>9} watermark",
+        seeded.vertices, seeded.vertices_watermark
+    );
+
+    let mut republished = 0usize;
+    for direction in &directions {
+        let plane =
+            ClipPlane::new(*direction * (RADIUS * 0.94), *direction).expect("a unit normal");
+        // Bounded, as the shaped cut is: a cap a little BEYOND the spur, so
+        // this measures thirty trims rather than thirty cuts through the model.
+        // The two normals face each other and the region removed is the shell
+        // between them -- putting the cap INSIDE the first plane instead makes
+        // the intersection empty and the whole loop a no-op, which reports a
+        // perfectly flat watermark for entirely the wrong reason.
+        let cap = ClipPlane::new(*direction * (RADIUS * 1.25), -*direction).expect("a unit normal");
+        volume.clip_convex(&[plane, cap]);
+        republished += publish(renderer, &mut volume, &mut coords, &mut meshes);
+    }
+
+    let after = renderer.stats();
+    println!(
+        "  after {SPURS} cuts: {:>9} live, {:>9} watermark   ({republished} brick re-uploads)",
+        after.vertices, after.vertices_watermark
+    );
+    let headroom = after.vertices_watermark as f64 / after.vertices.max(1) as f64;
+    println!(
+        "  watermark is {headroom:.2}x live, and the pool fails at {:.0} MB of watermark",
+        after.vertex_capacity as f64 * 24.0 / (1024.0 * 1024.0)
+    );
+    if after.overflowed > 0 {
+        eprintln!("  MESH POOL OVERFLOWED during thirty ordinary cuts");
+    }
 }
 
 fn main() {
@@ -202,6 +323,14 @@ fn main() {
     );
 
     all_passed &= thumbnail_row(&device, &queue, &renderer, &volume, stats.bricks);
+
+    // Its own model and its own pool state, so it cannot be read as a comment
+    // on the rows above. Report only: this is the first measurement of the
+    // allocator under repeated editing, and a pass mark drawn on the same day
+    // as the first measurement is not a budget.
+    let mut cut_renderer = SculptRenderer::new(&device, &queue, TARGET_FORMAT);
+    cut_renderer.resize(&device, WIDTH, HEIGHT);
+    measure_repeated_cuts(&device, &queue, &mut cut_renderer);
 
     if !all_passed {
         eprintln!("\nRENDER BUDGET EXCEEDED");


### PR DESCRIPTION
Builds `docs/CUT-TOOL-PLAN.md`, all eight phases, and fixes three bugs
in shipped code that building it turned up.

## What the tool does

Arm with `c` or the CUT button, then one drag. The shape is inferred
and always previewed:

- **straight drag** — today's plane cut, bit-for-bit
- **open arc** — extended past both ends and hulled
- **closed loop** — the hull of what you drew

`shift` cuts through, `ctrl` selects instead of cutting, `Escape`
mid-drag drops the shape and leaves the tool armed. Still one drag, one
undo entry, still `max(field, cutter)`.

`Volume::clip` and `Document::clip` became one-line wrappers over
`clip_convex`, so every existing call site and all 25 clip tests are
untouched: `min` over one element IS the element.

## The cutter is a prism, not a pyramid

Side planes are built along the view direction rather than through the
eye, so the hole is the same size going in and coming out. The obvious
construction makes the removed region the view frustum's own wedge: at
the framing this app picks, the exit hole measured **1.81× the entry
diameter**. This is orthographic-cut behaviour without an orthographic
camera — the camera is untouched.

The straight drag keeps its plane through the eye. A half-space has no
aperture, so there is nothing for a taper to widen.

## Bounded by default

A far cap is placed from a grid of rays through the hull, one band past
the deepest exit and **clamped** to stay a band clear of whatever is
behind. The obvious rule — one band past the exit, unconditionally —
eats a quarter of a millimetre out of a wall half a millimetre behind a
spur, and `is_printable` returns true for the result because it counts
holes and winding and has no thickness term. Where there is not room
for both, the tool declines and says so rather than quietly thinning
the wall.

## Three bugs in shipped code

**Partial masking of a cut never worked.** `cut_voxel` blended toward
the raw cut distance — unbounded, four thousand for a plane a metre
from a quarter-millimetre voxel — and clamped only the finished value.
A voxel at -3 under half protection with the cutter twenty voxels away
came out at OUTSIDE: removed exactly as completely as an unprotected
one. The error grew with distance from the cutter, which is why it
survived — a cut drawn at a mask's edge, which is how anyone tests this
by hand, is the one case where the two orders nearly agree.

**Flatten and Clay had the same bug**, for the same reason: they blend
toward an unbounded plane distance. Measured on a half-protected
stamp, **505 of 15,536 moved Flatten voxels and 2,783 of 28,444 Clay
voxels took the full unmasked effect**. Smooth and Draw were always
right and are untouched; so are the Move/warp paths, whose `w * free`
form is what the gradient bound at `brush.rs:1969` is stated against.

**`bricks_spared_by_mask` undercounted** — this branch's own bug, from
the plane pruning. 152 bricks reported where 216 were spared. A fully
blocked cut could report "the cut missed the model", the one message
that sends a user to redraw a gesture that was never the problem.

Unmasked behaviour is bit-identical in all three cases, which is what
made them safe to change. For the brush that was verified by A/B — real
stamps, before and after, identical checksums — not by argument.

## Performance

`Document::clip` **11.9 → 7.4 ms** on the bench fixture. The three
costs were remesh 5.17, undo encode 3.62, cut 2.89. The classification
was never any of it, at 0.013 ms for seventeen planes against a body
they miss.

- **81% of the remesh was building nothing.** 540 of 669 dirtied bricks
  mesh to zero triangles — a cut removes material — and each paid a
  34³ apron gather and a full surface-nets pass to say so. Remesh −53%.
- **The undo encode was serial** beside a `par_iter` doing the same
  shape of job. −71%.
- **Half the recorded bricks were copied for nothing**: a dropped brick
  IS the prior undo needs. Cut −30%.
- **The shaped cut went 17.8 → 1.68 ms** across per-brick plane
  pruning, specialised write loops for one to four planes, and a
  plane-major fallback. All bit-exact against the definition written
  out through `edit_voxels`.

Worth recording: routing the **single**-plane path through a slice, the
obvious way to write this, cost 9.6 ms against 2.2 — a four-fold
regression in the shipping cut, invisible to every test, caused by
nothing but the plane no longer being a value the compiler could keep
in a register.

## Verified in the running app

Driven with `scripts/drive.py`: the preview draws over the model, the
lasso punches the polygon it showed, the curve leaves the arch it
showed, ctrl+lasso paints a visibly feathered selection that splits off
as its own body, and the brush ring is gone while the cut is armed.

The preview needed the compositor to find at all — it was first
projected onto the plane through the camera target, which is *inside*
the model, so the depth test hid it while every headless assertion
passed. `the_live_preview_is_drawn_in_front_of_the_model` now pins it.

## Caveats

- **The bench is not idle-machine data.** Cut rows are min-of-five and
  comparable to each other, but no absolute timing here is publishable
  until someone runs it idle. The r80 fast-drag brush row was OVER at
  8.1 ms earlier in the session and passed at 7.15 ms later; it fails
  identically on stock `main`, so it is load, not a regression.
- **Mesh pool fragmentation is real and measured**: thirty trims take
  it from 1.11× to 1.45× watermark over live. The banner now tells
  fragmentation apart from real fullness, because "delete a body or
  resample coarser" is advice about a problem the user does not have
  after thirty successful trims. Whether a cut should auto-reset the
  pool above some ratio is **still open** and wants a decision.
- **v1 is convex-only.** A C-shaped lasso is hulled, so the gap goes
  too. That is visible before release because the preview draws the
  decimated hull rather than the stroke. `docs/CUT-TOOL-PLAN.md` §6
  records why the tempting fix — a union of ear-clipped pieces — is
  actively broken on an SDF.

## Checks

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D
warnings` and `cargo check -p brokkr-app --target
x86_64-pc-windows-gnu` all clean on the pinned 1.98.0 toolchain.
**1471 tests pass**, up from 1411.
