### PR TITLE
Make Windows say what it found before it says "no tablet found"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ real hardware.
 
 ### Fixed
 
+- **Windows said "no tablet found" to everyone.** The PEN panel and the bug
+  report read a device list that only the Linux scanner ever filled, so on
+  Windows the line was a default rather than a finding, whether or not a pen
+  was reporting. Windows now enumerates its HID devices at startup, names the
+  pen with its pressure range, tilt and eraser, and listens for a pen whichever
+  of the two top-level usages its driver presents. `brokkrsculpt.exe --tablets
+  > tablets.txt` lists every HID device and says why each is or is not a
+  stylus, including the mouse-mode case, which is the one to check first: a
+  tablet whose driver has Windows Ink switched off is a mouse to every
+  application. A tablet plugged in after launch is not seen until a relaunch.
+
 - **Vendor forks and every packaging format are found, not just OrcaSlicer.**
   Snapmaker ships its own OrcaSlicer fork, BambuStudio is the same lineage again,
   and any of them can arrive as a native package, an AppImage, a flatpak or a

--- a/crates/brokkr-app/src/raw_input.rs
+++ b/crates/brokkr-app/src/raw_input.rs
@@ -28,13 +28,15 @@
 //! rather than ours.
 
 use windows_sys::Win32::Devices::HumanInterfaceDevice::{
-    HIDP_STATUS_SUCCESS, HIDP_VALUE_CAPS, HidP_GetUsageValue, HidP_GetUsages, HidP_GetValueCaps,
-    HidP_Input, PHIDP_PREPARSED_DATA,
+    HIDP_BUTTON_CAPS, HIDP_STATUS_SUCCESS, HIDP_VALUE_CAPS, HidP_GetButtonCaps, HidP_GetUsageValue,
+    HidP_GetUsages, HidP_GetValueCaps, HidP_Input, PHIDP_PREPARSED_DATA,
 };
-use windows_sys::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows_sys::Win32::Foundation::{HANDLE, HWND, LPARAM, LRESULT, WPARAM};
 use windows_sys::Win32::UI::Input::{
-    GetRawInputData, GetRawInputDeviceInfoW, HRAWINPUT, RAWINPUT, RAWINPUTDEVICE, RAWINPUTHEADER,
-    RID_INPUT, RIDEV_INPUTSINK, RIDI_PREPARSEDDATA, RegisterRawInputDevices,
+    GetRawInputData, GetRawInputDeviceInfoW, GetRawInputDeviceList, HRAWINPUT, RAWINPUT,
+    RAWINPUTDEVICE, RAWINPUTDEVICELIST, RAWINPUTHEADER, RID_DEVICE_INFO, RID_INPUT,
+    RIDEV_INPUTSINK, RIDI_DEVICEINFO, RIDI_DEVICENAME, RIDI_PREPARSEDDATA, RIM_TYPEHID,
+    RegisterRawInputDevices,
 };
 use windows_sys::Win32::UI::WindowsAndMessaging::{
     CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, HWND_MESSAGE, MSG,
@@ -55,12 +57,7 @@ pub const PAGE_DIGITIZER: u16 = 0x0D;
 ///
 /// `class` must be unique per caller. Registering a window class twice fails,
 /// and two devices read on two threads need two windows.
-pub fn pump(
-    class: &str,
-    usage_page: u16,
-    usage: u16,
-    on_report: impl Fn(PHIDP_PREPARSED_DATA, &[u8]),
-) {
+pub fn pump(class: &str, usages: &[(u16, u16)], on_report: impl Fn(PHIDP_PREPARSED_DATA, &[u8])) {
     let class_name: Vec<u16> = class.encode_utf16().chain(std::iter::once(0)).collect();
     let mut descriptor: WNDCLASSW = unsafe { std::mem::zeroed() };
     descriptor.lpfnWndProc = Some(wndproc);
@@ -89,15 +86,29 @@ pub fn pump(
         return;
     }
 
-    let device = RAWINPUTDEVICE {
-        usUsagePage: usage_page,
-        usUsage: usage,
-        // Delivered even unfocused, which this window always is: without this
-        // flag a message-only window receives nothing at all.
-        dwFlags: RIDEV_INPUTSINK,
-        hwndTarget: window,
+    // Every usage in one registration. A pen is usage 0x02 on the digitizer
+    // page by the HID specification, but a vendor driver may present its
+    // top-level collection as 0x01, the plain "digitizer", and a registration
+    // for the one would never hear from the other.
+    let devices: Vec<RAWINPUTDEVICE> = usages
+        .iter()
+        .map(|(usage_page, usage)| RAWINPUTDEVICE {
+            usUsagePage: *usage_page,
+            usUsage: *usage,
+            // Delivered even unfocused, which this window always is: without
+            // this flag a message-only window receives nothing at all.
+            dwFlags: RIDEV_INPUTSINK,
+            hwndTarget: window,
+        })
+        .collect();
+    let registered = unsafe {
+        RegisterRawInputDevices(
+            devices.as_ptr(),
+            devices.len() as u32,
+            size_of::<RAWINPUTDEVICE>() as u32,
+        )
     };
-    if unsafe { RegisterRawInputDevices(&device, 1, size_of::<RAWINPUTDEVICE>() as u32) } == 0 {
+    if registered == 0 {
         return;
     }
 
@@ -255,5 +266,122 @@ pub fn range(data: PHIDP_PREPARSED_DATA, usage_page: u16, usage: u16) -> Option<
             && !cap.IsRange
             && unsafe { cap.Anonymous.NotRange.Usage } == usage;
         matches.then_some((cap.LogicalMin, cap.LogicalMax))
+    })
+}
+
+/// One HID device Windows knows about, as Raw Input describes it.
+#[derive(Debug, Clone)]
+pub struct HidDevice {
+    pub handle: HANDLE,
+    /// The device interface path, which carries the vendor and product ids
+    /// and is the only name available without opening the device.
+    pub path: String,
+    pub usage_page: u16,
+    pub usage: u16,
+    pub vendor: u16,
+    pub product: u16,
+}
+
+/// Every HID device Raw Input can see right now.
+///
+/// **This is what makes "no tablet found" a statement rather than a default
+/// on Windows.** The pen pipe used to be the only thing that ran here: a
+/// registration and a message loop, with no enumeration at all, so the device
+/// list the panel and the bug report read from stayed empty for every Windows
+/// user whether or not a pen was reporting. Mice and keyboards are skipped;
+/// they are not HID collections to Raw Input.
+pub fn devices() -> Vec<HidDevice> {
+    let mut count = 0u32;
+    let size = size_of::<RAWINPUTDEVICELIST>() as u32;
+    if unsafe { GetRawInputDeviceList(std::ptr::null_mut(), &mut count, size) } == u32::MAX
+        || count == 0
+    {
+        return Vec::new();
+    }
+    let mut list: Vec<RAWINPUTDEVICELIST> = vec![unsafe { std::mem::zeroed() }; count as usize];
+    let got = unsafe { GetRawInputDeviceList(list.as_mut_ptr(), &mut count, size) };
+    if got == u32::MAX {
+        return Vec::new();
+    }
+    list.truncate(got as usize);
+
+    list.into_iter()
+        .filter(|entry| entry.dwType == RIM_TYPEHID)
+        .filter_map(|entry| {
+            let mut info: RID_DEVICE_INFO = unsafe { std::mem::zeroed() };
+            info.cbSize = size_of::<RID_DEVICE_INFO>() as u32;
+            let mut size = info.cbSize;
+            let read = unsafe {
+                GetRawInputDeviceInfoW(
+                    entry.hDevice,
+                    RIDI_DEVICEINFO,
+                    (&mut info as *mut RID_DEVICE_INFO).cast(),
+                    &mut size,
+                )
+            };
+            if read == u32::MAX || info.dwType != RIM_TYPEHID {
+                return None;
+            }
+            let hid = unsafe { info.Anonymous.hid };
+            Some(HidDevice {
+                handle: entry.hDevice,
+                path: device_name(entry.hDevice),
+                usage_page: hid.usUsagePage,
+                usage: hid.usUsage,
+                vendor: hid.dwVendorId as u16,
+                product: hid.dwProductId as u16,
+            })
+        })
+        .collect()
+}
+
+/// The device interface path, or an empty string when Windows will not say.
+fn device_name(device: HANDLE) -> String {
+    let mut length = 0u32;
+    unsafe { GetRawInputDeviceInfoW(device, RIDI_DEVICENAME, std::ptr::null_mut(), &mut length) };
+    if length == 0 {
+        return String::new();
+    }
+    let mut buffer: Vec<u16> = vec![0; length as usize];
+    let read = unsafe {
+        GetRawInputDeviceInfoW(device, RIDI_DEVICENAME, buffer.as_mut_ptr().cast(), &mut length)
+    };
+    if read == u32::MAX {
+        return String::new();
+    }
+    let end = buffer.iter().position(|c| *c == 0).unwrap_or(buffer.len());
+    String::from_utf16_lossy(&buffer[..end])
+}
+
+/// The preparsed report descriptor of a device, for asking about its usages
+/// before any report has arrived.
+pub fn preparsed(device: HANDLE) -> Option<Vec<u8>> {
+    preparsed_data(device)
+}
+
+/// Whether the device declares a button usage at all, whatever its state.
+///
+/// [`button`] answers for one report; this answers for the device, which is
+/// what a panel that says "eraser" before the pen has been turned over needs.
+pub fn has_button(data: PHIDP_PREPARSED_DATA, usage_page: u16, usage: u16) -> bool {
+    let mut count = 0u16;
+    unsafe { HidP_GetButtonCaps(HidP_Input, std::ptr::null_mut(), &mut count, data) };
+    if count == 0 {
+        return false;
+    }
+    let mut caps: Vec<HIDP_BUTTON_CAPS> = vec![unsafe { std::mem::zeroed() }; count as usize];
+    let status = unsafe { HidP_GetButtonCaps(HidP_Input, caps.as_mut_ptr(), &mut count, data) };
+    if status != HIDP_STATUS_SUCCESS {
+        return false;
+    }
+    caps[..count as usize].iter().any(|cap| {
+        cap.UsagePage == usage_page
+            && if cap.IsRange {
+                let range = unsafe { cap.Anonymous.Range };
+                (range.UsageMin..=range.UsageMax).contains(&usage)
+            } else {
+                let single = unsafe { cap.Anonymous.NotRange.Usage };
+                single == usage
+            }
     })
 }

--- a/crates/brokkr-app/src/spacemouse.rs
+++ b/crates/brokkr-app/src/spacemouse.rs
@@ -1098,8 +1098,7 @@ mod backend {
             .spawn(move || {
                 raw_input::pump(
                     "BrokkrPuckSink",
-                    PAGE_GENERIC,
-                    USAGE_MULTI_AXIS,
+                    &[(PAGE_GENERIC, USAGE_MULTI_AXIS)],
                     |data, report| {
                         decode(&shared, data, report);
                     },

--- a/crates/brokkr-app/src/tablet.rs
+++ b/crates/brokkr-app/src/tablet.rs
@@ -387,8 +387,10 @@ fn normalise_signed(value: i32, minimum: i32, maximum: i32) -> f32 {
 ///
 /// Platform independent so the verdicts and the `--tablets` wording are
 /// tested here, on the machine that has the test suite, rather than only on
-/// the machine that has the tablet.
-#[cfg_attr(target_os = "linux", allow(dead_code))]
+/// the machine that has the tablet. Compiled for Windows, which reads it, and
+/// for every test build, which is where it is exercised; a release build on
+/// Linux or macOS has no use for it and `-D warnings` would say so.
+#[cfg(any(target_os = "windows", test))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct HidSummary {
     pub vendor: u16,
@@ -403,12 +405,18 @@ pub(crate) struct HidSummary {
 }
 
 /// The HID digitizer page, and the two top-level usages a pen arrives as.
+#[cfg(any(target_os = "windows", test))]
 pub(crate) const HID_PAGE_DIGITIZER: u16 = 0x0D;
+#[cfg(any(target_os = "windows", test))]
 pub(crate) const HID_USAGE_DIGITIZER: u16 = 0x01;
+#[cfg(any(target_os = "windows", test))]
 pub(crate) const HID_USAGE_PEN: u16 = 0x02;
+#[cfg(any(target_os = "windows", test))]
 const HID_USAGE_TOUCH_SCREEN: u16 = 0x04;
+#[cfg(any(target_os = "windows", test))]
 const HID_USAGE_TOUCH_PAD: u16 = 0x05;
 
+#[cfg(any(target_os = "windows", test))]
 impl HidSummary {
     /// A name a person can read, from the vendor id when it is one this
     /// application knows and the raw ids otherwise.
@@ -455,7 +463,7 @@ impl HidSummary {
 
 /// The `--tablets` report for a scanner that sees HID devices, from what it
 /// found and whether the live pipe has heard anything.
-#[cfg_attr(target_os = "linux", allow(dead_code))]
+#[cfg(any(target_os = "windows", test))]
 pub(crate) fn hid_report(devices: &[HidSummary], pipe: &str) -> String {
     use std::fmt::Write;
     let mut out = String::new();

--- a/crates/brokkr-app/src/tablet.rs
+++ b/crates/brokkr-app/src/tablet.rs
@@ -382,6 +382,133 @@ fn normalise_signed(value: i32, minimum: i32, maximum: i32) -> f32 {
     (value as f32 / extent as f32).clamp(-1.0, 1.0)
 }
 
+/// One HID device as the Windows and macOS scanners describe it, reduced to
+/// what decides whether it is a stylus.
+///
+/// Platform independent so the verdicts and the `--tablets` wording are
+/// tested here, on the machine that has the test suite, rather than only on
+/// the machine that has the tablet.
+#[cfg_attr(target_os = "linux", allow(dead_code))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HidSummary {
+    pub vendor: u16,
+    pub product: u16,
+    pub usage_page: u16,
+    pub usage: u16,
+    /// The tip pressure range the descriptor declares, if it declares one.
+    pub pressure: Option<(i32, i32)>,
+    pub has_tilt: bool,
+    pub has_eraser: bool,
+    pub path: String,
+}
+
+/// The HID digitizer page, and the two top-level usages a pen arrives as.
+pub(crate) const HID_PAGE_DIGITIZER: u16 = 0x0D;
+pub(crate) const HID_USAGE_DIGITIZER: u16 = 0x01;
+pub(crate) const HID_USAGE_PEN: u16 = 0x02;
+const HID_USAGE_TOUCH_SCREEN: u16 = 0x04;
+const HID_USAGE_TOUCH_PAD: u16 = 0x05;
+
+impl HidSummary {
+    /// A name a person can read, from the vendor id when it is one this
+    /// application knows and the raw ids otherwise.
+    pub fn name(&self) -> String {
+        let vendor = match self.vendor {
+            0x056A => "Wacom",
+            0x256C => "Huion or Gaomon",
+            0x28BD => "XP-Pen",
+            0x2D1F => "Wacom (Intuos)",
+            0x04F3 => "Elan",
+            0x1B96 => "N-Trig",
+            _ => "",
+        };
+        if vendor.is_empty() {
+            format!("HID {:04X}:{:04X}", self.vendor, self.product)
+        } else {
+            format!("{vendor} {:04X}:{:04X}", self.vendor, self.product)
+        }
+    }
+
+    /// `Ok` with what will be read from it, or `Err` with why it is not a
+    /// stylus. Mirrors the Linux scanner's rules: a pen without pressure is
+    /// not worth opening, and a touch device is not a pen however much
+    /// pressure it reports.
+    pub fn verdict(&self) -> Result<&'static str, &'static str> {
+        if self.usage_page != HID_PAGE_DIGITIZER {
+            return Err("ignored: not a digitizer");
+        }
+        match self.usage {
+            HID_USAGE_TOUCH_SCREEN | HID_USAGE_TOUCH_PAD => {
+                Err("ignored: a touch device, not a pen")
+            }
+            HID_USAGE_PEN | HID_USAGE_DIGITIZER => match self.pressure {
+                Some(_) => Ok("STYLUS, pressure will be read from this"),
+                None => {
+                    Err("ignored: a digitizer that declares no tip pressure -- the driver is in \
+                     mouse mode, or this collection is the tablet's buttons")
+                }
+            },
+            _ => Err("ignored: a digitizer collection that is not a pen"),
+        }
+    }
+}
+
+/// The `--tablets` report for a scanner that sees HID devices, from what it
+/// found and whether the live pipe has heard anything.
+#[cfg_attr(target_os = "linux", allow(dead_code))]
+pub(crate) fn hid_report(devices: &[HidSummary], pipe: &str) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(out, "HID devices, as the tablet scanner sees them.\n");
+    if devices.is_empty() {
+        let _ = writeln!(out, "No HID devices at all, which usually means the enumeration failed.");
+    }
+    let mut found = 0usize;
+    for device in devices {
+        let range = device
+            .pressure
+            .map(|(low, high)| format!("{low} to {high}"))
+            .unwrap_or_else(|| "none".into());
+        let mut extras = Vec::new();
+        if device.has_tilt {
+            extras.push("tilt");
+        }
+        if device.has_eraser {
+            extras.push("eraser");
+        }
+        let also =
+            if extras.is_empty() { String::new() } else { format!(", {}", extras.join(", ")) };
+        let verdict = match device.verdict() {
+            Ok(verdict) => {
+                found += 1;
+                verdict
+            }
+            Err(why) => why,
+        };
+        let _ = writeln!(
+            out,
+            "{}\n  usage page {:#04X} usage {:#04X}\n  pressure range {range}{also}\n  {verdict}\n",
+            if device.path.is_empty() {
+                device.name()
+            } else {
+                format!("{} at {}", device.name(), device.path)
+            },
+            device.usage_page,
+            device.usage
+        );
+    }
+    let _ = writeln!(out, "{found} stylus device(s) usable. {pipe}");
+    if found == 0 {
+        let _ = writeln!(
+            out,
+            "No stylus found. A tablet whose driver is in mouse-only mode does not appear as a\n\
+             pen at all: switch on Windows Ink in the driver's settings (Huion, Gaomon and\n\
+             XP-Pen call it that; Wacom calls it \"Use Windows Ink\"), then unplug and replug."
+        );
+    }
+    out
+}
+
 /// Print what every input device looks like to the scanner, and why each was
 /// accepted or rejected.
 ///
@@ -709,20 +836,73 @@ mod backend {
     static SAW_A_REPORT: AtomicBool = AtomicBool::new(false);
 
     pub fn report() -> String {
-        if SAW_A_REPORT.load(Ordering::Relaxed) {
-            "Reading the pen through Raw Input.".to_string()
+        let pipe = if SAW_A_REPORT.load(Ordering::Relaxed) {
+            "Reading the pen through Raw Input."
         } else {
-            "Listening for a pen through Raw Input; none has reported yet.".to_string()
-        }
+            "Listening for a pen through Raw Input; none has reported yet."
+        };
+        super::hid_report(&scan(), pipe)
+    }
+
+    /// Every HID device, reduced to what decides whether it is a stylus.
+    ///
+    /// The tip pressure range and the tilt and eraser usages are read out of
+    /// the preparsed descriptor, which Raw Input hands over without the
+    /// device being opened, so this needs no permission and no report.
+    fn scan() -> Vec<super::HidSummary> {
+        raw_input::devices()
+            .into_iter()
+            .map(|device| {
+                let preparsed = raw_input::preparsed(device.handle);
+                let data = preparsed.as_ref().map(|bytes| bytes.as_ptr() as PHIDP_PREPARSED_DATA);
+                let range =
+                    |usage| data.and_then(|data| raw_input::range(data, PAGE_DIGITIZER, usage));
+                super::HidSummary {
+                    vendor: device.vendor,
+                    product: device.product,
+                    usage_page: device.usage_page,
+                    usage: device.usage,
+                    pressure: range(USAGE_TIP_PRESSURE),
+                    has_tilt: range(USAGE_X_TILT).is_some(),
+                    has_eraser: data.is_some_and(|data| {
+                        raw_input::has_button(data, PAGE_DIGITIZER, USAGE_ERASER)
+                    }),
+                    path: device.path,
+                }
+            })
+            .collect()
     }
 
     pub fn spawn(shared: Arc<Shared>) {
+        // The device list first, on the caller's thread, so the panel and
+        // the bug report have something to say from the first frame. Read
+        // once: Windows raises no event this code listens for when a tablet
+        // is plugged in later, and a relaunch is the answer until it does.
+        {
+            let mut devices = shared.devices.lock().expect("tablet state poisoned");
+            for device in scan() {
+                if device.verdict().is_err() {
+                    continue;
+                }
+                devices.push(super::TabletDevice {
+                    name: device.name(),
+                    path: device.path.clone(),
+                    pressure_max: device.pressure.map_or(0, |(_, high)| high),
+                    has_tilt: device.has_tilt,
+                    has_eraser: device.has_eraser,
+                });
+            }
+        }
         std::thread::Builder::new()
             .name("brokkr-pen".to_string())
             .spawn(move || {
-                raw_input::pump("BrokkrPenSink", PAGE_DIGITIZER, USAGE_PEN, |data, report| {
-                    decode(&shared, data, report);
-                });
+                raw_input::pump(
+                    "BrokkrPenSink",
+                    &[(PAGE_DIGITIZER, USAGE_PEN), (PAGE_DIGITIZER, super::HID_USAGE_DIGITIZER)],
+                    |data, report| {
+                        decode(&shared, data, report);
+                    },
+                );
             })
             .ok();
     }
@@ -1065,6 +1245,49 @@ mod tests {
 
         tablet.shared.set_tool(Some(false), None);
         assert_eq!(tablet.state().tilt, Vec2::ZERO);
+    }
+
+    fn hid(usage_page: u16, usage: u16, pressure: Option<(i32, i32)>) -> HidSummary {
+        HidSummary {
+            vendor: 0x256C,
+            product: 0x006D,
+            usage_page,
+            usage,
+            pressure,
+            has_tilt: true,
+            has_eraser: false,
+            path: String::new(),
+        }
+    }
+
+    /// The verdicts the Windows and macOS scanners hand out, pinned here where
+    /// they can run: a pen with pressure is a stylus whichever of the two
+    /// top-level usages its driver chose, a touch device never is, and a
+    /// digitizer without pressure is named as the mouse-mode case it usually
+    /// is rather than silently skipped.
+    #[test]
+    fn a_hid_device_is_a_stylus_only_when_it_is_a_pen_with_pressure() {
+        assert!(hid(HID_PAGE_DIGITIZER, HID_USAGE_PEN, Some((0, 8191))).verdict().is_ok());
+        assert!(hid(HID_PAGE_DIGITIZER, HID_USAGE_DIGITIZER, Some((0, 4095))).verdict().is_ok());
+        assert!(hid(HID_PAGE_DIGITIZER, 0x04, Some((0, 255))).verdict().is_err(), "touch");
+        assert!(hid(0x01, 0x02, Some((0, 255))).verdict().is_err(), "a mouse is not a pen");
+        let mouse_mode = hid(HID_PAGE_DIGITIZER, HID_USAGE_PEN, None).verdict().unwrap_err();
+        assert!(mouse_mode.contains("mouse mode"), "{mouse_mode}");
+    }
+
+    #[test]
+    fn the_hid_report_names_the_device_and_says_what_to_do_when_none_is_a_stylus() {
+        let report = hid_report(&[hid(HID_PAGE_DIGITIZER, HID_USAGE_PEN, Some((0, 8191)))], "pipe");
+        assert!(report.contains("Huion or Gaomon 256C:006D"), "{report}");
+        assert!(report.contains("0 to 8191"), "{report}");
+        assert!(report.contains("1 stylus device(s) usable. pipe"), "{report}");
+        assert!(!report.contains("Windows Ink"), "advice given when a stylus was found");
+
+        let none = hid_report(&[hid(HID_PAGE_DIGITIZER, HID_USAGE_PEN, None)], "pipe");
+        assert!(none.contains("0 stylus device(s) usable"), "{none}");
+        assert!(none.contains("Windows Ink"), "{none}");
+        let empty = hid_report(&[], "pipe");
+        assert!(empty.contains("No HID devices at all"), "{empty}");
     }
 
     #[test]


### PR DESCRIPTION
Bug report `c8c92d9d`: "windows no tablet found", build 1038, no device named.

## Cause

`Tablet::diagnosis` answers "no tablet found" whenever the shared device list is empty, and only the Linux scanner ever filled it. Windows registered for pen reports and pumped messages but enumerated nothing, so every Windows user has seen that line whether the pen was absent, in mouse mode, or working with the panel lying. The report could not be read for the same reason.

## Change

- `raw_input::devices` enumerates HID collections through Raw Input; the Windows tablet backend fills the device list at spawn from each device's preparsed descriptor (tip pressure range, tilt, eraser). Nothing is opened, so nothing needs a permission.
- The pen pipe registers both digitizer usages, 0x02 Pen and 0x01 Digitizer, because a vendor driver may present either.
- `brokkrsculpt.exe --tablets > tablets.txt` prints every HID device with its page and usage, pressure range and a verdict, and names the mouse-mode case (Windows Ink off in the driver) since that is the one to check first.

## Checked

789 app tests, clippy clean, Windows target cross-checked with clippy. **Not run on Windows**; the verdicts and wording are platform-independent and tested on Linux. Hotplug is not handled: a tablet plugged in after launch needs a relaunch, and the code says so.
